### PR TITLE
Added the possibility to compile with a version of GCC older than 8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@
 #SANITIZE=1
 #USE_GPIOD=1
 
+#enable to compile on a version of GCC older than 8.0
+#USE_OLDGCC=1
+
 #
 ## Common options for all targets
 #
@@ -36,6 +39,10 @@ ifndef DEBUG
 	CFLAGS += -O3
 else
 	CFLAGS += -g -rdynamic -funwind-tables -DDEBUG -Wl,--export-dynamic
+endif
+
+ifdef USE_OLDGCC
+	CFLAGS += -DUSE_OLDGCC
 endif
 
 #Common flags for all 32bit targets

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,12 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+
+#ifdef USE_OLDGCC
+#include <experimental/filesystem>
+#else
 #include <filesystem>
+#endif
 
 #include "sysconfig.h"
 #include "sysdeps.h"
@@ -1069,7 +1074,11 @@ long get_file_size(const std::string& filename)
 
 bool file_exists(std::string file)
 {
+	#ifdef USE_OLDGCC
+	namespace fs = std::experimental::filesystem;
+	#else
 	namespace fs = std::filesystem;
+	#endif
 	fs::path f { file };
 	return (fs::exists(f));
 }

--- a/src/osdep/amiberry_filesys.cpp
+++ b/src/osdep/amiberry_filesys.cpp
@@ -11,7 +11,13 @@
 #include <dirent.h>
 #include <iconv.h>
 #include <iostream>
+
+#ifdef USE_OLDGCC
+#include <experimental/filesystem>
+#else
 #include <filesystem>
+#endif
+
 #include <sys/mman.h>
 
 #include "crc32.h"
@@ -707,8 +713,13 @@ int target_get_volume_name(struct uaedev_mount_info* mtinf, struct uaedev_config
 // If replace is false, copyfile will fail if file already exists
 bool copyfile(const char* target, const char* source, const bool replace)
 {
+	#ifdef USE_OLDGCC
+	std::experimental::filesystem::copy_options options = {};
+	options = replace ? experimental::filesystem::copy_options::overwrite_existing : experimental::filesystem::copy_options::none;
+	#else
 	std::filesystem::copy_options options = {};
 	options = replace ? filesystem::copy_options::overwrite_existing : filesystem::copy_options::none;
+	#endif
 	return copy_file(source, target, options);
 }
 


### PR DESCRIPTION
Fixes # . Added the possibility to compile with a version of GCC older than 8.0 where filesystem is found under
<experimental/filesystem>. Tested on my Linux box (CPU AMD E1) with Mint 19.3 and GCC 7.5

Changes proposed in this pull request:
- Makefile Added USE_OLDGCC option
- Main.cpp and amiberry_filesys.cpp fixed define for OLDGCC and also fixed some lines where filesystem where used.
-

@midwan
