### PR TITLE
Protect Make Bundle

### DIFF
--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -4,8 +4,8 @@ USERDIR=`echo ~`
 
 LONGVER=`cat src/osdep/target.h | grep AMIBERRYVERSION | awk -F '_T\\\(\\\"' '{print $2}' | awk -F '\\\"' '{printf $1}'`
 VERSION=`echo $LONGVER | awk -F v '{printf $2}' | awk '{print $1}'`
-MAJOR=`echo $VERSION | awk -F . '{printf $1}'`
-MINOR=`echo $VERSION | awk -F . '{printf $2}'`
+MAJOR=`echo $VERSION | awk -F . '{printf $1}' | sed 's/[^0-9]*//g'`
+MINOR=`echo $VERSION | awk -F . '{printf $2}' | sed 's/[^0-9]*//g'`
 
 echo "Removing old App directory"
 rm -Rf Amiberry.app


### PR DESCRIPTION
protect the MINOR and MAJOR values to remove non-integers

Fixes # 1034

Changes proposed in this pull request:
- Remove non numeric vales from the MAJOR and MINOR vars in the make-bundle.sh

@midwan
