### PR TITLE
VersionNumberUpdate

### DIFF
--- a/src/osdep/target.h
+++ b/src/osdep/target.h
@@ -24,7 +24,7 @@
 #define GETBDM(x) (((x) - (((x) / 10000) * 10000)) / 100)
 #define GETBDD(x) ((x) % 100)
 
-#define AMIBERRYVERSION _T("Amiberry 5.7 DEV (2023-02-19)")
+#define AMIBERRYVERSION _T("Amiberry v5.7 DEV (2023-02-19)")
 #define AMIBERRYDATE MAKEBD(2023, 2, 19)
 
 #define IHF_WINDOWHIDDEN 6


### PR DESCRIPTION

Fixes # N/A.

Changes proposed in this pull request:
- Updated version number to include a v in front.
  Such as v5.7 so the apple build script can sign
  as expected.


@midwan
