### PR TITLE
Fix libserialport0 APT package name in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ Amiberry requires the [SDL2 framework](https://libsdl.org) for graphics display,
 
 If you just want to just run the Amiberry binary, you can install the required libraries on Debian/Raspbian/Ubuntu derived distros like this:
 
-      sudo apt install libsdl2-2.0-0 libsdl2-ttf-2.0-0 libsdl2-image-2.0-0 flac mpg123 libmpeg2-4 libserialport
+      sudo apt install libsdl2-2.0-0 libsdl2-ttf-2.0-0 libsdl2-image-2.0-0 flac mpg123 libmpeg2-4 libserialport0
 
 If you want to compile Amiberry from source, you'll need the `-dev` version of the same packages instead. For example, on Debian-based distros:
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- The APT package is called `libserialport0`:
  - https://packages.debian.org/libserialport0
  - https://packages.ubuntu.com/libserialport0

@midwan
