### PR TITLE
Add Brewfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,4 @@ VSLinux/.vs
 .vs
 .flatpak-builder/
 .flatpak/
+Brewfile.lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,13 @@
+# This should already be tapped, but just in case
+tap "homebrew/core"
+
+# Install dependencies
+brew "sdl2"
+brew "mpg123"
+brew "sdl2_ttf"
+brew "sdl2_image"
+brew "flac"
+brew "libmpeg2"
+brew "dylibbundler"
+brew "wget"
+brew "libserialport"


### PR DESCRIPTION
Changes proposed in this pull request:
- This adds a Brewfile, which can install all of the dependencies listed through Homebrew by running a `brew bundle` command.  I'm hoping to get this added and then update the wiki instructions for macOS compilation to use that for dependency installation, to simplify it (and hopefully avoid future instances where the wiki doesn't mention a new dependency, which seems to be the case with `libserialport` currently).

@midwan
