### PR TITLE
Initial experimental RISC-V 64bit port. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,11 @@ else ifeq ($(PLATFORM),a64)
 else ifeq ($(PLATFORM),x86-64)
 	CPPFLAGS += -DUSE_RENDER_THREAD
 
+# Generic EXPERIMENTAL riscv64 target
+else ifeq ($(PLATFORM),riscv64)
+	# USE_RENDER_THREAD fails under sway on VisionFive2
+	# CPPFLAGS += -DUSE_RENDER_THREAD
+
 # RK3588 e.g. RockPi 5
 else ifeq ($(PLATFORM),rk3588)
 	CPUFLAGS ?= -mcpu=cortex-a76+fp
@@ -598,6 +603,8 @@ OBJS += src/osdep/aarch64_helper_osx.o
 else ifeq ($(PLATFORM),$(filter $(PLATFORM),osx-x86))
 	USE_JIT = 0
 else ifeq ($(PLATFORM),$(filter $(PLATFORM),x86-64))
+	USE_JIT = 0
+else ifeq ($(PLATFORM),$(filter $(PLATFORM),riscv64))
 	USE_JIT = 0
 else
 OBJS += src/osdep/neon_helper.o

--- a/src/include/sysdeps.h
+++ b/src/include/sysdeps.h
@@ -58,6 +58,9 @@ using namespace std;
 #define SAHF_SETO_PROFITABLE
 #elif defined(__powerpc__) || defined(_M_PPC)
 #define CPU_powerpc 1
+#elif defined(__riscv) && defined(__riscv_xlen) && __riscv_xlen == 64
+#define CPU_riscv64 1
+#define CPU_64_BIT 1
 #else
 #error unrecognized CPU type
 #endif

--- a/src/machdep/m68k.h
+++ b/src/machdep/m68k.h
@@ -129,12 +129,12 @@ STATIC_INLINE int cctrue (int cc)
 
 #endif /* REGS_DEFINED */
 
-#elif defined(CPU_arm) && (defined(ARMV6_ASSEMBLY) || defined(CPU_AARCH64))
+#elif defined(CPU_riscv64) || defined(CPU_arm) && (defined(ARMV6_ASSEMBLY) || defined(CPU_AARCH64))
 
 #ifndef REGS_DEFINED
 
 struct flag_struct {
-#if defined (CPU_AARCH64)
+#if defined(CPU_riscv64) || defined (CPU_AARCH64)
 	uae_u64 nzcv;
 	uae_u64 x;
 #else

--- a/src/osdep/sigsegv_handler.cpp
+++ b/src/osdep/sigsegv_handler.cpp
@@ -36,7 +36,7 @@
 #endif
 #include "uae.h"
 
-#if !defined(__MACH__) && !defined(CPU_AMD64) && !defined(__x86_64__)
+#if !defined(__MACH__) && !defined(CPU_AMD64) && !defined(__x86_64__) && !defined(__riscv)
 #include <asm/sigcontext.h>
 #else
 #include <sys/ucontext.h>

--- a/src/osdep/sysconfig.h
+++ b/src/osdep/sysconfig.h
@@ -18,7 +18,7 @@
 #define FILESYS /* filesys emulation */
 #define UAE_FILESYS_THREADS
 #define AUTOCONFIG /* autoconfig support, fast ram, harddrives etc.. */
-#if !defined (CPU_AMD64) && !defined (__x86_64__) && !defined (__MACH__)
+#if !defined (CPU_AMD64) && !defined (__x86_64__) && !defined(__riscv) && !defined (__MACH__)
 #define JIT /* JIT compiler support */
 #endif
 #if defined(ARMV6T2) || defined(CPU_AARCH64)
@@ -116,7 +116,7 @@
 
 #include <stdint.h>
 
-#if defined(__x86_64__) || defined(CPU_AARCH64) || defined(CPU_AMD64)
+#if defined(__x86_64__) || defined(CPU_AARCH64) || defined(CPU_AMD64) || defined(__LP64__)
 #define SIZEOF_VOID_P 8
 #else
 #define SIZEOF_VOID_P 4
@@ -263,7 +263,7 @@ typedef int32_t uae_atomic;
 #define SIZEOF_INT 4
 
 /* The number of bytes in a long.  */
-#if defined(__x86_64__) || defined(CPU_AARCH64) || defined(CPU_AMD64)
+#if defined(__x86_64__) || defined(CPU_AARCH64) || defined(CPU_AMD64) || defined(__LP64__)
 #define SIZEOF_LONG 8
 #else
 #define SIZEOF_LONG 4


### PR DESCRIPTION
While bringing to Batocera to RISC-V based StarFive VisionFive 2 SBC, I added initial RISC-V 64 support to Amiberry.

Changes proposed in this pull request:
- Add riscv64 target in Makefile
- Implement basic riscv64 support in CPU interpreter
- Tested working on StarFive VisionFive 2 SBC (implements RV64GC). 

@midwan please review, also tell me if this should go to upstream WinUAE code or not.
