### PR TITLE
platforms: add Raspberry Pi5 as a new target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,11 @@ ifneq (,$(findstring rpi4,$(PLATFORM)))
 	CPUFLAGS = -mcpu=cortex-a72 -mfpu=neon-fp-armv8
 endif
 
+# Raspberry 5 CPU flags
+ifneq (,$(findstring rpi5,$(PLATFORM)))
+     CPUFLAGS = -mcpu=cortex-a76 -mfpu=neon-fp-armv8
+endif
+
 # Mac OS X M1 CPU flags
 ifneq (,$(findstring osx-m1,$(PLATFORM)))
 	CPUFLAGS=-mcpu=apple-m1
@@ -105,10 +110,10 @@ ifeq ($(PLATFORM),$(filter $(PLATFORM),rpi1 rpi2 rpi3 rpi4))
 #
 # SDL2 targets
 #
-# Raspberry Pi 1/2/3/4 (SDL2)
-else ifeq ($(PLATFORM),$(filter $(PLATFORM),rpi1-sdl2 rpi2-sdl2 rpi3-sdl2 rpi4-sdl2))
+# Raspberry Pi 1/2/3/4/5 (SDL2)
+else ifeq ($(PLATFORM),$(filter $(PLATFORM),rpi1-sdl2 rpi2-sdl2 rpi3-sdl2 rpi4-sdl2 rpi5-sdl2))
 	CPPFLAGS += $(CPPFLAGS32)
-	ifeq ($(PLATFORM),$(filter $(PLATFORM), rpi2-sdl2 rpi3-sdl2 rpi4-sdl2))
+	ifeq ($(PLATFORM),$(filter $(PLATFORM), rpi2-sdl2 rpi3-sdl2 rpi4-sdl2 rpi5-sdl2))
 	   CPPFLAGS += $(NEON_FLAGS)
 	   HAVE_NEON = 1
 	endif
@@ -184,6 +189,12 @@ else ifeq ($(PLATFORM),rpi4-64-dmx)
 	CPPFLAGS += $(CPPFLAGS64) $(DISPMANX_FLAGS)
 	LDFLAGS += $(DISPMANX_LDFLAGS)
 	AARCH64 = 1
+
+# Raspberry Pi 5 (SDL2 64-bit)
+else ifeq ($(PLATFORM),rpi5-64-sdl2)
+     CPUFLAGS = -mcpu=cortex-a76
+     CPPFLAGS += $(CPPFLAGS64)
+     AARCH64 = 1
 
 # Vero 4k (SDL2)
 else ifeq ($(PLATFORM),vero4k)


### PR DESCRIPTION
Changes proposed in this pull request:
 - Added support for the Raspberry Pi 5 SBC [1], with the following 'platform' targets:
   
   * `pi5-sdl2` should build a 32bit (armhf) binary
   * `pi5-64-sdl2` should build a 64bit (aarch64) binary

 

Note:
 I didn't add any `dispmanx`/`dmx` targets since DispmanX is no longer supported upstream since RaspiOS 11 _bullseye_ and certainly won't work on a 64bit arch (on a Pi4 or otherwise).

Refs:
[1] https://www.raspberrypi.com/products/raspberry-pi-5/