### PR TITLE
1084 expose gui theme

### DIFF
--- a/src/include/options.h
+++ b/src/include/options.h
@@ -14,6 +14,7 @@
 #include "uae/types.h"
 
 #include "traps.h"
+#include "guisan/color.hpp"
 
 #define UAEMAJOR 5
 #define UAEMINOR 6
@@ -1188,6 +1189,16 @@ struct amiberry_hotkey
 	std::string key_name;
 	std::string modifiers_string;
 	hotkey_modifiers modifiers;
+};
+
+struct amiberry_gui_theme
+{
+	gcn::Color base_color = gcn::Color(170, 170, 170);
+	gcn::Color selector_inactive = gcn::Color(170, 170, 170);
+	gcn::Color selector_active = gcn::Color(103, 136, 187);
+	gcn::Color textbox_background = gcn::Color(220, 220, 220);
+	std::string font_name = "AmigaTopaz.ttf";
+	int font_size = 15;
 };
 
 struct amiberry_options

--- a/src/include/options.h
+++ b/src/include/options.h
@@ -1193,12 +1193,12 @@ struct amiberry_hotkey
 
 struct amiberry_gui_theme
 {
-	gcn::Color base_color = gcn::Color(170, 170, 170);
-	gcn::Color selector_inactive = gcn::Color(170, 170, 170);
-	gcn::Color selector_active = gcn::Color(103, 136, 187);
-	gcn::Color textbox_background = gcn::Color(220, 220, 220);
-	std::string font_name = "AmigaTopaz.ttf";
-	int font_size = 15;
+	gcn::Color base_color;
+	gcn::Color selector_inactive;
+	gcn::Color selector_active;
+	gcn::Color textbox_background;
+	std::string font_name;
+	int font_size;
 };
 
 struct amiberry_options
@@ -1260,6 +1260,12 @@ struct amiberry_options
 	char default_vkbd_style[128] = "Original";
 	int default_vkbd_transparency;
 	char default_vkbd_toggle[128] = "guide";
+	char gui_theme_font_name[128] = "AmigaTopaz.ttf";
+	int gui_theme_font_size = 15;
+	char gui_theme_base_color[128] = "170, 170, 170";
+	char gui_theme_selector_inactive[128] = "170, 170, 170";
+	char gui_theme_selector_active[128] = "103, 136, 187";
+	char gui_theme_textbox_background[128] = "220, 220, 220";
 };
 
 extern struct amiberry_options amiberry_options;

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -135,6 +135,17 @@ std::string get_sdl2_version_string()
 	return sdl_compiled.str();
 }
 
+std::vector<int> parse_color_string(std::string input)
+{
+	std::vector<int> result;
+	std::stringstream ss(input);
+	std::string token;
+	while (std::getline(ss, token, ',')) {
+		result.push_back(std::stoi(token));
+	}
+	return result;
+}
+
 amiberry_hotkey get_hotkey_from_config(std::string config_option)
 {
 	amiberry_hotkey hotkey = {};
@@ -2086,6 +2097,110 @@ void target_default_options(struct uae_prefs* p, int type)
 		_tcscpy(p->vkbd_style, ""); // This will use the default theme.
 	p->vkbd_transparency = amiberry_options.default_vkbd_transparency;
 	_tcscpy(p->vkbd_toggle, amiberry_options.default_vkbd_toggle);
+
+	//
+	// GUI Theme section
+	//
+	// Font name
+	if (amiberry_options.gui_theme_font_name[0])
+		gui_theme.font_name = std::string(amiberry_options.gui_theme_font_name);
+	else
+		gui_theme.font_name = "AmigaTopaz.ttf";
+
+	// Font size
+	gui_theme.font_size = amiberry_options.gui_theme_font_size > 0 ? amiberry_options.gui_theme_font_size : 15;
+
+	// Base Color
+	if (amiberry_options.gui_theme_base_color[0])
+	{
+		// parse string as comma-separated numbers
+		std::vector<int> result = parse_color_string(amiberry_options.gui_theme_base_color);
+		if (result.size() == 3)
+		{
+			gui_theme.base_color = gcn::Color(result[0], result[1], result[2]);
+		}
+		else if (result.size() == 4)
+		{
+			gui_theme.base_color = gcn::Color(result[0], result[1], result[2], result[3]);
+		}
+		else
+		{
+			gui_theme.base_color = gcn::Color(170, 170, 170);
+		}
+	}
+	else
+	{
+		gui_theme.base_color = gcn::Color(170, 170, 170);
+	}
+
+	// Selector Inactive
+	if (amiberry_options.gui_theme_selector_inactive[0])
+	{
+		// parse string as comma-separated numbers
+		std::vector<int> result = parse_color_string(amiberry_options.gui_theme_selector_inactive);
+		if (result.size() == 3)
+		{
+			gui_theme.selector_inactive = gcn::Color(result[0], result[1], result[2]);
+		}
+		else if (result.size() == 4)
+		{
+			gui_theme.selector_inactive = gcn::Color(result[0], result[1], result[2], result[3]);
+		}
+		else
+		{
+			gui_theme.selector_inactive = gcn::Color(170, 170, 170);
+		}
+	}
+	else
+	{
+		gui_theme.selector_inactive = gcn::Color(170, 170, 170);
+	}
+
+	// Selector Active
+	if (amiberry_options.gui_theme_selector_active[0])
+	{
+		// parse string as comma-separated numbers
+		std::vector<int> result = parse_color_string(amiberry_options.gui_theme_selector_active);
+		if (result.size() == 3)
+		{
+			gui_theme.selector_active = gcn::Color(result[0], result[1], result[2]);
+		}
+		else if (result.size() == 4)
+		{
+			gui_theme.selector_active = gcn::Color(result[0], result[1], result[2], result[3]);
+		}
+		else
+		{
+			gui_theme.selector_active = gcn::Color(103, 136, 187);
+		}
+	}
+	else
+	{
+		gui_theme.selector_active = gcn::Color(103, 136, 187);
+	}
+
+	// Textbox Background
+	if (amiberry_options.gui_theme_textbox_background[0])
+	{
+		// parse string as comma-separated numbers
+		std::vector<int> result = parse_color_string(amiberry_options.gui_theme_textbox_background);
+		if (result.size() == 3)
+		{
+			gui_theme.textbox_background = gcn::Color(result[0], result[1], result[2]);
+		}
+		else if (result.size() == 4)
+		{
+			gui_theme.textbox_background = gcn::Color(result[0], result[1], result[2], result[3]);
+		}
+		else
+		{
+			gui_theme.textbox_background = gcn::Color(220, 220, 220);
+		}
+	}
+	else
+	{
+		gui_theme.textbox_background = gcn::Color(220, 220, 220);
+	}
 }
 
 static const TCHAR* scsimode[] = { _T("SCSIEMU"), _T("SPTI"), _T("SPTI+SCSISCAN"), NULL };
@@ -3014,6 +3129,30 @@ void save_amiberry_settings(void)
 	snprintf(buffer, MAX_DPATH, "default_vkbd_toggle=%s\n", amiberry_options.default_vkbd_toggle);
 	fputs(buffer, f);
 
+	// GUI Theme: Font name
+	snprintf(buffer, MAX_DPATH, "gui_theme_font_name=%s\n", amiberry_options.gui_theme_font_name);
+	fputs(buffer, f);
+
+	// GUI Theme: Font size
+	snprintf(buffer, MAX_DPATH, "gui_theme_font_size=%d\n", amiberry_options.gui_theme_font_size);
+	fputs(buffer, f);
+
+	// GUI Theme: Base color
+	snprintf(buffer, MAX_DPATH, "gui_theme_base_color=%s\n", amiberry_options.gui_theme_base_color);
+	fputs(buffer, f);
+
+	// GUI Theme: Selector Inactive color
+	snprintf(buffer, MAX_DPATH, "gui_theme_selector_inactive=%s\n", amiberry_options.gui_theme_selector_inactive);
+	fputs(buffer, f);
+
+	// GUI Theme: Selector Active color
+	snprintf(buffer, MAX_DPATH, "gui_theme_selector_active=%s\n", amiberry_options.gui_theme_selector_active);
+	fputs(buffer, f);
+
+	// GUI Theme: Textbox Background color
+	snprintf(buffer, MAX_DPATH, "gui_theme_textbox_background=%s\n", amiberry_options.gui_theme_textbox_background);
+	fputs(buffer, f);
+
 	// Paths
 	snprintf(buffer, MAX_DPATH, "path=%s\n", current_dir);
 	fputs(buffer, f);
@@ -3267,6 +3406,12 @@ static int parse_amiberry_settings_line(const char *path, char *linea)
 		ret |= cfgfile_string(option, value, "default_vkbd_style", amiberry_options.default_vkbd_style, sizeof amiberry_options.default_vkbd_style);
 		ret |= cfgfile_intval(option, value, "default_vkbd_transparency", &amiberry_options.default_vkbd_transparency, 1);
 		ret |= cfgfile_string(option, value, "default_vkbd_toggle", amiberry_options.default_vkbd_toggle, sizeof amiberry_options.default_vkbd_toggle);
+		ret |= cfgfile_string(option, value, "gui_theme_font_name", amiberry_options.gui_theme_font_name, sizeof amiberry_options.gui_theme_font_name);
+		ret |= cfgfile_intval(option, value, "gui_theme_font_size", &amiberry_options.gui_theme_font_size, 1);
+		ret |= cfgfile_string(option, value, "gui_theme_base_color", amiberry_options.gui_theme_base_color, sizeof amiberry_options.gui_theme_base_color);
+		ret |= cfgfile_string(option, value, "gui_theme_selector_inactive", amiberry_options.gui_theme_selector_inactive, sizeof amiberry_options.gui_theme_selector_inactive);
+		ret |= cfgfile_string(option, value, "gui_theme_selector_active", amiberry_options.gui_theme_selector_active, sizeof amiberry_options.gui_theme_selector_active);
+		ret |= cfgfile_string(option, value, "gui_theme_textbox_background", amiberry_options.gui_theme_textbox_background, sizeof amiberry_options.gui_theme_textbox_background);
 	}
 	return ret;
 }

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -103,6 +103,7 @@ int relativepaths = 0;
 int saveimageoriginalpath = 0;
 
 struct amiberry_options amiberry_options = {};
+struct amiberry_gui_theme gui_theme = {};
 amiberry_hotkey enter_gui_key;
 SDL_GameControllerButton enter_gui_button;
 amiberry_hotkey quit_key;
@@ -3205,7 +3206,7 @@ static int parse_amiberry_settings_line(const char *path, char *linea)
 		ret |= cfgfile_string(option, value, "inputrecordings_dir", input_dir, sizeof input_dir);
 		ret |= cfgfile_string(option, value, "screenshot_dir", screenshot_dir, sizeof screenshot_dir);
 		ret |= cfgfile_string(option, value, "nvram_dir", nvram_dir, sizeof nvram_dir);
-		// NOTE: amiberry_config is a "read only", ie. it's not written in
+		// NOTE: amiberry_config is a "read only", i.e. it's not written in
 		// save_amiberry_settings(). It's purpose is to provide -o amiberry_config=path
 		// command line option.
 		ret |= cfgfile_string(option, value, "amiberry_config", amiberry_conf_file, sizeof amiberry_conf_file);

--- a/src/osdep/gui/ShowMessage.cpp
+++ b/src/osdep/gui/ShowMessage.cpp
@@ -1,5 +1,7 @@
 #include <cstdio>
 #include <cstring>
+#include <cstdlib>
+#include <iostream>
 
 #include <guisan.hpp>
 #include <SDL_ttf.h>
@@ -167,20 +169,30 @@ static void InitShowMessage(const std::string& message)
 	{
 		gui_top = new gcn::Container();
 		gui_top->setDimension(gcn::Rectangle(0, 0, GUI_WIDTH, GUI_HEIGHT));
-		gui_baseCol = gcn::Color(170, 170, 170);
+		gui_baseCol = gui_theme.base_color;
 		gui_top->setBaseColor(gui_baseCol);
 		uae_gui->setTop(gui_top);
 	}
 	if (gui_font == nullptr)
 	{
 		TTF_Init();
-#ifdef USE_OPENGL
-		gui_font = new gcn::ImageFont(prefix_with_data_path("rpgfont.png"), " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?-+/():;%&`'*#=[]\"");
 
+		try
+		{
+#ifdef USE_OPENGL
+			gui_font = new gcn::ImageFont(prefix_with_data_path("rpgfont.png"), " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?-+/():;%&`'*#=[]\"");
 #else
-		gui_font = new gcn::SDLTrueTypeFont(prefix_with_data_path("AmigaTopaz.ttf"), 15);
-		gui_font->setAntiAlias(false);
+			gui_font = new gcn::SDLTrueTypeFont(prefix_with_data_path(gui_theme.font_name), gui_theme.font_size);
+			gui_font->setAntiAlias(false);
 #endif
+		}
+		catch (exception& ex)
+		{
+			cout << ex.what() << '\n';
+			write_log("An error occurred while trying to open the GUI font! Exception: %s\n", ex.what());
+			abort();
+		}
+
 		gcn::Widget::setGlobalFont(gui_font);
 	}
 

--- a/src/osdep/gui/gui_handling.h
+++ b/src/osdep/gui/gui_handling.h
@@ -146,9 +146,14 @@ extern bool gui_running;
 extern ConfigCategory categories[];
 extern gcn::Gui* uae_gui;
 extern gcn::Container* gui_top;
+
+// GUI Colors
+extern amiberry_gui_theme gui_theme;
 extern gcn::Color gui_baseCol;
 extern gcn::Color colTextboxBackground;
+extern gcn::Color colSelectorInactive;
 extern gcn::Color colSelectorActive;
+
 extern gcn::SDLInput* gui_input;
 extern SDL_Surface* gui_screen;
 extern SDL_Joystick* gui_joystick;

--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -174,10 +174,12 @@ gcn::Container* gui_top;
 gcn::Container* selectors;
 gcn::ScrollArea* selectorsScrollArea;
 
+// GUI Colors
 gcn::Color gui_baseCol;
 gcn::Color colTextboxBackground;
 gcn::Color colSelectorInactive;
 gcn::Color colSelectorActive;
+
 gcn::FocusHandler* focusHdl;
 gcn::Widget* activeWidget;
 
@@ -1238,10 +1240,10 @@ void gui_widgets_init()
 	//-------------------------------------------------
 	// Define base colors
 	//-------------------------------------------------
-	gui_baseCol = gcn::Color(170, 170, 170);
-	colSelectorInactive = gcn::Color(170, 170, 170);
-	colSelectorActive = gcn::Color(103, 136, 187);
-	colTextboxBackground = gcn::Color(220, 220, 220);
+	gui_baseCol = gui_theme.base_color;
+	colSelectorInactive = gui_theme.selector_inactive;
+	colSelectorActive = gui_theme.selector_active;
+	colTextboxBackground = gui_theme.textbox_background;
 
 	//-------------------------------------------------
 	// Create container for main page
@@ -1263,7 +1265,8 @@ void gui_widgets_init()
 #ifdef USE_OPENGL
 		gui_font = new gcn::ImageFont(prefix_with_data_path("rpgfont.png"), " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?-+/():;%&`'*#=[]\"");
 #else
-		gui_font = new gcn::SDLTrueTypeFont(prefix_with_data_path("AmigaTopaz.ttf"), 15);
+		gui_font = new gcn::SDLTrueTypeFont(prefix_with_data_path(gui_theme.font_name), gui_theme.font_size);
+		gui_font->setAntiAlias(false);
 #endif
 	}
 	catch (exception& ex)
@@ -1274,9 +1277,6 @@ void gui_widgets_init()
 	}
 
 	gcn::Widget::setGlobalFont(gui_font);
-#ifndef USE_OPENGL
-	gui_font->setAntiAlias(false);
-#endif
 
 	//--------------------------------------------------
 	// Create main buttons


### PR DESCRIPTION
Fixes #1084

This exports the GUI colors used, as well as the Font name and size, to `amiberry.conf`.
The default values will be used if none exist. If they do exist there, they will be parsed and used instead of the built-in defaults.

This allows users to customize the look of the GUI, with custom colors and fonts.

@midwan
