### PR TITLE
Support ccache, distcc etc. in Makefile - and fix files missed from clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -739,7 +739,8 @@ endif
 clean:
 	$(RM) $(PROG) $(PROG)-debug $(C_OBJS) $(OBJS) $(ASMS) $(DEPS)
 	$(MAKE) -C external/libguisan clean && $(RM) external/libguisan/libguisan.a
-	-cmake --build external/mt32emu/build --target clean 
+	-cmake --build external/mt32emu/build --target clean
+	-rm external/mt32emu/build
 	-rm external/mt32emu/libmt32emu.a
 
 cleanprofile:

--- a/Makefile
+++ b/Makefile
@@ -386,6 +386,11 @@ CXX    ?= g++
 STRIP  ?= strip
 PROG   = amiberry
 
+ifdef CWRAPPER
+CC  := $(CWRAPPER) $(CC)
+CXX := $(CWRAPPER) $(CXX)
+endif
+
 #
 # SDL2 options
 #
@@ -742,10 +747,10 @@ cleanprofile:
 	$(MAKE) -C external/libguisan cleanprofile
 	
 guisan:
-	$(MAKE) -C external/libguisan
+	$(MAKE) -C external/libguisan CC="$(CC)" CXX="$(CXX)"
 
 mt32emu:
-	cmake -DCMAKE_BUILD_TYPE=Release -Dlibmt32emu_SHARED=FALSE -S external/mt32emu -B external/mt32emu/build
+	cmake $(if $(CWRAPPER),-DCMAKE_CXX_COMPILER_LAUNCHER=$(CWRAPPER),) -DCMAKE_BUILD_TYPE=Release -Dlibmt32emu_SHARED=FALSE -S external/mt32emu -B external/mt32emu/build
 	cmake --build external/mt32emu/build --target all --parallel
 	cp external/mt32emu/build/libmt32emu.a external/mt32emu/
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Setting the `CWRAPPER` Makefile variable will prefix gcc/g++ commands with the wrapper. This enables the use of `ccache` which can vastly speed up rebuilds. Tested with `ccache`, but `distcc` and other tools of this kind should work too.
- The `clean` target left behind a directory - fixed this, `make clean` (with the right `PLATFORM` set) now leaves the workspace pristine.

My first contribution to this project (and indeed any open source project in quite a long time!) I hope it is something that the project will find interesting or useful.

@midwan
