### PR TITLE
Fix ARM 32-bit build through CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,7 @@ endif ()
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm" OR ARCHITECTURE MATCHES "arm32")
     add_definitions(-DCPU_arm -DARMV6_ASSEMBLY -DARMV6T2 -DUSE_ARMNEON -DARM_HAS_DIV)
     target_sources(${PROJECT_NAME} PRIVATE
-            src/osdep/arm_helper.s
+            src/osdep/neon_helper.s
             src/jit/compemu.cpp
             src/jit/compstbl.cpp
             src/jit/compemu_fpp.cpp


### PR DESCRIPTION
Fixes #1297 .

Changes proposed in this pull request:
- Updated CMakeLists.txt to fix the build issue

Thorougly tested for vaious ARM 32-bit targets.

@midwan
