### PR TITLE
Add keywords to .desktop file

### DIFF
--- a/flatpak/com.blitterstudio.amiberry.desktop
+++ b/flatpak/com.blitterstudio.amiberry.desktop
@@ -9,3 +9,5 @@ Categories=Game;Emulator;
 Icon=amiberry
 Exec=amiberry.sh
 Terminal=false
+
+Keywords=emulator;raspberry-pi;rpi;emulation;amiga;amiga-emulator;


### PR DESCRIPTION
These are also used by Flathub, KDE Discover and Gnome Software

Changes proposed in this pull request:
- Add keywords as specified here: https://webcache.googleusercontent.com/search?q=cache:https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

E.g. for [Ghidra](https://flathub.org/apps/org.ghidra_sre.Ghidra), it looks like this:
![image](https://github.com/BlitterStudio/amiberry/assets/3226457/57bd8614-08a4-48d4-ab53-6194a926fba5)


@midwan
