### PR TITLE
bugfix: remove newlines from debugger input

### DIFF
--- a/src/osdep/writelog.cpp
+++ b/src/osdep/writelog.cpp
@@ -408,7 +408,11 @@ int console_get (TCHAR *out, int maxlen)
 		return -1;
 	}
 	int len = strlen(out);
-	return len - 1;
+	while (len > 0 && (out[len - 1] == '\r' || out[len - 1] == '\n')) {
+		out[len - 1] = 0;
+		len--;
+	}
+	return len;
 #endif
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- The `fd` command in the debugger didn't work, because the debugger code expects the `d` to be followed by `\0` in the input buffer. Fix amiberry's version of `console_get` to strip newline characters from the end of the string it returns, as the Windows version does (rather than just adjusting the length value).

@midwan
