### PR TITLE
Picasso GFX MAX_RTG_Board # change

### DIFF
--- a/src/include/options.h
+++ b/src/include/options.h
@@ -468,7 +468,7 @@ struct boardromconfig
 	int device_order;
 	struct romconfig roms[MAX_BOARD_ROMS];
 };
-#define MAX_RTG_BOARDS 1
+#define MAX_RTG_BOARDS 4
 struct rtgboardconfig
 {
 	int rtg_index;


### PR DESCRIPTION
Increase GFX MAX_RTG_Boards to 4 as it looks like Picasso96 code is expecting 4 not the 1 listed.

Fixes # .

Changes proposed in this pull request:
Increase number of MAX_RTG_Boards defined to 4 as the Picasso96.cpp file looks like it is trying to set data for 4 and with the previous 1 looks like a possible buffer overflow.

This single change corrected all issues with MacOS 15 with a M1 and looks like minimal to no impact.

@midwan
