### PR TITLE
Use XDG_*_HOME in a more standard way

### DIFF
--- a/flatpak/com.blitterstudio.amiberry.yml
+++ b/flatpak/com.blitterstudio.amiberry.yml
@@ -105,4 +105,4 @@ modules:
       - type: script
         dest-filename: amiberry.sh
         commands:
-          - "if [ ! -e \"$XDG_DATA_HOME/data\" ]; then cp -R /app/data/* $XDG_DATA_HOME; fi; exec /app/bin/amiberry"
+          - "if [ ! -e \"$XDG_DATA_HOME/amiberry/data\" ]; then mkdir -p \"$XDG_DATA_HOME/amiberry\"; cp -R /app/data/* \"$XDG_DATA_HOME/amiberry\"; fi; exec /app/bin/amiberry"


### PR DESCRIPTION
Changes proposed in this pull request:

These variables are defined in the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/latest/).

Previously, if `XDG_DATA_HOME` or `XDG_CONFIG_HOME` were defined, amiberry would store data and config files directly in those directories. This is nonstandard -- defining these variables will change the behaviour of other programs too, and programs should use a subdirectory if they're storing multiple files.

After this commit, amiberry now computes the standard default values for these variables based on `HOME` if they aren't defined, and checks to see whether `XDG_DATA_HOME/amiberry` and `XDG_CONFIG_HOME/amiberry` exist. If they do, then they will be used as amiberry's home directory and config directory respectively (and `XDG_DATA_HOME/amiberry/data` will also be used as the data directory if `AMIBERRY_DATADIR` doesn't exist). If they don't exist, then `~/Amiberry` and `~/Amiberry/conf` will be used.

The effect of this is that if a user wants to avoid having `~/Amiberry`, they can now just create an empty `~/.config/amiberry` and `~/.local/share/amiberry`, and it'll put its files in those standard locations instead.

(I think this is consistent with what the original code that added `XDG_CONFIG_HOME` support was trying to do. I've updated the Flatpak config to match, but I can't test this locally - please check the behaviour looks sane to you!)

Fixes #1457.

@midwan
