### PR TITLE
Alt tab fixes

### DIFF
--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -360,10 +360,6 @@ int keyhack (const int scancode, const int pressed, const int num)
 	if (currprefs.alt_tab_release)
 	{
 		if (pressed && state[SDL_SCANCODE_LALT] && scancode == SDL_SCANCODE_TAB) {
-			// Ensure we release Alt-Tab before we release capture
-			inputdevice_translatekeycode(num, SDL_SCANCODE_TAB, 0, true);
-			inputdevice_translatekeycode(num, SDL_SCANCODE_LALT, 0, true);
-
 			disablecapture();
 			return -1;
 		}

--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -764,6 +764,13 @@ static void close_kb()
 
 void release_keys(void)
 {
+	// Special handling in case Alt-Tab was still stuck in pressed state
+	if (currprefs.alt_tab_release)
+	{
+		my_kbd_handler(0, SDL_SCANCODE_LALT, 0, true);
+		my_kbd_handler(0, SDL_SCANCODE_TAB, 0, true);
+	}
+
 	const Uint8* state = SDL_GetKeyboardState(NULL);
 	SDL_Event event;
 

--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -765,7 +765,7 @@ static void close_kb()
 void release_keys(void)
 {
 	// Special handling in case Alt-Tab was still stuck in pressed state
-	if (currprefs.alt_tab_release)
+	if (currprefs.alt_tab_release && key_altpressed())
 	{
 		my_kbd_handler(0, SDL_SCANCODE_LALT, 0, true);
 		my_kbd_handler(0, SDL_SCANCODE_TAB, 0, true);


### PR DESCRIPTION
Improve releasing of Alt-Tab keys when releasing capture.
Apparently in some distros, we still had those keys stuck as "pressed" when we got back to Amiberry.
Hopefully this should improve things