### PR TITLE
1480 implement missing features in expansion gui panel

### DIFF
--- a/cmake/SourceFiles.cmake
+++ b/cmake/SourceFiles.cmake
@@ -225,6 +225,7 @@ set(SOURCE_FILES
         src/osdep/ioport.cpp
         src/osdep/sigsegv_handler.cpp
         src/osdep/socket.cpp
+        src/osdep/registry.cpp
         src/osdep/retroarch.cpp
         src/osdep/vpar.cpp
         src/pcem/386.cpp

--- a/external/libguisan/include/guisan/listmodel.hpp
+++ b/external/libguisan/include/guisan/listmodel.hpp
@@ -94,7 +94,7 @@ namespace gcn
         virtual std::string getElementAt(int i) = 0;
 
     // Add a new element
-    virtual void add(std::string str) { }
+    virtual void add(const std::string& str) { }
 
     // Clear all elements
     virtual void clear_elements() { }

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -6629,7 +6629,6 @@ void cfgfile_compatibility_rtg(struct uae_prefs *p)
 			}
 		}
 	}
-#ifndef AMIBERRY // Only 1 RTG board in Amiberry for now
 	int rtgs[MAX_RTG_BOARDS] = { 0 };
 	for (int i = 0; i < MAX_RTG_BOARDS; i++) {
 		if (p->rtgboards[i].rtgmem_size && !rtgs[i]) {
@@ -6666,7 +6665,6 @@ void cfgfile_compatibility_rtg(struct uae_prefs *p)
 			}
 		}
 	}
-#endif
 }
 
 void cfgfile_compatibility_romtype(struct uae_prefs *p)

--- a/src/include/uae.h
+++ b/src/include/uae.h
@@ -82,6 +82,7 @@ struct bstring {
 
 extern TCHAR *colormodes[];
 extern int saveimageoriginalpath;
+extern std::string get_ini_file_path();
 extern void get_saveimage_path(char* out, int size, int dir);
 extern std::string get_configuration_path();
 extern void get_nvram_path(TCHAR* out, int size);

--- a/src/ini.cpp
+++ b/src/ini.cpp
@@ -92,7 +92,7 @@ void ini_addnewstring(struct ini_data *ini, const TCHAR *section, const TCHAR *k
 	if (!il)
 		return;
 	il->section = my_strdup(section);
-	if (!_tcsicmp(section, _T("WinUAE")))
+	if (!_tcsicmp(section, _T("Amiberry")))
 		il->section_order = 1;
 	if (key == NULL) {
 		il->key = my_strdup(_T(""));

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4045,11 +4045,25 @@ static void init_amiberry_dirs()
     plugins_dir = get_plugins_directory();
 
 	std::string xdg_data_home = get_xdg_data_home();
+	if (!my_existsdir(xdg_data_home.c_str()))
+	{
+		// Create the XDG_DATA_HOME directory if it doesn't exist
+		const auto user_home_dir = getenv("HOME");
+		if (user_home_dir != nullptr)
+		{
+			std::string destination = std::string(user_home_dir) + "/.local";
+			my_mkdir(destination.c_str());
+			destination += "/share";
+			my_mkdir(destination.c_str());
+		}
+	}
 	xdg_data_home += "/" + amiberry_dir;
 	if (!my_existsdir(xdg_data_home.c_str()))
 		my_mkdir(xdg_data_home.c_str());
 
 	std::string xdg_config_home = get_xdg_config_home();
+	if (!my_existsdir(xdg_config_home.c_str()))
+		my_mkdir(xdg_config_home.c_str());
 	xdg_config_home += "/" + amiberry_dir;
 	if (!my_existsdir(xdg_config_home.c_str()))
 		my_mkdir(xdg_config_home.c_str());

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4521,18 +4521,6 @@ bool is_mainthread()
 	return uae_thread_get_id(nullptr) == mainthreadid;
 }
 
-static struct netdriverdata *ndd[MAX_TOTAL_NET_DEVICES + 1];
-static int net_enumerated;
-
-struct netdriverdata **target_ethernet_enumerate(void)
-{
-	if (net_enumerated)
-		return ndd;
-	ethernet_enumerate(ndd, 0);
-	net_enumerated = 1;
-	return ndd;
-}
-
 void clear_whdload_prefs()
 {
 	whdload_prefs.filename.clear();

--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -594,30 +594,23 @@ static int scan_roms_2(UAEREG* fkey, const TCHAR* path, bool deepscan, int level
 
 	scan_rom_hook(path, 1);
 
-	while ((entry = readdir(dp)) != NULL) {
-		TCHAR tmppath[MAX_DPATH];
-		_tcscpy(tmppath, path);
-		_tcscat(tmppath, entry->d_name);
+    while ((entry = readdir(dp)) != NULL) {
+        TCHAR tmppath[MAX_DPATH];
+        _stprintf(tmppath, _T("%s/%s"), path, entry->d_name);
 
-		if (stat(tmppath, &statbuf) == -1)
-			continue;
+        if (stat(tmppath, &statbuf) == -1)
+            continue;
 
-		if (S_ISREG(statbuf.st_mode) && statbuf.st_size < 10000000) {
-			if (scan_rom(tmppath, fkey, deepscan))
-				ret = 1;
-		}
-		else if (deepscan && S_ISDIR(statbuf.st_mode)) {
-			if (recursiveromscan < 0 || recursiveromscan > level) {
-				if (entry->d_name[0] != '.') {
-					_tcscat(tmppath, _T("/"));
-					scan_roms_2(fkey, tmppath, deepscan, level + 1);
-				}
-			}
-		}
+        if (S_ISREG(statbuf.st_mode) && statbuf.st_size < 10000000) {
+            if (scan_rom(tmppath, fkey, deepscan))
+                ret = 1;
+        } else if (deepscan && S_ISDIR(statbuf.st_mode) && entry->d_name[0] != '.' && (recursiveromscan < 0 || recursiveromscan > level)) {
+            scan_roms_2(fkey, tmppath, deepscan, level + 1);
+        }
 
-		if (!scan_rom_hook(NULL, 0))
-			break;
-	}
+        if (!scan_rom_hook(NULL, 0))
+            break;
+    }
 
 	closedir(dp);
 	return ret;

--- a/src/osdep/amiberry_whdbooter.cpp
+++ b/src/osdep/amiberry_whdbooter.cpp
@@ -340,9 +340,6 @@ void cd_auto_prefs(uae_prefs* prefs, char* filepath)
 
 	write_log("\nCD Autoload: %s  \n\n", filepath);
 
-	if (!regexiststree(NULL, _T("DetectedROMs")))
-		scan_roms();
-
 	conf_path = get_configuration_path();
 	whdload_prefs.filename = get_game_filename(filepath);
 
@@ -1219,9 +1216,6 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)
 	write_log("WHDBooter Launched\n");
 	if (amiberry_options.use_jst_instead_of_whd)
 		write_log("WHDBooter - Using JST instead of WHDLoad\n");
-
-	if (!regexiststree(NULL, _T("DetectedROMs")))
-		scan_roms();
 
 	conf_path = get_configuration_path();
 	whdbooter_path = get_whdbootpath();

--- a/src/osdep/amiberry_whdbooter.cpp
+++ b/src/osdep/amiberry_whdbooter.cpp
@@ -23,6 +23,7 @@
 #include "xwin.h"
 #include "drawing.h"
 #include "midiemu.h"
+#include "registry.h"
 
 extern void SetLastActiveConfig(const char* filename);
 extern std::string current_dir;
@@ -339,8 +340,8 @@ void cd_auto_prefs(uae_prefs* prefs, char* filepath)
 
 	write_log("\nCD Autoload: %s  \n\n", filepath);
 
-	if (lstAvailableROMs.empty())
-		RescanROMs();
+	if (!regexiststree(NULL, _T("DetectedROMs")))
+		scan_roms();
 
 	conf_path = get_configuration_path();
 	whdload_prefs.filename = get_game_filename(filepath);
@@ -1219,8 +1220,8 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)
 	if (amiberry_options.use_jst_instead_of_whd)
 		write_log("WHDBooter - Using JST instead of WHDLoad\n");
 
-	if (lstAvailableROMs.empty())
-		RescanROMs();
+	if (!regexiststree(NULL, _T("DetectedROMs")))
+		scan_roms();
 
 	conf_path = get_configuration_path();
 	whdbooter_path = get_whdbootpath();

--- a/src/osdep/gui/PanelExpansions.cpp
+++ b/src/osdep/gui/PanelExpansions.cpp
@@ -1107,7 +1107,7 @@ void InitPanelExpansions(const config_category& category)
 	grpExpansionBoard->add(chkScsiRomFileAutoboot, chkScsiRomSelected->getX(), cboScsiRomSubSelect->getY());
 	grpExpansionBoard->add(chkScsiRomFilePcmcia, chkScsiRomFileAutoboot->getX() + chkScsiRomFileAutoboot->getWidth(), chkScsiRomFileAutoboot->getY());
 	grpExpansionBoard->add(txtExpansionBoardStringBox, chkScsiRomFileAutoboot->getX(), chkScsiRomFileAutoboot->getY());
-	grpExpansionBoard->add(chkExpansionBoardCheckbox, chkScsiRomFileAutoboot->getX(), chkScsiRomFileAutoboot->getY() + DISTANCE_NEXT_Y);
+	grpExpansionBoard->add(chkExpansionBoardCheckbox, chkScsiRomFileAutoboot->getX(), chkScsiRomFileAutoboot->getY() + chkScsiRomFileAutoboot->getHeight() + DISTANCE_NEXT_Y);
 	grpExpansionBoard->add(cboExpansionBoardItemSelector, posX, cboScsiRomSubSelect->getY() + cboScsiRomSubSelect->getHeight() + DISTANCE_NEXT_Y);
 	//grpExpansionBoard->add(cboExpansionBoardSelector, chkScsiRomSelected->getX(), cboExpansionBoardItemSelector->getY());
 	//TODO add items here

--- a/src/osdep/gui/PanelExpansions.cpp
+++ b/src/osdep/gui/PanelExpansions.cpp
@@ -60,6 +60,10 @@ static gcn::DropDown* cboCpuBoardSubType;
 static gcn::DropDown* cboCpuBoardRomFile;
 static gcn::Button* btnCpuBoardRomChooser;
 
+static gcn::Label* lblCpuBoardMem;
+static gcn::Slider* sldCpuBoardMem;
+static gcn::Label* lblCpuBoardRam;
+
 static gcn::DropDown* cboAcceleratorBoardItemSelector;
 static gcn::DropDown* cboAcceleratorBoardSelector;
 static gcn::CheckBox* chkAcceleratorBoardCheckbox;
@@ -145,18 +149,41 @@ static void setcpuboardmemsize()
 	if (changed_prefs.cpuboardmem1.size > maxmem) {
 		changed_prefs.cpuboardmem1.size = maxmem;
 	}
-	//if (maxmem <= 8 * 1024 * 1024)
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_Z2));
-	//else if (maxmem <= 16 * 1024 * 1024)
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_16M));
-	//else if (maxmem <= 32 * 1024 * 1024)
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_32M));
-	//else if (maxmem <= 64 * 1024 * 1024)
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_64M));
-	//else if (maxmem <= 128 * 1024 * 1024)
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_128M));
-	//else
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_256M));
+	if (maxmem <= 8 * 1024 * 1024)
+	{
+		sldCpuBoardMem->setScaleStart(MIN_CB_MEM); //	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_Z2));
+		sldCpuBoardMem->setScaleEnd(MAX_CB_MEM_Z2);
+	}
+	else if (maxmem <= 16 * 1024 * 1024)
+	{
+		//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_16M));
+		sldCpuBoardMem->setScaleStart(MIN_CB_MEM);
+		sldCpuBoardMem->setScaleEnd(MAX_CB_MEM_16M);
+	}
+	else if (maxmem <= 32 * 1024 * 1024)
+	{
+		//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_32M));
+		sldCpuBoardMem->setScaleStart(MIN_CB_MEM);
+		sldCpuBoardMem->setScaleEnd(MAX_CB_MEM_32M);
+	}
+	else if (maxmem <= 64 * 1024 * 1024)
+	{
+		//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_64M));
+		sldCpuBoardMem->setScaleStart(MIN_CB_MEM);
+		sldCpuBoardMem->setScaleEnd(MAX_CB_MEM_64M);
+	}
+	else if (maxmem <= 128 * 1024 * 1024)
+	{
+		//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_128M));
+		sldCpuBoardMem->setScaleStart(MIN_CB_MEM);
+		sldCpuBoardMem->setScaleEnd(MAX_CB_MEM_128M);
+	}
+	else
+	{
+		//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_256M));
+		sldCpuBoardMem->setScaleStart(MIN_CB_MEM);
+		sldCpuBoardMem->setScaleEnd(MAX_CB_MEM_256M);
+	}
 
 	int mem_size = 0;
 	switch (changed_prefs.cpuboardmem1.size) {
@@ -171,10 +198,11 @@ static void setcpuboardmemsize()
 	case 0x08000000: mem_size = 8; break;
 	case 0x10000000: mem_size = 9; break;
 	}
-	//SendDlgItemMessage(hDlg, IDC_CPUBOARDMEM, TBM_SETPOS, TRUE, mem_size);
-	//SetDlgItemText(hDlg, IDC_CPUBOARDRAM, memsize_names[msi_cpuboard[mem_size]]);
-	//SendDlgItemMessage(hDlg, IDC_CPUBOARD_TYPE, CB_SETCURSEL, changed_prefs.cpuboard_type, 0);
-	//SendDlgItemMessage(hDlg, IDC_CPUBOARD_SUBTYPE, CB_SETCURSEL, changed_prefs.cpuboard_subtype, 0);
+	sldCpuBoardMem->setValue(mem_size); //SendDlgItemMessage(hDlg, IDC_CPUBOARDMEM, TBM_SETPOS, TRUE, mem_size);
+	lblCpuBoardRam->setCaption(memsize_names[msi_cpuboard[mem_size]]); //SetDlgItemText(hDlg, IDC_CPUBOARDRAM, memsize_names[msi_cpuboard[mem_size]]);
+	lblCpuBoardRam->adjustSize();
+	cboCpuBoardType->setSelected(changed_prefs.cpuboard_type); //SendDlgItemMessage(hDlg, IDC_CPUBOARD_TYPE, CB_SETCURSEL, changed_prefs.cpuboard_type, 0);//SendDlgItemMessage(hDlg, IDC_CPUBOARD_TYPE, CB_SETCURSEL, changed_prefs.cpuboard_type, 0);
+	cboCpuBoardSubType->setSelected(changed_prefs.cpuboard_subtype); //SendDlgItemMessage(hDlg, IDC_CPUBOARD_SUBTYPE, CB_SETCURSEL, changed_prefs.cpuboard_subtype, 0);
 }
 
 struct expansionrom_gui
@@ -738,8 +766,6 @@ static void values_to_expansion2_expansion_settings()
 	}
 }
 
-
-
 static void updatecpuboardsubtypes()
 {
 	cpuboard_subtype_list.clear();
@@ -961,7 +987,12 @@ public:
 				setcpuboardmemsize();
 				RefreshPanelExpansions();
 			}
-		}	
+		}
+		else if (source == sldCpuBoardMem)
+		{
+			changed_prefs.cpuboardmem1.size = memsizes[msi_cpuboard[static_cast<int>(sldCpuBoardMem->getValue())]];
+			setcpuboardmemsize();
+		}
 	}
 };
 
@@ -1128,6 +1159,21 @@ void InitPanelExpansions(const config_category& category)
 	btnCpuBoardRomChooser->setId("btnCpuBoardRomChooser");
 	btnCpuBoardRomChooser->addActionListener(expansions_action_listener);
 
+	lblCpuBoardMem = new gcn::Label("Memory:");
+	lblCpuBoardMem->setBaseColor(gui_base_color);
+	lblCpuBoardMem->setForegroundColor(gui_foreground_color);
+	sldCpuBoardMem = new gcn::Slider(0, 256);
+	sldCpuBoardMem->setSize(150, SLIDER_HEIGHT);
+	sldCpuBoardMem->setBaseColor(gui_base_color);
+	sldCpuBoardMem->setForegroundColor(gui_foreground_color);
+	sldCpuBoardMem->setMarkerLength(20);
+	sldCpuBoardMem->setStepLength(1);
+	sldCpuBoardMem->setId("sldCpuBoardMem");
+	sldCpuBoardMem->addActionListener(expansions_action_listener);
+	lblCpuBoardRam = new gcn::Label("none");
+	lblCpuBoardRam->setBaseColor(gui_base_color);
+	lblCpuBoardRam->setForegroundColor(gui_foreground_color);
+
 	cboAcceleratorBoardItemSelector = new gcn::DropDown(&acceleratorboard_itemselector_list);
 	cboAcceleratorBoardItemSelector->setSize(250, cboAcceleratorBoardItemSelector->getHeight());
 	cboAcceleratorBoardItemSelector->setBaseColor(gui_base_color);
@@ -1202,7 +1248,6 @@ void InitPanelExpansions(const config_category& category)
 	grpExpansionBoard->add(chkExpansionBoardCheckbox, chkScsiRomFileAutoboot->getX(), chkScsiRomFileAutoboot->getY() + chkScsiRomFileAutoboot->getHeight() + DISTANCE_NEXT_Y);
 	grpExpansionBoard->add(cboExpansionBoardItemSelector, posX, cboScsiRomSubSelect->getY() + cboScsiRomSubSelect->getHeight() + DISTANCE_NEXT_Y);
 	grpExpansionBoard->add(cboExpansionBoardSelector, chkScsiRomSelected->getX(), cboExpansionBoardItemSelector->getY());
-	//TODO add items here
 	grpExpansionBoard->setMovable(false);
 	grpExpansionBoard->setSize(category.panel->getWidth() - DISTANCE_BORDER * 2, 250);
 	grpExpansionBoard->setTitleBarHeight(TITLEBAR_HEIGHT);
@@ -1215,6 +1260,10 @@ void InitPanelExpansions(const config_category& category)
 	grpAcceleratorBoard->add(cboCpuBoardSubType, posX, posY + cboCpuBoardType->getHeight() + DISTANCE_NEXT_Y);
 	grpAcceleratorBoard->add(cboCpuBoardRomFile, cboCpuBoardType->getX() + cboCpuBoardType->getWidth() + DISTANCE_NEXT_X * 3, cboCpuBoardType->getY());
 	grpAcceleratorBoard->add(btnCpuBoardRomChooser, cboCpuBoardRomFile->getX() + cboCpuBoardRomFile->getWidth() + DISTANCE_NEXT_X, cboCpuBoardRomFile->getY());
+	grpAcceleratorBoard->add(lblCpuBoardMem, cboCpuBoardType->getX() + cboCpuBoardType->getWidth() + DISTANCE_NEXT_X, cboCpuBoardSubType->getY());
+	grpAcceleratorBoard->add(sldCpuBoardMem, lblCpuBoardMem->getX() + lblCpuBoardMem->getWidth() + DISTANCE_NEXT_X, lblCpuBoardMem->getY());
+	grpAcceleratorBoard->add(lblCpuBoardRam, sldCpuBoardMem->getX() + sldCpuBoardMem->getWidth() + DISTANCE_NEXT_X, lblCpuBoardMem->getY());
+
 	//TODO add items here
 	grpAcceleratorBoard->setMovable(false);
 	grpAcceleratorBoard->setSize(category.panel->getWidth() - DISTANCE_BORDER * 2, 200);
@@ -1264,6 +1313,10 @@ void ExitPanelExpansions()
 	delete cboCpuBoardSubType;
 	delete cboCpuBoardRomFile;
 	delete btnCpuBoardRomChooser;
+
+	delete lblCpuBoardMem;
+	delete sldCpuBoardMem;
+	delete lblCpuBoardRam;
 
 	delete cboAcceleratorBoardItemSelector;
 	delete cboAcceleratorBoardSelector;
@@ -1317,10 +1370,9 @@ void RefreshPanelExpansions()
 	chkCD32Fmv->setEnabled(!emulating);
 	chkSana2->setEnabled(!emulating);
 	cboCpuBoardRomFile->setEnabled(changed_prefs.cpuboard_type != 0); //ew(hDlg, IDC_CPUBOARDROMFILE, workprefs.cpuboard_type != 0);
-	//TODO : Enable these
-	//ew(hDlg, IDC_CPUBOARDROMCHOOSER, workprefs.cpuboard_type != 0);
-	//ew(hDlg, IDC_CPUBOARDMEM, workprefs.cpuboard_type > 0);
-	//ew(hDlg, IDC_CPUBOARDRAM, workprefs.cpuboard_type > 0);
+	btnCpuBoardRomChooser->setEnabled(changed_prefs.cpuboard_type != 0); //ew(hDlg, IDC_CPUBOARDROMCHOOSER, workprefs.cpuboard_type != 0);
+	sldCpuBoardMem->setEnabled(changed_prefs.cpuboard_type > 0); //ew(hDlg, IDC_CPUBOARDMEM, workprefs.cpuboard_type > 0);
+	lblCpuBoardRam->setEnabled(changed_prefs.cpuboard_type > 0); //ew(hDlg, IDC_CPUBOARDRAM, workprefs.cpuboard_type > 0);
 	cboCpuBoardSubType->setEnabled(changed_prefs.cpuboard_type); //ew(hDlg, IDC_CPUBOARD_SUBTYPE, workprefs.cpuboard_type);
 }
 

--- a/src/osdep/gui/PanelExpansions.cpp
+++ b/src/osdep/gui/PanelExpansions.cpp
@@ -776,9 +776,6 @@ static void updatecpuboardsubtypes()
 		cpuboard_subtype_list.add(cpuboards[changed_prefs.cpuboard_type].subtypes[i].name);
 	}
 
-	acceleratorboard_itemselector_list.clear();
-	acceleratorboard_selector_list.clear();
-
 	const expansionboardsettings* cbs = cpuboards[changed_prefs.cpuboard_type].subtypes[changed_prefs.cpuboard_subtype].settings;
 	create_expansionrom_gui(&accelerator_gui_item, cbs, changed_prefs.cpuboard_settings, nullptr,
 		cboAcceleratorBoardItemSelector, cboAcceleratorBoardSelector, chkAcceleratorBoardCheckbox, nullptr);

--- a/src/osdep/gui/PanelExpansions.cpp
+++ b/src/osdep/gui/PanelExpansions.cpp
@@ -12,7 +12,10 @@
 #include "memory.h"
 #include "autoconf.h"
 #include "cpuboard.h"
+#include "ethernet.h"
 #include "rommgr.h"
+#include "sana2.h"
+#include "uae.h"
 
 static gcn::Window* grpExpansionBoard;
 static gcn::Window* grpAcceleratorBoard;
@@ -29,8 +32,8 @@ static gcn::StringListModel scsi_romid_list;
 static gcn::StringListModel scsirom_selectnum_list;
 static gcn::StringListModel scsirom_file_list;
 
-static gcn::StringListModel cpuboards_list;
-static gcn::StringListModel cpuboards_subtype_list;
+static gcn::StringListModel cpuboard_type_list;
+static gcn::StringListModel cpuboard_subtype_list;
 static gcn::StringListModel cpuboard_romfile_list;
 static gcn::StringListModel acceleratorboard_itemselector_list;
 static gcn::StringListModel acceleratorboard_selector_list;
@@ -55,6 +58,7 @@ static gcn::TextBox* txtExpansionBoardStringBox;
 static gcn::DropDown* cboCpuBoardType;
 static gcn::DropDown* cboCpuBoardSubType;
 static gcn::DropDown* cboCpuBoardRomFile;
+static gcn::Button* btnCpuBoardRomChooser;
 
 static gcn::DropDown* cboAcceleratorBoardItemSelector;
 static gcn::DropDown* cboAcceleratorBoardSelector;
@@ -69,29 +73,7 @@ int scsiromselected = 0;
 static int scsiromselectednum = 0;
 static int scsiromselectedcatnum = 0;
 
-static const int scsiromselectedmask[] = {
-	EXPANSIONTYPE_INTERNAL, EXPANSIONTYPE_SCSI, EXPANSIONTYPE_IDE, EXPANSIONTYPE_SASI, EXPANSIONTYPE_CUSTOM,
-	EXPANSIONTYPE_PCI_BRIDGE, EXPANSIONTYPE_X86_BRIDGE, EXPANSIONTYPE_RTG,
-	EXPANSIONTYPE_SOUND, EXPANSIONTYPE_NET, EXPANSIONTYPE_FLOPPY, EXPANSIONTYPE_X86_EXPANSION
-};
-
-struct expansionrom_gui
-{
-	const expansionboardsettings* expansionrom_gui_ebs;
-	int expansionrom_gui_item;
-	gcn::DropDown* expansionrom_gui_itemselector;
-	gcn::DropDown* expansionrom_gui_selector;
-	gcn::CheckBox* expansionrom_gui_checkbox;
-	gcn::TextBox* expansionrom_gui_stringbox;
-	int expansionrom_gui_settingsbits;
-	int expansionrom_gui_settingsshift;
-	int expansionrom_gui_settings;
-	TCHAR expansionrom_gui_string[ROMCONFIG_CONFIGTEXT_LEN];
-};
-static expansionrom_gui expansion_gui_item;
-static expansionrom_gui accelerator_gui_item;
-
-static void gui_add_string(int *table, gcn::StringListModel *item, int id, const TCHAR *str)
+static void gui_add_string(int* table, gcn::StringListModel* item, int id, const TCHAR* str)
 {
 	while (*table >= 0)
 		table++;
@@ -118,6 +100,98 @@ static int gui_get_string_cursor(int* table, gcn::DropDown* item)
 		return -1;
 	return table[posn];
 }
+
+static void getromfile(gcn::DropDown* d, TCHAR* path, int size)
+{
+	auto val = d->getSelected();
+
+	romdata* rd;
+	auto tmp1 = d->getListModel()->getElementAt(val);	//SendDlgItemMessage(d, CB_GETLBTEXT, (WPARAM)val, (LPARAM)tmp1);
+	path[0] = 0;
+	rd = getromdatabyname(tmp1.c_str());
+	if (rd) {
+		romlist* rl = getromlistbyromdata(rd);
+		if (rd->configname)
+			_stprintf(path, _T(":%s"), rd->configname);
+		else if (rl)
+			_tcsncpy(path, rl->path, size);
+	}
+}
+
+static void addromfiles(gcn::DropDown* d, const TCHAR* path, int type1, int type2)
+{
+	//TODO when we implement ROM files
+}
+
+static void setcpuboardmemsize()
+{
+	if (changed_prefs.cpuboardmem1.size > cpuboard_maxmemory(&changed_prefs))
+		changed_prefs.cpuboardmem1.size = cpuboard_maxmemory(&changed_prefs);
+
+	if (cpuboard_memorytype(&changed_prefs) == BOARD_MEMORY_Z2) {
+		changed_prefs.fastmem[0].size = changed_prefs.cpuboardmem1.size;
+	}
+	if (cpuboard_memorytype(&changed_prefs) == BOARD_MEMORY_25BITMEM) {
+		changed_prefs.mem25bit.size = changed_prefs.cpuboardmem1.size;
+	}
+	if (changed_prefs.cpuboard_type == 0) {
+		changed_prefs.mem25bit.size = 0;
+	}
+
+	if (cpuboard_memorytype(&changed_prefs) == BOARD_MEMORY_HIGHMEM)
+		changed_prefs.mbresmem_high.size = changed_prefs.cpuboardmem1.size;
+
+	int maxmem = cpuboard_maxmemory(&changed_prefs);
+	if (changed_prefs.cpuboardmem1.size > maxmem) {
+		changed_prefs.cpuboardmem1.size = maxmem;
+	}
+	//if (maxmem <= 8 * 1024 * 1024)
+	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_Z2));
+	//else if (maxmem <= 16 * 1024 * 1024)
+	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_16M));
+	//else if (maxmem <= 32 * 1024 * 1024)
+	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_32M));
+	//else if (maxmem <= 64 * 1024 * 1024)
+	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_64M));
+	//else if (maxmem <= 128 * 1024 * 1024)
+	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_128M));
+	//else
+	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_256M));
+
+	int mem_size = 0;
+	switch (changed_prefs.cpuboardmem1.size) {
+	case 0x00000000: mem_size = 0; break;
+	case 0x00100000: mem_size = 1; break;
+	case 0x00200000: mem_size = 2; break;
+	case 0x00400000: mem_size = 3; break;
+	case 0x00800000: mem_size = 4; break;
+	case 0x01000000: mem_size = 5; break;
+	case 0x02000000: mem_size = 6; break;
+	case 0x04000000: mem_size = 7; break;
+	case 0x08000000: mem_size = 8; break;
+	case 0x10000000: mem_size = 9; break;
+	}
+	//SendDlgItemMessage(hDlg, IDC_CPUBOARDMEM, TBM_SETPOS, TRUE, mem_size);
+	//SetDlgItemText(hDlg, IDC_CPUBOARDRAM, memsize_names[msi_cpuboard[mem_size]]);
+	//SendDlgItemMessage(hDlg, IDC_CPUBOARD_TYPE, CB_SETCURSEL, changed_prefs.cpuboard_type, 0);
+	//SendDlgItemMessage(hDlg, IDC_CPUBOARD_SUBTYPE, CB_SETCURSEL, changed_prefs.cpuboard_subtype, 0);
+}
+
+struct expansionrom_gui
+{
+	const expansionboardsettings* expansionrom_gui_ebs;
+	int expansionrom_gui_item;
+	gcn::DropDown* expansionrom_gui_itemselector;
+	gcn::DropDown* expansionrom_gui_selector;
+	gcn::CheckBox* expansionrom_gui_checkbox;
+	gcn::TextBox* expansionrom_gui_stringbox;
+	int expansionrom_gui_settingsbits;
+	int expansionrom_gui_settingsshift;
+	int expansionrom_gui_settings;
+	TCHAR expansionrom_gui_string[ROMCONFIG_CONFIGTEXT_LEN];
+};
+static expansionrom_gui expansion_gui_item;
+static expansionrom_gui accelerator_gui_item;
 
 static void reset_expansionrom_gui(expansionrom_gui* eg, gcn::DropDown* itemselector, gcn::DropDown* selector, gcn::CheckBox* checkbox, gcn::TextBox* stringbox)
 {
@@ -264,7 +338,7 @@ static void get_expansionrom_gui(expansionrom_gui* eg)
 	int settings = eg->expansionrom_gui_settings;
 
 	val = eg->expansionrom_gui_itemselector->getSelected();
-	if (val != eg->expansionrom_gui_item) {
+	if (val != -1 && val != eg->expansionrom_gui_item) {
 		eg->expansionrom_gui_item = val;
 		create_expansionrom_gui(eg, eg->expansionrom_gui_ebs, eg->expansionrom_gui_settings, eg->expansionrom_gui_string,
 			eg->expansionrom_gui_itemselector, eg->expansionrom_gui_selector, eg->expansionrom_gui_checkbox, eg->expansionrom_gui_stringbox);
@@ -295,59 +369,23 @@ static void get_expansionrom_gui(expansionrom_gui* eg)
 	eg->expansionrom_gui_settings = settings;
 }
 
-static void setcpuboardmemsize()
+static struct netdriverdata* ndd[MAX_TOTAL_NET_DEVICES + 1];
+static int net_enumerated;
+
+struct netdriverdata** target_ethernet_enumerate(void)
 {
-	if (changed_prefs.cpuboardmem1.size > cpuboard_maxmemory(&changed_prefs))
-		changed_prefs.cpuboardmem1.size = cpuboard_maxmemory(&changed_prefs);
-
-	if (cpuboard_memorytype(&changed_prefs) == BOARD_MEMORY_Z2) {
-		changed_prefs.fastmem[0].size = changed_prefs.cpuboardmem1.size;
-	}
-	if (cpuboard_memorytype(&changed_prefs) == BOARD_MEMORY_25BITMEM) {
-		changed_prefs.mem25bit.size = changed_prefs.cpuboardmem1.size;
-	}
-	if (changed_prefs.cpuboard_type == 0) {
-		changed_prefs.mem25bit.size = 0;
-	}
-
-	if (cpuboard_memorytype(&changed_prefs) == BOARD_MEMORY_HIGHMEM)
-		changed_prefs.mbresmem_high.size = changed_prefs.cpuboardmem1.size;
-
-	int maxmem = cpuboard_maxmemory(&changed_prefs);
-	if (changed_prefs.cpuboardmem1.size > maxmem) {
-		changed_prefs.cpuboardmem1.size = maxmem;
-	}
-	//if (maxmem <= 8 * 1024 * 1024)
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_Z2));
-	//else if (maxmem <= 16 * 1024 * 1024)
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_16M));
-	//else if (maxmem <= 32 * 1024 * 1024)
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_32M));
-	//else if (maxmem <= 64 * 1024 * 1024)
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_64M));
-	//else if (maxmem <= 128 * 1024 * 1024)
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_128M));
-	//else
-	//	SendDlgItemMessage(IDC_CPUBOARDMEM, TBM_SETRANGE, TRUE, MAKELONG(MIN_CB_MEM, MAX_CB_MEM_256M));
-
-	int mem_size = 0;
-	switch (changed_prefs.cpuboardmem1.size) {
-	case 0x00000000: mem_size = 0; break;
-	case 0x00100000: mem_size = 1; break;
-	case 0x00200000: mem_size = 2; break;
-	case 0x00400000: mem_size = 3; break;
-	case 0x00800000: mem_size = 4; break;
-	case 0x01000000: mem_size = 5; break;
-	case 0x02000000: mem_size = 6; break;
-	case 0x04000000: mem_size = 7; break;
-	case 0x08000000: mem_size = 8; break;
-	case 0x10000000: mem_size = 9; break;
-	}
-	//SendDlgItemMessage(hDlg, IDC_CPUBOARDMEM, TBM_SETPOS, TRUE, mem_size);
-	//SetDlgItemText(hDlg, IDC_CPUBOARDRAM, memsize_names[msi_cpuboard[mem_size]]);
-	//SendDlgItemMessage(hDlg, IDC_CPUBOARD_TYPE, CB_SETCURSEL, changed_prefs.cpuboard_type, 0);
-	//SendDlgItemMessage(hDlg, IDC_CPUBOARD_SUBTYPE, CB_SETCURSEL, changed_prefs.cpuboard_subtype, 0);
+	if (net_enumerated)
+		return ndd;
+	ethernet_enumerate(ndd, 0);
+	net_enumerated = 1;
+	return ndd;
 }
+
+static const int scsiromselectedmask[] = {
+	EXPANSIONTYPE_INTERNAL, EXPANSIONTYPE_SCSI, EXPANSIONTYPE_IDE, EXPANSIONTYPE_SASI, EXPANSIONTYPE_CUSTOM,
+	EXPANSIONTYPE_PCI_BRIDGE, EXPANSIONTYPE_X86_BRIDGE, EXPANSIONTYPE_RTG,
+	EXPANSIONTYPE_SOUND, EXPANSIONTYPE_NET, EXPANSIONTYPE_FLOPPY, EXPANSIONTYPE_X86_EXPANSION
+};
 
 static void init_expansion2(bool init)
 {
@@ -378,7 +416,7 @@ static void init_expansion2(bool init)
 				continue;
 			int cnt = 0;
 			for (int j = 0; j < MAX_DUPLICATE_EXPANSION_BOARDS; j++) {
-				if (is_board_enabled(&changed_prefs, int(expansionroms[i].romtype), j)) {
+				if (is_board_enabled(&changed_prefs, static_cast<int>(expansionroms[i].romtype), j)) {
 					cnt++;
 				}
 			}
@@ -471,7 +509,7 @@ static void init_expansion2(bool init)
 
 	scsi_romid_list.clear(); //SendDlgItemMessage(hDlg, IDC_SCSIROMID, CB_RESETCONTENT, 0, 0);
 	int index;
-	boardromconfig* brc = get_device_rom(&changed_prefs, int(expansionroms[scsiromselected].romtype), scsiromselectednum, &index);
+	boardromconfig* brc = get_device_rom(&changed_prefs, static_cast<int>(expansionroms[scsiromselected].romtype), scsiromselectednum, &index);
 	const expansionromtype* ert = &expansionroms[scsiromselected];
 	if (brc && ert && ert->id_jumper) {
 		for (int i = 0; i < 8; i++) {
@@ -487,22 +525,121 @@ static void init_expansion2(bool init)
 	}
 }
 
-static void updatecpuboardsubtypes()
+static void values_to_expansion2dlg_sub()
 {
-	cpuboards_subtype_list.clear();
-	for (int i = 0; cpuboards[changed_prefs.cpuboard_type].subtypes[i].name; i++)
-	{
-		cpuboards_subtype_list.add(cpuboards[changed_prefs.cpuboard_type].subtypes[i].name);
-	}
+	cpuboard_subtype_list.clear(); //SendDlgItemMessage(hDlg, IDC_CPUBOARDROMSUBSELECT, CB_RESETCONTENT, 0, 0);
+	cboCpuBoardSubType->setEnabled(false); //ew(hDlg, IDC_CPUBOARDROMSUBSELECT, false);
 
-	const expansionboardsettings* cbs = cpuboards[changed_prefs.cpuboard_type].subtypes[changed_prefs.cpuboard_subtype].settings;
-	create_expansionrom_gui(&accelerator_gui_item, cbs, changed_prefs.cpuboard_settings, nullptr,
-		cboAcceleratorBoardItemSelector, cboAcceleratorBoardSelector, chkAcceleratorBoardCheckbox, nullptr);
+	scsirom_subselect_list.clear(); //SendDlgItemMessage(hDlg, IDC_SCSIROMSUBSELECT, CB_RESETCONTENT, 0, 0);
+	const expansionromtype* er = &expansionroms[scsiromselected];
+	const expansionsubromtype* srt = er->subtypes;
+	int deviceflags = er->deviceflags;
+	cboScsiRomSubSelect->setEnabled(srt != nullptr); //ew(hDlg, IDC_SCSIROMSUBSELECT, srt != NULL);
+	while (srt && srt->name) {
+		scsirom_subselect_list.add(srt->name); //SendDlgItemMessage(hDlg, IDC_SCSIROMSUBSELECT, CB_ADDSTRING, 0, (LPARAM)srt->name);
+		srt++;
+	}
+	int index;
+	boardromconfig* brc = get_device_rom(&changed_prefs, static_cast<int>(expansionroms[scsiromselected].romtype), scsiromselectednum, &index);
+	if (brc && er->subtypes) {
+		cboScsiRomSubSelect->setSelected(brc->roms[index].subtype); //SendDlgItemMessage(hDlg, IDC_SCSIROMSUBSELECT, CB_SETCURSEL, brc->roms[index].subtype, 0);
+		cboScsiRomId->setSelected(brc->roms[index].device_id); //SendDlgItemMessage(hDlg, IDC_SCSIROMID, CB_SETCURSEL, brc->roms[index].device_id, 0);
+		deviceflags |= er->subtypes[brc->roms[index].subtype].deviceflags;
+	}
+	else if (srt) {
+		cboScsiRomSubSelect->setSelected(0); //SendDlgItemMessage(hDlg, IDC_SCSIROMSUBSELECT, CB_SETCURSEL, 0, 0);
+		cboScsiRomId->setSelected(0); //SendDlgItemMessage(hDlg, IDC_SCSIROMID, CB_SETCURSEL, 0, 0);
+	}
+	scsirom_selectnum_list.clear(); //SendDlgItemMessage(hDlg, IDC_SCSIROMSELECTNUM, CB_RESETCONTENT, 0, 0);
+	if (deviceflags & EXPANSIONTYPE_CLOCKPORT) {
+		scsirom_selectnum_list.add(_T("-")); //SendDlgItemMessage(hDlg, IDC_SCSIROMSELECTNUM, CB_ADDSTRING, 0, (LPARAM)_T("-"));
+	}
+	for (int i = 0; i < MAX_AVAILABLE_DUPLICATE_EXPANSION_BOARDS; i++) {
+		TCHAR tmp[10];
+		_stprintf(tmp, _T("%d"), i + 1);
+		scsirom_selectnum_list.add(tmp); //SendDlgItemMessage(hDlg, IDC_SCSIROMSELECTNUM, CB_ADDSTRING, 0, (LPARAM)tmp);
+	}
+	cboScsiRomSelectNum->setSelected(scsiromselectednum); //SendDlgItemMessage(hDlg, IDC_SCSIROMSELECTNUM, CB_SETCURSEL, scsiromselectednum, 0);
+	if ((er->zorro < 2 || er->singleonly) && !(deviceflags & EXPANSIONTYPE_CLOCKPORT)) {
+		scsiromselectednum = 0;
+		cboScsiRomSelectNum->setSelected(0); //SendDlgItemMessage(hDlg, IDC_SCSIROMSELECTNUM, CB_SETCURSEL, 0, 0);
+	}
+	cboScsiRomSelectNum->setEnabled((er->zorro >= 2 && !er->singleonly) || (deviceflags & EXPANSIONTYPE_CLOCKPORT)); //ew(hDlg, IDC_SCSIROMSELECTNUM, (er->zorro >= 2 && !er->singleonly) || (deviceflags & EXPANSIONTYPE_CLOCKPORT));
+	chkScsiRom24bitDma->setVisible((deviceflags & EXPANSIONTYPE_DMA24) != 0); //hide(hDlg, IDC_SCSIROM24BITDMA, (deviceflags & EXPANSIONTYPE_DMA24) == 0);
+	chkScsiRom24bitDma->setEnabled((deviceflags & EXPANSIONTYPE_DMA24) != 0); //ew(hDlg, IDC_SCSIROM24BITDMA, (deviceflags & EXPANSIONTYPE_DMA24) != 0);
 }
 
-static void addromfiles(gcn::DropDown* d, const TCHAR* path, int type1, int type2)
+static void values_from_expansion2dlg()
 {
-	//TODO when we implement ROM files
+	int index;
+	boardromconfig* brc;
+	TCHAR tmp[MAX_DPATH];
+	bool changed = false;
+	bool isnew = false;
+
+	int checked = chkScsiRomSelected->isSelected();
+	getromfile(cboScsiRomSelect, tmp, MAX_DPATH / sizeof(TCHAR));
+	if (tmp[0] || checked) {
+		const expansionromtype* ert = &expansionroms[scsiromselected];
+		if (!get_device_rom(&changed_prefs, static_cast<int>(expansionroms[scsiromselected].romtype), scsiromselectednum, &index))
+			isnew = true;
+		brc = get_device_rom_new(&changed_prefs, static_cast<int>(expansionroms[scsiromselected].romtype), scsiromselectednum, &index);
+		if (checked) {
+			if (!brc->roms[index].romfile[0])
+				changed = true;
+			_tcscpy(brc->roms[index].romfile, _T(":ENABLED"));
+		}
+		else {
+			changed = _tcscmp(tmp, brc->roms[index].romfile) != 0;
+			getromfile(cboScsiRomSelect, brc->roms[index].romfile, MAX_DPATH / sizeof(TCHAR));
+		}
+		brc->roms[index].autoboot_disabled = chkScsiRomFileAutoboot->isSelected(); //ischecked(hDlg, IDC_SCSIROMFILEAUTOBOOT);
+		brc->roms[index].inserted = chkScsiRomFilePcmcia->isSelected(); //ischecked(hDlg, IDC_SCSIROMFILEPCMCIA);
+		brc->roms[index].dma24bit = chkScsiRom24bitDma->isSelected(); //ischecked(hDlg, IDC_SCSIROM24BITDMA);
+
+		int v = cboScsiRomId->getSelected(); //SendDlgItemMessage(IDC_SCSIROMID, CB_GETCURSEL, 0, 0L);
+		if (!isnew)
+			brc->roms[index].device_id = v;
+
+		const expansionboardsettings* cbs = ert->settings;
+		if (cbs) {
+			brc->roms[index].device_settings = expansion_gui_item.expansionrom_gui_settings;
+			_tcscpy(brc->roms[index].configtext, expansion_gui_item.expansionrom_gui_string);
+		}
+
+		v = cboScsiRomSubSelect->getSelected(); //SendDlgItemMessage(IDC_SCSIROMSUBSELECT, CB_GETCURSEL, 0, 0L);
+		brc->roms[index].subtype = v;
+	}
+	else {
+		brc = get_device_rom(&changed_prefs, static_cast<int>(expansionroms[scsiromselected].romtype), scsiromselectednum, &index);
+		if (brc && brc->roms[index].romfile[0])
+			changed = true;
+		clear_device_rom(&changed_prefs, static_cast<int>(expansionroms[scsiromselected].romtype), scsiromselectednum, true);
+	}
+	if (changed) {
+		// singleonly check and removal
+		if (expansionroms[scsiromselected].singleonly) {
+			if (get_device_rom(&changed_prefs, static_cast<int>(expansionroms[scsiromselected].romtype), scsiromselectednum, &index)) {
+				for (int i = 0; i < MAX_EXPANSION_BOARDS; i++) {
+					if (i != scsiromselectednum) {
+						clear_device_rom(&changed_prefs, static_cast<int>(expansionroms[scsiromselected].romtype), i, true);
+					}
+				}
+			}
+		}
+		init_expansion2(false);
+		values_to_expansion2dlg_sub();
+	}
+
+	changed_prefs.cpuboard_settings = accelerator_gui_item.expansionrom_gui_settings;
+	getromfile(cboCpuBoardType, tmp, sizeof(brc->roms[index].romfile) / sizeof(TCHAR));
+	if (tmp[0]) {
+		brc = get_device_rom_new(&changed_prefs, ROMTYPE_CPUBOARD, 0, &index);
+		getromfile(cboCpuBoardType, brc->roms[index].romfile, sizeof(brc->roms[index].romfile) / sizeof(TCHAR));
+	}
+	else {
+		clear_device_rom(&changed_prefs, ROMTYPE_CPUBOARD, 0, true);
+	}
 }
 
 static void values_to_expansion2_expansion_roms()
@@ -512,15 +649,15 @@ static void values_to_expansion2_expansion_roms()
 
 	if (scsiromselected) {
 		const expansionromtype* ert = &expansionroms[scsiromselected];
-		int romtype = int(ert->romtype);
-		int romtype_extra = int(ert->romtype_extra);
+		int romtype = static_cast<int>(ert->romtype);
+		int romtype_extra = static_cast<int>(ert->romtype_extra);
 		int deviceflags = ert->deviceflags;
 
 		brc = get_device_rom(&changed_prefs, romtype, scsiromselectednum, &index);
 		if (brc && ert->subtypes) {
 			const expansionsubromtype* esrt = &ert->subtypes[brc->roms[index].subtype];
 			if (esrt->romtype) {
-				romtype = int(esrt->romtype);
+				romtype = static_cast<int>(esrt->romtype);
 				romtype_extra = 0;
 			}
 			deviceflags |= esrt->deviceflags;
@@ -579,7 +716,7 @@ static void values_to_expansion2_expansion_settings()
 	boardromconfig* brc;
 	if (scsiromselected) {
 		const expansionromtype* ert = &expansionroms[scsiromselected];
-		brc = get_device_rom(&changed_prefs, int(expansionroms[scsiromselected].romtype), scsiromselectednum, &index);
+		brc = get_device_rom(&changed_prefs, static_cast<int>(expansionroms[scsiromselected].romtype), scsiromselectednum, &index);
 		if (brc) {
 			if (brc->roms[index].romfile[0])
 				chkScsiRomFileAutoboot->setEnabled(ert->autoboot_jumper); //ew(hDlg, IDC_SCSIROMFILEAUTOBOOT, ert->autoboot_jumper);
@@ -601,147 +738,46 @@ static void values_to_expansion2_expansion_settings()
 	}
 }
 
-static void values_to_expansion2dlg_sub()
+
+
+static void updatecpuboardsubtypes()
 {
-	cpuboards_subtype_list.clear(); //SendDlgItemMessage(hDlg, IDC_CPUBOARDROMSUBSELECT, CB_RESETCONTENT, 0, 0);
-	cboCpuBoardSubType->setEnabled(false); //ew(hDlg, IDC_CPUBOARDROMSUBSELECT, false);
-
-	scsirom_subselect_list.clear(); //SendDlgItemMessage(hDlg, IDC_SCSIROMSUBSELECT, CB_RESETCONTENT, 0, 0);
-	const expansionromtype* er = &expansionroms[scsiromselected];
-	const expansionsubromtype* srt = er->subtypes;
-	int deviceflags = er->deviceflags;
-	cboScsiRomSubSelect->setEnabled(srt != nullptr); //ew(hDlg, IDC_SCSIROMSUBSELECT, srt != NULL);
-	while (srt && srt->name) {
-		scsirom_subselect_list.add(srt->name); //SendDlgItemMessage(hDlg, IDC_SCSIROMSUBSELECT, CB_ADDSTRING, 0, (LPARAM)srt->name);
-		srt++;
-	}
-	int index;
-	boardromconfig* brc = get_device_rom(&changed_prefs, int(expansionroms[scsiromselected].romtype), scsiromselectednum, &index);
-	if (brc && er->subtypes) {
-		cboScsiRomSubSelect->setSelected(brc->roms[index].subtype); //SendDlgItemMessage(hDlg, IDC_SCSIROMSUBSELECT, CB_SETCURSEL, brc->roms[index].subtype, 0);
-		cboScsiRomId->setSelected(brc->roms[index].device_id); //SendDlgItemMessage(hDlg, IDC_SCSIROMID, CB_SETCURSEL, brc->roms[index].device_id, 0);
-		deviceflags |= er->subtypes[brc->roms[index].subtype].deviceflags;
-	}
-	else if (srt) {
-		cboScsiRomSubSelect->setSelected(0); //SendDlgItemMessage(hDlg, IDC_SCSIROMSUBSELECT, CB_SETCURSEL, 0, 0);
-		cboScsiRomId->setSelected(0); //SendDlgItemMessage(hDlg, IDC_SCSIROMID, CB_SETCURSEL, 0, 0);
-	}
-	scsirom_selectnum_list.clear(); //SendDlgItemMessage(hDlg, IDC_SCSIROMSELECTNUM, CB_RESETCONTENT, 0, 0);
-	if (deviceflags & EXPANSIONTYPE_CLOCKPORT) {
-		scsirom_selectnum_list.add(_T("-")); //SendDlgItemMessage(hDlg, IDC_SCSIROMSELECTNUM, CB_ADDSTRING, 0, (LPARAM)_T("-"));
-	}
-	for (int i = 0; i < MAX_AVAILABLE_DUPLICATE_EXPANSION_BOARDS; i++) {
-		TCHAR tmp[10];
-		_stprintf(tmp, _T("%d"), i + 1);
-		scsirom_selectnum_list.add(tmp); //SendDlgItemMessage(hDlg, IDC_SCSIROMSELECTNUM, CB_ADDSTRING, 0, (LPARAM)tmp);
-	}
-	cboScsiRomSelectNum->setSelected(scsiromselectednum); //SendDlgItemMessage(hDlg, IDC_SCSIROMSELECTNUM, CB_SETCURSEL, scsiromselectednum, 0);
-	if ((er->zorro < 2 || er->singleonly) && !(deviceflags & EXPANSIONTYPE_CLOCKPORT)) {
-		scsiromselectednum = 0;
-		cboScsiRomSelectNum->setSelected(0); //SendDlgItemMessage(hDlg, IDC_SCSIROMSELECTNUM, CB_SETCURSEL, 0, 0);
-	}
-	cboScsiRomSelectNum->setEnabled((er->zorro >= 2 && !er->singleonly) || (deviceflags & EXPANSIONTYPE_CLOCKPORT)); //ew(hDlg, IDC_SCSIROMSELECTNUM, (er->zorro >= 2 && !er->singleonly) || (deviceflags & EXPANSIONTYPE_CLOCKPORT));
-	chkScsiRom24bitDma->setVisible((deviceflags & EXPANSIONTYPE_DMA24) != 0); //hide(hDlg, IDC_SCSIROM24BITDMA, (deviceflags & EXPANSIONTYPE_DMA24) == 0);
-	chkScsiRom24bitDma->setEnabled((deviceflags & EXPANSIONTYPE_DMA24) != 0); //ew(hDlg, IDC_SCSIROM24BITDMA, (deviceflags & EXPANSIONTYPE_DMA24) != 0);
-}
-
-static void getromfile(gcn::DropDown* d, TCHAR* path, int size)
-{
-	auto val = d->getSelected();
-
-	romdata* rd;
-	auto tmp1 = d->getListModel()->getElementAt(val);	//SendDlgItemMessage(d, CB_GETLBTEXT, (WPARAM)val, (LPARAM)tmp1);
-	path[0] = 0;
-	rd = getromdatabyname(tmp1.c_str());
-	if (rd) {
-		romlist* rl = getromlistbyromdata(rd);
-		if (rd->configname)
-			_stprintf(path, _T(":%s"), rd->configname);
-		else if (rl)
-			_tcsncpy(path, rl->path, size);
-	}
-}
-
-static void values_from_expansion2dlg()
-{
-	int index;
-	boardromconfig* brc;
-	TCHAR tmp[MAX_DPATH];
-	bool changed = false;
-	bool isnew = false;
-	
-	int checked = chkScsiRomSelected->isSelected();
-	getromfile(cboScsiRomSelect, tmp, MAX_DPATH / sizeof(TCHAR));
-	if (tmp[0] || checked) {
-		const expansionromtype* ert = &expansionroms[scsiromselected];
-		if (!get_device_rom(&changed_prefs, int(expansionroms[scsiromselected].romtype), scsiromselectednum, &index))
-			isnew = true;
-		brc = get_device_rom_new(&changed_prefs, int(expansionroms[scsiromselected].romtype), scsiromselectednum, &index);
-		if (checked) {
-			if (!brc->roms[index].romfile[0])
-				changed = true;
-			_tcscpy(brc->roms[index].romfile, _T(":ENABLED"));
-		}
-		else {
-			changed = _tcscmp(tmp, brc->roms[index].romfile) != 0;
-			getromfile(cboScsiRomSelect, brc->roms[index].romfile, MAX_DPATH / sizeof(TCHAR));
-		}
-		brc->roms[index].autoboot_disabled = chkScsiRomFileAutoboot->isSelected(); //ischecked(hDlg, IDC_SCSIROMFILEAUTOBOOT);
-		brc->roms[index].inserted = chkScsiRomFilePcmcia->isSelected(); //ischecked(hDlg, IDC_SCSIROMFILEPCMCIA);
-		brc->roms[index].dma24bit = chkScsiRom24bitDma->isSelected(); //ischecked(hDlg, IDC_SCSIROM24BITDMA);
-
-		int v = cboScsiRomId->getSelected(); //SendDlgItemMessage(IDC_SCSIROMID, CB_GETCURSEL, 0, 0L);
-		if (!isnew)
-			brc->roms[index].device_id = v;
-
-		const expansionboardsettings* cbs = ert->settings;
-		if (cbs) {
-			brc->roms[index].device_settings = expansion_gui_item.expansionrom_gui_settings;
-			_tcscpy(brc->roms[index].configtext, expansion_gui_item.expansionrom_gui_string);
-		}
-
-		v = cboScsiRomSubSelect->getSelected(); //SendDlgItemMessage(IDC_SCSIROMSUBSELECT, CB_GETCURSEL, 0, 0L);
-		brc->roms[index].subtype = v;
-	}
-	else {
-		brc = get_device_rom(&changed_prefs, int(expansionroms[scsiromselected].romtype), scsiromselectednum, &index);
-		if (brc && brc->roms[index].romfile[0])
-			changed = true;
-		clear_device_rom(&changed_prefs, int(expansionroms[scsiromselected].romtype), scsiromselectednum, true);
-	}
-	if (changed) {
-		// singleonly check and removal
-		if (expansionroms[scsiromselected].singleonly) {
-			if (get_device_rom(&changed_prefs, int(expansionroms[scsiromselected].romtype), scsiromselectednum, &index)) {
-				for (int i = 0; i < MAX_EXPANSION_BOARDS; i++) {
-					if (i != scsiromselectednum) {
-						clear_device_rom(&changed_prefs, int(expansionroms[scsiromselected].romtype), i, true);
-					}
-				}
-			}
-		}
-		init_expansion2(false);
-		values_to_expansion2dlg_sub();
+	cpuboard_subtype_list.clear();
+	for (int i = 0; cpuboards[changed_prefs.cpuboard_type].subtypes[i].name; i++)
+	{
+		cpuboard_subtype_list.add(cpuboards[changed_prefs.cpuboard_type].subtypes[i].name);
 	}
 
-	changed_prefs.cpuboard_settings = accelerator_gui_item.expansionrom_gui_settings;
-	getromfile(cboCpuBoardType, tmp, sizeof(brc->roms[index].romfile) / sizeof(TCHAR));
-	if (tmp[0]) {
-		brc = get_device_rom_new(&changed_prefs, ROMTYPE_CPUBOARD, 0, &index);
-		getromfile(cboCpuBoardType, brc->roms[index].romfile, sizeof(brc->roms[index].romfile) / sizeof(TCHAR));
-	}
-	else {
-		clear_device_rom(&changed_prefs, ROMTYPE_CPUBOARD, 0, true);
-	}
+	const expansionboardsettings* cbs = cpuboards[changed_prefs.cpuboard_type].subtypes[changed_prefs.cpuboard_subtype].settings;
+	create_expansionrom_gui(&accelerator_gui_item, cbs, changed_prefs.cpuboard_settings, nullptr,
+		cboAcceleratorBoardItemSelector, cboAcceleratorBoardSelector, chkAcceleratorBoardCheckbox, nullptr);
 }
 
 static void expansion2dlgproc()
 {
+	// Populate Ethernet list
+	if (!net_enumerated) {
+		target_ethernet_enumerate();
+		for (int i = 0; ndd[i]; i++) {
+			struct netdriverdata* n = ndd[i];
+			if (!n->active)
+				continue;
+			if (n->type == UAENET_SLIRP) {
+				n->desc = my_strdup("SLIRP User Mode NAT");
+			}
+			else if (n->type == UAENET_SLIRP_INBOUND) {
+				n->desc = my_strdup("SLIRP + Open ports (21-23,80)");
+			}
+		}
+		ethernet_updateselection();
+		net_enumerated = 1;
+	}
+
 	//Populate CPU boards list
-	cpuboards_list.clear();
+	cpuboard_type_list.clear();
 	for (int i = 0; cpuboards[i].name; i++)
 	{
-		cpuboards_list.add(cpuboards[i].name);
+		cpuboard_type_list.add(cpuboards[i].name);
 	}
 
 	//Populate Expansion Categories
@@ -773,61 +809,93 @@ class ExpansionsActionListener : public gcn::ActionListener
 public:
 	void action(const gcn::ActionEvent& action_event) override
 	{
-		if (action_event.getSource() == txtExpansionBoardStringBox
-			|| action_event.getSource() == chkExpansionBoardCheckbox
-			|| action_event.getSource() == cboExpansionBoardItemSelector
-			|| action_event.getSource() == cboExpansionBoardSelector)
+		const auto source = action_event.getSource();
+
+		if (source == btnScsiRomChooser)
+		{
+			const char* filter[] = { ".rom", ".bin", "\0" };
+			std::string full_path = SelectFile("Select ROM", get_rom_path(), filter);
+			if (!full_path.empty())
+			{
+				int val = gui_get_string_cursor(scsiromselect_table, cboScsiRomSelect);
+				if (val != -1) {
+					int index;
+					struct boardromconfig* brc;
+					brc = get_device_rom_new(&changed_prefs, static_cast<int>(expansionroms[scsiromselected].romtype), scsiromselectednum, &index);
+					_tcscpy(brc->roms[index].romfile, full_path.c_str());
+					fullpath(brc->roms[index].romfile, MAX_DPATH);
+				}
+			}
+			RefreshPanelExpansions();
+		}
+		else if (source == btnCpuBoardRomChooser)
+		{
+			const char* filter[] = { ".rom", ".bin", "\0" };
+			std::string full_path = SelectFile("Select ROM", get_rom_path(), filter);
+			if (!full_path.empty())
+			{
+				int index;
+				struct boardromconfig* brc = get_device_rom_new(&changed_prefs, ROMTYPE_CPUBOARD, 0, &index);
+				_tcscpy(brc->roms[index].romfile, full_path.c_str());
+				fullpath(brc->roms[index].romfile, MAX_DPATH);
+			}
+			RefreshPanelExpansions();
+		}
+		else if (source == txtExpansionBoardStringBox
+			|| source == chkExpansionBoardCheckbox
+			|| source == cboExpansionBoardItemSelector
+			|| source == cboExpansionBoardSelector)
 		{
 			get_expansionrom_gui(&expansion_gui_item);
 			values_from_expansion2dlg();
 		}
-		else if (action_event.getSource() == chkAcceleratorBoardCheckbox
-			|| action_event.getSource() == cboAcceleratorBoardItemSelector
-			|| action_event.getSource() == cboAcceleratorBoardSelector)
+		else if (source == chkAcceleratorBoardCheckbox
+			|| source == cboAcceleratorBoardItemSelector
+			|| source == cboAcceleratorBoardSelector)
 		{
 			get_expansionrom_gui(&accelerator_gui_item);
 			values_from_expansion2dlg();
 		}
-		else if (action_event.getSource() == chkScsiRomFileAutoboot
-			|| action_event.getSource() == chkScsiRomFilePcmcia
-			|| action_event.getSource() == chkScsiRom24bitDma)
+		else if (source == chkScsiRomFileAutoboot
+			|| source == chkScsiRomFilePcmcia
+			|| source == chkScsiRom24bitDma)
 		{
 			values_from_expansion2dlg();
 		}
-		else if (action_event.getSource() == chkBSDSocket)
+		else if (source == chkBSDSocket)
 		{
 			changed_prefs.socket_emu = chkBSDSocket->isSelected();
 		}
-		else if (action_event.getSource() == chkScsi)
+		else if (source == chkScsi)
 		{
 			changed_prefs.scsi = chkScsi->isSelected();
 			RefreshPanelExpansions();
 		}
-		else if (action_event.getSource() == chkSana2)
+		else if (source == chkSana2)
 		{
 			changed_prefs.sana2 = chkSana2->isSelected();
 		}
-		else if (action_event.getSource() == chkCD32Fmv)
+		else if (source == chkCD32Fmv)
 		{
 			changed_prefs.cs_cd32fmv = chkCD32Fmv->isSelected();
 			cfgfile_compatibility_romtype(&changed_prefs);
 		}
-		else if (action_event.getSource() == chkScsiRomSelected
-			|| action_event.getSource() == cboScsiRomFile
-			|| action_event.getSource() == cboScsiRomId
-			|| action_event.getSource() == cboCpuBoardRomFile
-			|| action_event.getSource() == cboCpuBoardSubType)
+		else if (source == chkScsiRomSelected
+			|| source == cboScsiRomFile
+			|| source == cboScsiRomId
+			|| source == cboCpuBoardRomFile
+			|| source == cboCpuBoardSubType)
 		{
 			values_from_expansion2dlg();
 			values_to_expansion2_expansion_settings();
 		}
-		else if (action_event.getSource() == cboScsiRomSubSelect)
+		else if (source == cboScsiRomSubSelect)
 		{
 			values_from_expansion2dlg();
 			values_to_expansion2_expansion_roms();
 			values_to_expansion2_expansion_settings();
 		}
-		else if (action_event.getSource() == cboScsiRomSelectCat)
+		else if (source == cboScsiRomSelectCat)
 		{
 			auto val = cboScsiRomSelectCat->getSelected();
 			if (val != -1 && val != scsiromselectedcatnum)
@@ -840,8 +908,8 @@ public:
 				values_to_expansion2dlg_sub();
 			}
 		}
-		else if (action_event.getSource() == cboScsiRomSelectNum
-			|| action_event.getSource() == cboScsiRomSelect)
+		else if (source == cboScsiRomSelectNum
+			|| source == cboScsiRomSelect)
 		{
 			auto val = cboScsiRomSelectNum->getSelected();
 			if (val != -1)
@@ -855,25 +923,44 @@ public:
 				values_to_expansion2dlg_sub();
 			}
 		}
-		
-		else if (action_event.getSource() == cboCpuBoardType)
+		else if (source == cboCpuBoardType)
 		{
-			changed_prefs.cpuboard_type = cboCpuBoardType->getSelected();
-			changed_prefs.cpuboard_subtype = 0;
-			changed_prefs.cpuboard_settings = 0;
-			updatecpuboardsubtypes();
-			cpuboard_set_cpu(&changed_prefs);
-			setcpuboardmemsize();
-			RefreshPanelExpansions();
+			auto v = cboCpuBoardType->getSelected();
+			if (v != -1 && v != changed_prefs.cpuboard_type)
+			{
+				changed_prefs.cpuboard_type = v;
+				changed_prefs.cpuboard_subtype = 0;
+				changed_prefs.cpuboard_settings = 0;
+				updatecpuboardsubtypes();
+				if (is_ppc_cpu(&changed_prefs)) {
+					changed_prefs.ppc_mode = 2;
+				}
+				else if (changed_prefs.ppc_mode == 2) {
+					changed_prefs.ppc_mode = 0;
+				}
+				cpuboard_set_cpu(&changed_prefs);
+				setcpuboardmemsize();
+				RefreshPanelExpansions();
+			}
 		}
-		else if (action_event.getSource() == cboCpuBoardSubType)
+		else if (source == cboCpuBoardSubType)
 		{
-			changed_prefs.cpuboard_subtype = cboCpuBoardSubType->getSelected();
-			changed_prefs.cpuboard_settings = 0;
-			updatecpuboardsubtypes();
-			cpuboard_set_cpu(&changed_prefs);
-			setcpuboardmemsize();
-			RefreshPanelExpansions();
+			auto v = cboCpuBoardSubType->getSelected();
+			if (v != -1 && v != changed_prefs.cpuboard_subtype)
+			{
+				changed_prefs.cpuboard_subtype = v;
+				changed_prefs.cpuboard_settings = 0;
+				updatecpuboardsubtypes();
+				if (is_ppc_cpu(&changed_prefs)) {
+					changed_prefs.ppc_mode = 2;
+				}
+				else if (changed_prefs.ppc_mode == 2) {
+					changed_prefs.ppc_mode = 0;
+				}
+				cpuboard_set_cpu(&changed_prefs);
+				setcpuboardmemsize();
+				RefreshPanelExpansions();
+			}
 		}	
 	}
 };
@@ -1006,7 +1093,7 @@ void InitPanelExpansions(const config_category& category)
 	txtExpansionBoardStringBox->setBackgroundColor(gui_background_color);
 	txtExpansionBoardStringBox->setForegroundColor(gui_foreground_color);
 	
-	cboCpuBoardType = new gcn::DropDown(&cpuboards_list);
+	cboCpuBoardType = new gcn::DropDown(&cpuboard_type_list);
 	cboCpuBoardType->setSize(250, cboCpuBoardType->getHeight());
 	cboCpuBoardType->setBaseColor(gui_base_color);
 	cboCpuBoardType->setBackgroundColor(gui_background_color);
@@ -1014,9 +1101,8 @@ void InitPanelExpansions(const config_category& category)
 	cboCpuBoardType->setSelectionColor(gui_selection_color);
 	cboCpuBoardType->setId("cboCpuBoardType");
 	cboCpuBoardType->addActionListener(expansions_action_listener);
-	cboCpuBoardType->setEnabled(false); //TODO enable this when implemented
 
-	cboCpuBoardSubType = new gcn::DropDown(&cpuboards_subtype_list);
+	cboCpuBoardSubType = new gcn::DropDown(&cpuboard_subtype_list);
 	cboCpuBoardSubType->setSize(250, cboCpuBoardSubType->getHeight());
 	cboCpuBoardSubType->setBaseColor(gui_base_color);
 	cboCpuBoardSubType->setBackgroundColor(gui_background_color);
@@ -1024,17 +1110,23 @@ void InitPanelExpansions(const config_category& category)
 	cboCpuBoardSubType->setSelectionColor(gui_selection_color);
 	cboCpuBoardSubType->setId("cboCpuBoardSubType");
 	cboCpuBoardSubType->addActionListener(expansions_action_listener);
-	cboCpuBoardSubType->setEnabled(false); //TODO enable this when implemented
 
 	cboCpuBoardRomFile = new gcn::DropDown(&cpuboard_romfile_list);
-	cboCpuBoardRomFile->setSize(250, cboCpuBoardRomFile->getHeight());
+	cboCpuBoardRomFile->setSize(200, cboCpuBoardRomFile->getHeight());
 	cboCpuBoardRomFile->setBaseColor(gui_base_color);
 	cboCpuBoardRomFile->setBackgroundColor(gui_background_color);
 	cboCpuBoardRomFile->setForegroundColor(gui_foreground_color);
 	cboCpuBoardRomFile->setSelectionColor(gui_selection_color);
 	cboCpuBoardRomFile->setId("cboCpuBoardRomFile");
 	cboCpuBoardRomFile->addActionListener(expansions_action_listener);
-	cboCpuBoardRomFile->setEnabled(false); //TODO Enable this when implemented
+
+	btnCpuBoardRomChooser = new gcn::Button("...");
+	btnCpuBoardRomChooser->setBaseColor(gui_base_color);
+	btnCpuBoardRomChooser->setBackgroundColor(gui_background_color);
+	btnCpuBoardRomChooser->setForegroundColor(gui_foreground_color);
+	btnCpuBoardRomChooser->setSize(SMALL_BUTTON_WIDTH, SMALL_BUTTON_HEIGHT);
+	btnCpuBoardRomChooser->setId("btnCpuBoardRomChooser");
+	btnCpuBoardRomChooser->addActionListener(expansions_action_listener);
 
 	cboAcceleratorBoardItemSelector = new gcn::DropDown(&acceleratorboard_itemselector_list);
 	cboAcceleratorBoardItemSelector->setSize(250, cboAcceleratorBoardItemSelector->getHeight());
@@ -1122,6 +1214,7 @@ void InitPanelExpansions(const config_category& category)
 	grpAcceleratorBoard->add(cboCpuBoardType, posX, posY);
 	grpAcceleratorBoard->add(cboCpuBoardSubType, posX, posY + cboCpuBoardType->getHeight() + DISTANCE_NEXT_Y);
 	grpAcceleratorBoard->add(cboCpuBoardRomFile, cboCpuBoardType->getX() + cboCpuBoardType->getWidth() + DISTANCE_NEXT_X * 3, cboCpuBoardType->getY());
+	grpAcceleratorBoard->add(btnCpuBoardRomChooser, cboCpuBoardRomFile->getX() + cboCpuBoardRomFile->getWidth() + DISTANCE_NEXT_X, cboCpuBoardRomFile->getY());
 	//TODO add items here
 	grpAcceleratorBoard->setMovable(false);
 	grpAcceleratorBoard->setSize(category.panel->getWidth() - DISTANCE_BORDER * 2, 200);
@@ -1170,6 +1263,7 @@ void ExitPanelExpansions()
 	delete cboCpuBoardType;
 	delete cboCpuBoardSubType;
 	delete cboCpuBoardRomFile;
+	delete btnCpuBoardRomChooser;
 
 	delete cboAcceleratorBoardItemSelector;
 	delete cboAcceleratorBoardSelector;
@@ -1192,11 +1286,12 @@ void RefreshPanelExpansions()
 	expansion2dlgproc();
 	
 	// values_to_expansion2dlg is covered here
-	chkBSDSocket->setEnabled(!emulating);
 	chkBSDSocket->setSelected(changed_prefs.socket_emu);
-	chkScsi->setSelected(changed_prefs.scsi);
+	chkScsi->setSelected(changed_prefs.scsi == 1);
 	chkCD32Fmv->setSelected(changed_prefs.cs_cd32fmv);
 	chkSana2->setSelected(changed_prefs.sana2);
+	// We don't really need Catweasel support in Amiberry, let's disable it
+	changed_prefs.catweasel = 0;
 
 	values_to_expansion2_expansion_roms();
 	values_to_expansion2_expansion_settings();
@@ -1207,9 +1302,8 @@ void RefreshPanelExpansions()
 		const cpuboardsubtype* cst = &cpuboards[changed_prefs.cpuboard_type].subtypes[changed_prefs.cpuboard_subtype];
 		brc = get_device_rom(&changed_prefs, ROMTYPE_CPUBOARD, 0, &index);
 		addromfiles(cboCpuBoardRomFile, brc ? brc->roms[index].romfile : nullptr,
-			int(cst->romtype), cst->romtype_extra);
-	}
-	else {
+			static_cast<int>(cst->romtype), cst->romtype_extra);
+	} else {
 		auto list_model = cboCpuBoardRomFile->getListModel();
 		list_model->clear_elements(); //SendDlgItemMessage(hDlg, IDC_CPUBOARDROMFILE, CB_RESETCONTENT, 0, 0);
 	}
@@ -1218,11 +1312,16 @@ void RefreshPanelExpansions()
 	values_to_expansion2dlg_sub();
 
 	// enable_for_expansion2dlg is covered here
+	chkBSDSocket->setEnabled(!emulating);
+	chkScsi->setEnabled(!emulating);
+	chkCD32Fmv->setEnabled(!emulating);
+	chkSana2->setEnabled(!emulating);
 	cboCpuBoardRomFile->setEnabled(changed_prefs.cpuboard_type != 0); //ew(hDlg, IDC_CPUBOARDROMFILE, workprefs.cpuboard_type != 0);
+	//TODO : Enable these
 	//ew(hDlg, IDC_CPUBOARDROMCHOOSER, workprefs.cpuboard_type != 0);
 	//ew(hDlg, IDC_CPUBOARDMEM, workprefs.cpuboard_type > 0);
 	//ew(hDlg, IDC_CPUBOARDRAM, workprefs.cpuboard_type > 0);
-	//ew(hDlg, IDC_CPUBOARD_SUBTYPE, workprefs.cpuboard_type);
+	cboCpuBoardSubType->setEnabled(changed_prefs.cpuboard_type); //ew(hDlg, IDC_CPUBOARD_SUBTYPE, workprefs.cpuboard_type);
 }
 
 bool HelpPanelExpansions(std::vector<std::string>& helptext)
@@ -1230,10 +1329,6 @@ bool HelpPanelExpansions(std::vector<std::string>& helptext)
     helptext.clear();
     helptext.emplace_back("Some of these expansions will be set automatically for you, depending on the model of");
     helptext.emplace_back("Amiga you chose to emulate (ie; the internal IDE for A1200 models).");
-    helptext.emplace_back(" ");
-    helptext.emplace_back("Please note that many of the options here are not yet fully functional, since they are");
-    helptext.emplace_back("currently stripped down in Amiberry. They may be added in future versions, but for now ");
-    helptext.emplace_back("only the most commonly used options are available.");
     helptext.emplace_back(" ");
     helptext.emplace_back("Here you can enable a few expansion options that are commonly used:");
     helptext.emplace_back(" ");

--- a/src/osdep/gui/PanelExpansions.cpp
+++ b/src/osdep/gui/PanelExpansions.cpp
@@ -35,6 +35,7 @@ static gcn::StringListModel scsirom_file_list;
 static gcn::StringListModel cpuboard_type_list;
 static gcn::StringListModel cpuboard_subtype_list;
 static gcn::StringListModel cpuboard_romfile_list;
+static gcn::StringListModel cpuboard_romsubselect_list;
 static gcn::StringListModel acceleratorboard_itemselector_list;
 static gcn::StringListModel acceleratorboard_selector_list;
 
@@ -58,6 +59,7 @@ static gcn::TextBox* txtExpansionBoardStringBox;
 static gcn::DropDown* cboCpuBoardType;
 static gcn::DropDown* cboCpuBoardSubType;
 static gcn::DropDown* cboCpuBoardRomFile;
+static gcn::DropDown* cboCpuRomSubSelect;
 static gcn::Button* btnCpuBoardRomChooser;
 
 static gcn::Label* lblCpuBoardMem;
@@ -555,8 +557,8 @@ static void init_expansion2(bool init)
 
 static void values_to_expansion2dlg_sub()
 {
-	cpuboard_subtype_list.clear(); //SendDlgItemMessage(hDlg, IDC_CPUBOARDROMSUBSELECT, CB_RESETCONTENT, 0, 0);
-	cboCpuBoardSubType->setEnabled(false); //ew(hDlg, IDC_CPUBOARDROMSUBSELECT, false);
+	cpuboard_romsubselect_list.clear(); //SendDlgItemMessage(hDlg, IDC_CPUBOARDROMSUBSELECT, CB_RESETCONTENT, 0, 0);
+	cboCpuRomSubSelect->setEnabled(false); //ew(hDlg, IDC_CPUBOARDROMSUBSELECT, false);
 
 	scsirom_subselect_list.clear(); //SendDlgItemMessage(hDlg, IDC_SCSIROMSUBSELECT, CB_RESETCONTENT, 0, 0);
 	const expansionromtype* er = &expansionroms[scsiromselected];
@@ -908,9 +910,13 @@ public:
 		}
 		else if (source == chkScsiRomSelected
 			|| source == cboScsiRomFile
-			|| source == cboScsiRomId
-			|| source == cboCpuBoardRomFile
-			|| source == cboCpuBoardSubType)
+			|| source == cboScsiRomId)
+		{
+			values_from_expansion2dlg();
+			values_to_expansion2_expansion_settings();
+		}
+		else if (source == cboCpuBoardRomFile
+			|| source == cboCpuRomSubSelect)
 		{
 			values_from_expansion2dlg();
 			values_to_expansion2_expansion_settings();
@@ -1151,6 +1157,15 @@ void InitPanelExpansions(const config_category& category)
 	cboCpuBoardRomFile->setId("cboCpuBoardRomFile");
 	cboCpuBoardRomFile->addActionListener(expansions_action_listener);
 
+	cboCpuRomSubSelect = new gcn::DropDown(&cpuboard_romsubselect_list);
+	cboCpuRomSubSelect->setSize(250, cboCpuRomSubSelect->getHeight());
+	cboCpuRomSubSelect->setBaseColor(gui_base_color);
+	cboCpuRomSubSelect->setBackgroundColor(gui_background_color);
+	cboCpuRomSubSelect->setForegroundColor(gui_foreground_color);
+	cboCpuRomSubSelect->setSelectionColor(gui_selection_color);
+	cboCpuRomSubSelect->setId("cboCpuRomSubSelect");
+	cboCpuRomSubSelect->addActionListener(expansions_action_listener);
+
 	btnCpuBoardRomChooser = new gcn::Button("...");
 	btnCpuBoardRomChooser->setBaseColor(gui_base_color);
 	btnCpuBoardRomChooser->setBackgroundColor(gui_background_color);
@@ -1312,6 +1327,7 @@ void ExitPanelExpansions()
 	delete cboCpuBoardType;
 	delete cboCpuBoardSubType;
 	delete cboCpuBoardRomFile;
+	delete cboCpuRomSubSelect;
 	delete btnCpuBoardRomChooser;
 
 	delete lblCpuBoardMem;

--- a/src/osdep/gui/PanelExpansions.cpp
+++ b/src/osdep/gui/PanelExpansions.cpp
@@ -24,6 +24,7 @@ static gcn::StringListModel scsirom_select_cat_list;
 static gcn::StringListModel scsirom_select_list;
 static gcn::StringListModel scsirom_subselect_list;
 static gcn::StringListModel expansionboard_itemselector_list;
+static gcn::StringListModel expansionboard_selector_list;
 static gcn::StringListModel scsi_romid_list;
 static gcn::StringListModel scsirom_selectnum_list;
 static gcn::StringListModel scsirom_file_list;
@@ -196,13 +197,13 @@ retry:
 		bitcnt += eb->bitshift;
 	}
 	if (reset) {
-		auto list_model = itemselector->getListModel();
+		auto list_model = itemselector->getListModel(); //xSendDlgItemMessage(hDlg, itemselector, CB_RESETCONTENT, 0, 0);
 		list_model->clear_elements();
 		for (int i = 0; ebs[i].name; i++) {
 			eb = &ebs[i];
-			list_model->add(eb->name);
+			list_model->add(eb->name); //xSendDlgItemMessage(hDlg, itemselector, CB_ADDSTRING, 0, (LPARAM)eb->name);
 		}
-		itemselector->setSelected(item);
+		itemselector->setSelected(item); //xSendDlgItemMessage(hDlg, itemselector, CB_SETCURSEL, item, 0);
 	}
 	eb = &ebs[item];
 	bitcnt += eb->bitshift;
@@ -982,8 +983,7 @@ void InitPanelExpansions(const config_category& category)
 	cboExpansionBoardItemSelector->setId("cboExpansionBoardItemSelector");
 	cboExpansionBoardItemSelector->addActionListener(expansions_action_listener);
 
-	//TODO this one is probably not correct
-	cboExpansionBoardSelector = new gcn::DropDown(&expansionboard_itemselector_list);
+	cboExpansionBoardSelector = new gcn::DropDown(&expansionboard_selector_list);
 	cboExpansionBoardSelector->setSize(250, cboExpansionBoardSelector->getHeight());
 	cboExpansionBoardSelector->setBaseColor(gui_base_color);
 	cboExpansionBoardSelector->setBackgroundColor(gui_background_color);
@@ -1109,7 +1109,7 @@ void InitPanelExpansions(const config_category& category)
 	grpExpansionBoard->add(txtExpansionBoardStringBox, chkScsiRomFileAutoboot->getX(), chkScsiRomFileAutoboot->getY());
 	grpExpansionBoard->add(chkExpansionBoardCheckbox, chkScsiRomFileAutoboot->getX(), chkScsiRomFileAutoboot->getY() + chkScsiRomFileAutoboot->getHeight() + DISTANCE_NEXT_Y);
 	grpExpansionBoard->add(cboExpansionBoardItemSelector, posX, cboScsiRomSubSelect->getY() + cboScsiRomSubSelect->getHeight() + DISTANCE_NEXT_Y);
-	//grpExpansionBoard->add(cboExpansionBoardSelector, chkScsiRomSelected->getX(), cboExpansionBoardItemSelector->getY());
+	grpExpansionBoard->add(cboExpansionBoardSelector, chkScsiRomSelected->getX(), cboExpansionBoardItemSelector->getY());
 	//TODO add items here
 	grpExpansionBoard->setMovable(false);
 	grpExpansionBoard->setSize(category.panel->getWidth() - DISTANCE_BORDER * 2, 250);

--- a/src/osdep/gui/PanelPaths.cpp
+++ b/src/osdep/gui/PanelPaths.cpp
@@ -259,7 +259,7 @@ class RescanROMsButtonActionListener : public gcn::ActionListener
 public:
 	void action(const gcn::ActionEvent& actionEvent) override
 	{
-		RescanROMs();
+		scan_roms();
 		SymlinkROMs();
 
 		import_joysticks();

--- a/src/osdep/gui/PanelPaths.cpp
+++ b/src/osdep/gui/PanelPaths.cpp
@@ -259,7 +259,7 @@ class RescanROMsButtonActionListener : public gcn::ActionListener
 public:
 	void action(const gcn::ActionEvent& actionEvent) override
 	{
-		scan_roms();
+		scan_roms(true);
 		SymlinkROMs();
 
 		import_joysticks();

--- a/src/osdep/gui/PanelROM.cpp
+++ b/src/osdep/gui/PanelROM.cpp
@@ -9,6 +9,8 @@
 #include "options.h"
 #include "rommgr.h"
 #include "gui_handling.h"
+#include "memory.h"
+#include "registry.h"
 #include "uae.h"
 
 static gcn::Label* lblMainROM;
@@ -23,164 +25,85 @@ static gcn::Button* cmdCartROM;
 static gcn::Label* lblUAEROM;
 static gcn::DropDown* cboUAEROM;
 static gcn::CheckBox* chkMapRom;
-static gcn::CheckBox* chkShapeShifter;
+static gcn::CheckBox* chkKickShifter;
 
-class ROMListModel : public gcn::ListModel
-{
-	std::vector<std::string> roms;
-	std::vector<int> idxToAvailableROMs;
-	int ROMType;
-
-public:
-	explicit ROMListModel(const int romtype)
-	{
-		ROMType = romtype;
-	}
-
-	int getNumberOfElements() override
-	{
-		return int(roms.size());
-	}
-
-	void add(const std::string& elem)
-	{
-		roms.emplace_back(elem);
-	}
-
-	void clear()
-	{
-		roms.clear();
-	}
-	
-	std::string getElementAt(const int i) override
-	{
-		if (i < 0 || i >= static_cast<int>(roms.size()))
-			return "---";
-		return roms[i];
-	}
-
-	AvailableROM* get_rom_at(const int i)
-	{
-		if (i >= 0 && i < static_cast<int>(idxToAvailableROMs.size()))
-			return idxToAvailableROMs[i] < 0 ? nullptr : lstAvailableROMs[idxToAvailableROMs[i]];
-		return nullptr;
-	}
-
-	int init_rom_list(char* current)
-	{
-		roms.clear();
-		idxToAvailableROMs.clear();
-
-		auto currIdx = -1;
-		if (ROMType & (ROMTYPE_ALL_EXT | ROMTYPE_ALL_CART))
-		{
-			roms.emplace_back(" ");
-			idxToAvailableROMs.push_back(-1);
-			currIdx = 0;
-		}
-
-		for (auto i = 0; i < static_cast<int>(lstAvailableROMs.size()); ++i)
-		{
-			if (lstAvailableROMs[i]->ROMType & ROMType)
-			{
-				if (!stricmp(lstAvailableROMs[i]->Path.c_str(), current))
-					currIdx = int(roms.size());
-				roms.emplace_back(lstAvailableROMs[i]->Name);
-				idxToAvailableROMs.push_back(i);
-			}
-		}
-		return currIdx;
-	}
-};
-
-static ROMListModel* mainROMList;
-static ROMListModel* extROMList;
-static ROMListModel* cartROMList;
-
-static const std::vector<std::string> uaeValues = { "ROM disabled", "Original UAE (FS + F0 ROM)", "New UAE (64k + F0 ROM)", "New UAE (128k, ROM, Direct)", "New UAE (128k, ROM, Indirect)" };
-static gcn::StringListModel uaeList(uaeValues);
-
-class MainROMActionListener : public gcn::ActionListener
-{
-public:
-	void action(const gcn::ActionEvent& actionEvent) override
-	{
-		auto* const rom = mainROMList->get_rom_at(cboMainROM->getSelected());
-		if (rom != nullptr)
-			strncpy(changed_prefs.romfile, rom->Path.c_str(), sizeof changed_prefs.romfile);
-	}
-};
-
-static MainROMActionListener* mainROMActionListener;
-
-class ExtROMActionListener : public gcn::ActionListener
-{
-public:
-	void action(const gcn::ActionEvent& actionEvent) override
-	{
-		auto* const rom = extROMList->get_rom_at(cboExtROM->getSelected());
-		if (rom != nullptr)
-			strncpy(changed_prefs.romextfile, rom->Path.c_str(), sizeof changed_prefs.romextfile);
-		else
-			strncpy(changed_prefs.romextfile, " ", sizeof changed_prefs.romextfile);
-	}
-};
-
-static ExtROMActionListener* extROMActionListener;
-
-class CartROMActionListener : public gcn::ActionListener
-{
-public:
-	void action(const gcn::ActionEvent& actionEvent) override
-	{
-		auto* const rom = cartROMList->get_rom_at(cboCartROM->getSelected());
-		if (rom != nullptr)
-			strncpy(changed_prefs.cartfile, rom->Path.c_str(), sizeof changed_prefs.cartfile);
-		else
-			strncpy(changed_prefs.cartfile, "", sizeof changed_prefs.cartfile);
-	}
-};
-
-static CartROMActionListener* cartROMActionListener;
+static gcn::StringListModel mainROMList;
+static gcn::StringListModel extROMList;
+static gcn::StringListModel cartROMList;
+static gcn::StringListModel uaeboard_type_list;
 
 // Helper function to reduce code duplication
-void handleROMSelection(const gcn::ActionEvent& actionEvent, char* prefsFile, const int romType)
+void handleROMSelection(const gcn::ActionEvent& actionEvent, char* prefs)
 {
 	std::string tmp;
 	const char* filter[] = { ".rom", ".bin", "\0" };
 	tmp = SelectFile("Select ROM", get_rom_path(), filter);
 	if (!tmp.empty())
 	{
-		auto* const newrom = new AvailableROM();
-		newrom->Name = extract_filename(tmp);
-		newrom->Name = remove_file_extension(newrom->Name);
-		newrom->Path = tmp;
-		newrom->ROMType = romType;
-		lstAvailableROMs.push_back(newrom);
-		strncpy(prefsFile, tmp.c_str(), MAX_DPATH - 1);
+		strncpy(prefs, tmp.c_str(), MAX_DPATH);
+		fullpath(prefs, MAX_DPATH);
 		RefreshPanelROM();
 	}
 	actionEvent.getSource()->requestFocus();
 }
 
-class ROMButtonActionListener : public gcn::ActionListener
+static void getromfile(gcn::DropDown* d, TCHAR* path, int size)
+{
+	auto val = d->getSelected(); //LRESULT val = xSendDlgItemMessage(hDlg, d, CB_GETCURSEL, 0, 0L);
+	if (val == -1) {
+		//xSendDlgItemMessage(hDlg, d, WM_GETTEXT, (WPARAM)size, (LPARAM)path);
+		auto listmodel = d->getListModel();
+		listmodel->add(path);
+		val = listmodel->getNumberOfElements() - 1;
+		d->setSelected(val);
+	}
+	else {
+		struct romdata* rd;
+		auto listmodel = d->getListModel();
+		std::string tmp1 = listmodel->getElementAt(val);
+		path[0] = 0;
+		rd = getromdatabyname(tmp1.c_str());
+		if (rd) {
+			struct romlist* rl = getromlistbyromdata(rd);
+			if (rd->configname)
+				_stprintf(path, _T(":%s"), rd->configname);
+			else if (rl)
+				_tcsncpy(path, rl->path, size);
+		}
+	}
+}
+
+class ROMActionListener : public gcn::ActionListener
 {
 public:
 	void action(const gcn::ActionEvent& actionEvent) override
 	{
-		if (actionEvent.getSource() == cmdMainROM)
+		auto source = actionEvent.getSource();
+		if (source == cboMainROM)
 		{
-			handleROMSelection(actionEvent, changed_prefs.romfile, ROMTYPE_KICK);
+			getromfile(cboMainROM, changed_prefs.romfile, sizeof(changed_prefs.romfile) / sizeof(TCHAR));
 		}
-		else if (actionEvent.getSource() == cmdExtROM)
+		else if (source == cboExtROM)
 		{
-			handleROMSelection(actionEvent, changed_prefs.romextfile, ROMTYPE_EXTCDTV);
+			getromfile(cboExtROM, changed_prefs.romextfile, sizeof(changed_prefs.romextfile) / sizeof(TCHAR));
 		}
-		else if (actionEvent.getSource() == cmdCartROM)
+		else if (source == cboCartROM)
 		{
-			handleROMSelection(actionEvent, changed_prefs.cartfile, ROMTYPE_CD32CART);
+			getromfile(cboCartROM, changed_prefs.cartfile, sizeof(changed_prefs.cartfile) / sizeof(TCHAR));
 		}
-		else if (actionEvent.getSource() == cboUAEROM) 
+		else if (source == cmdMainROM)
+		{
+			handleROMSelection(actionEvent, changed_prefs.romfile);
+		}
+		else if (source == cmdExtROM)
+		{
+			handleROMSelection(actionEvent, changed_prefs.romextfile);
+		}
+		else if (source == cmdCartROM)
+		{
+			handleROMSelection(actionEvent, changed_prefs.cartfile);
+		}
+		else if (source == cboUAEROM)
 		{
 			const auto v = cboUAEROM->getSelected();
 			if (v > 0) {
@@ -192,102 +115,104 @@ public:
 				changed_prefs.boot_rom = 1; // disabled
 			}
 		}
-		else if (actionEvent.getSource() == chkMapRom)
+		else if (source == chkMapRom)
 		{
 			changed_prefs.maprom = chkMapRom->isSelected() ? 0x0f000000 : 0;
 		}
-		else if (actionEvent.getSource() == chkShapeShifter)
+		else if (source == chkKickShifter)
 		{
-			changed_prefs.kickshifter = chkShapeShifter->isSelected();
+			changed_prefs.kickshifter = chkKickShifter->isSelected();
 		}
+		read_kickstart_version(&changed_prefs);
 	}
 };
 
-static ROMButtonActionListener* romButtonActionListener;
+static ROMActionListener* romActionListener;
 
 void InitPanelROM(const config_category& category)
 {
+	uaeboard_type_list.clear();
+	uaeboard_type_list.add("ROM disabled");
+	uaeboard_type_list.add("Original UAE (FS + F0 ROM)");
+	uaeboard_type_list.add("New UAE (64k + F0 ROM)");
+	uaeboard_type_list.add("New UAE (128k, ROM, Direct)");
+	uaeboard_type_list.add("New UAE (128k, ROM, Indirect)");
+
 	const auto textFieldWidth = category.panel->getWidth() - 2 * DISTANCE_BORDER - SMALL_BUTTON_WIDTH - DISTANCE_NEXT_X;
 
-	mainROMActionListener = new MainROMActionListener();
-	extROMActionListener = new ExtROMActionListener();
-	cartROMActionListener = new CartROMActionListener();
-	romButtonActionListener = new ROMButtonActionListener();
-	mainROMList = new ROMListModel(ROMTYPE_ALL_KICK);
-	extROMList = new ROMListModel(ROMTYPE_ALL_EXT);
-	cartROMList = new ROMListModel(ROMTYPE_ALL_CART);
+	romActionListener = new ROMActionListener();
 
 	lblMainROM = new gcn::Label("Main ROM File:");
-	cboMainROM = new gcn::DropDown(mainROMList);
+	cboMainROM = new gcn::DropDown(&mainROMList);
 	cboMainROM->setSize(textFieldWidth, cboMainROM->getHeight());
 	cboMainROM->setBaseColor(gui_base_color);
 	cboMainROM->setBackgroundColor(gui_background_color);
 	cboMainROM->setForegroundColor(gui_foreground_color);
 	cboMainROM->setSelectionColor(gui_selection_color);
 	cboMainROM->setId("cboMainROM");
-	cboMainROM->addActionListener(mainROMActionListener);
+	cboMainROM->addActionListener(romActionListener);
 	cmdMainROM = new gcn::Button("...");
 	cmdMainROM->setId("MainROM");
 	cmdMainROM->setSize(SMALL_BUTTON_WIDTH, SMALL_BUTTON_HEIGHT);
 	cmdMainROM->setBaseColor(gui_base_color);
 	cmdMainROM->setForegroundColor(gui_foreground_color);
-	cmdMainROM->addActionListener(romButtonActionListener);
+	cmdMainROM->addActionListener(romActionListener);
 
 	lblExtROM = new gcn::Label("Extended ROM File:");
-	cboExtROM = new gcn::DropDown(extROMList);
+	cboExtROM = new gcn::DropDown(&extROMList);
 	cboExtROM->setSize(textFieldWidth, cboExtROM->getHeight());
 	cboExtROM->setBaseColor(gui_base_color);
 	cboExtROM->setBackgroundColor(gui_background_color);
 	cboExtROM->setForegroundColor(gui_foreground_color);
 	cboExtROM->setSelectionColor(gui_selection_color);
 	cboExtROM->setId("cboExtROM");
-	cboExtROM->addActionListener(extROMActionListener);
+	cboExtROM->addActionListener(romActionListener);
 	cmdExtROM = new gcn::Button("...");
 	cmdExtROM->setId("ExtROM");
 	cmdExtROM->setSize(SMALL_BUTTON_WIDTH, SMALL_BUTTON_HEIGHT);
 	cmdExtROM->setBaseColor(gui_base_color);
 	cmdExtROM->setForegroundColor(gui_foreground_color);
-	cmdExtROM->addActionListener(romButtonActionListener);
+	cmdExtROM->addActionListener(romActionListener);
 
 	chkMapRom = new gcn::CheckBox("MapROM emulation");
 	chkMapRom->setId("chkMapRom");
 	chkMapRom->setBaseColor(gui_base_color);
 	chkMapRom->setBackgroundColor(gui_background_color);
 	chkMapRom->setForegroundColor(gui_foreground_color);
-	chkMapRom->addActionListener(romButtonActionListener);
+	chkMapRom->addActionListener(romActionListener);
 
-	chkShapeShifter = new gcn::CheckBox("ShapeShifter support");
-	chkShapeShifter->setId("chkShapeShifter");
-	chkShapeShifter->setBaseColor(gui_base_color);
-	chkShapeShifter->setBackgroundColor(gui_background_color);
-	chkShapeShifter->setForegroundColor(gui_foreground_color);
-	chkShapeShifter->addActionListener(romButtonActionListener);
+	chkKickShifter = new gcn::CheckBox("ShapeShifter support");
+	chkKickShifter->setId("chkKickShifter");
+	chkKickShifter->setBaseColor(gui_base_color);
+	chkKickShifter->setBackgroundColor(gui_background_color);
+	chkKickShifter->setForegroundColor(gui_foreground_color);
+	chkKickShifter->addActionListener(romActionListener);
 
 	lblCartROM = new gcn::Label("Cartridge ROM File:");
-	cboCartROM = new gcn::DropDown(cartROMList);
+	cboCartROM = new gcn::DropDown(&cartROMList);
 	cboCartROM->setSize(textFieldWidth, cboCartROM->getHeight());
 	cboCartROM->setBaseColor(gui_base_color);
 	cboCartROM->setBackgroundColor(gui_background_color);
 	cboCartROM->setForegroundColor(gui_foreground_color);
 	cboCartROM->setSelectionColor(gui_selection_color);
 	cboCartROM->setId("cboCartROM");
-	cboCartROM->addActionListener(cartROMActionListener);
+	cboCartROM->addActionListener(romActionListener);
 	cmdCartROM = new gcn::Button("...");
 	cmdCartROM->setId("CartROM");
 	cmdCartROM->setSize(SMALL_BUTTON_WIDTH, SMALL_BUTTON_HEIGHT);
 	cmdCartROM->setBaseColor(gui_base_color);
 	cmdCartROM->setForegroundColor(gui_foreground_color);
-	cmdCartROM->addActionListener(romButtonActionListener);
+	cmdCartROM->addActionListener(romActionListener);
 
 	lblUAEROM = new gcn::Label("Advanced UAE expansion board/Boot ROM:");
-	cboUAEROM = new gcn::DropDown(&uaeList);
+	cboUAEROM = new gcn::DropDown(&uaeboard_type_list);
 	cboUAEROM->setSize(textFieldWidth, cboUAEROM->getHeight());
 	cboUAEROM->setBaseColor(gui_base_color);
 	cboUAEROM->setBackgroundColor(gui_background_color);\
 	cboUAEROM->setForegroundColor(gui_foreground_color);
 	cboUAEROM->setSelectionColor(gui_selection_color);
 	cboUAEROM->setId("cboUAEROM");
-	cboUAEROM->addActionListener(romButtonActionListener);
+	cboUAEROM->addActionListener(romActionListener);
 
 	int posY = DISTANCE_BORDER;
 	category.panel->add(lblMainROM, DISTANCE_BORDER, posY);
@@ -303,7 +228,7 @@ void InitPanelROM(const config_category& category)
 	posY += cboExtROM->getHeight() + DISTANCE_NEXT_Y;
 
 	category.panel->add(chkMapRom, DISTANCE_BORDER, posY);
-	category.panel->add(chkShapeShifter, chkMapRom->getX() + chkMapRom->getWidth() + DISTANCE_NEXT_X * 2, posY);
+	category.panel->add(chkKickShifter, chkMapRom->getX() + chkMapRom->getWidth() + DISTANCE_NEXT_X * 2, posY);
 	posY += chkMapRom->getHeight() + DISTANCE_NEXT_Y * 2;
 
 	category.panel->add(lblCartROM, DISTANCE_BORDER, posY);
@@ -324,53 +249,41 @@ void ExitPanelROM()
 	delete lblMainROM;
 	delete cboMainROM;
 	delete cmdMainROM;
-	delete mainROMList;
-	delete mainROMActionListener;
+	delete romActionListener;
 
 	delete lblExtROM;
 	delete cboExtROM;
 	delete cmdExtROM;
-	delete extROMList;
-	delete extROMActionListener;
 
 	delete lblCartROM;
 	delete cboCartROM;
 	delete cmdCartROM;
-	delete cartROMList;
-	delete cartROMActionListener;
 
 	delete lblUAEROM;
 	delete cboUAEROM;
 	delete chkMapRom;
-	delete chkShapeShifter;
-	delete romButtonActionListener;
-}
-
-void refresh_rom_list(ROMListModel* rom_list, const gcn::DropDown* cboROM, char* prefsFile, const int romType)
-{
-	const auto idx = rom_list->init_rom_list(prefsFile);
-	if (idx != -1)
-	{
-		cboROM->setSelected(idx);
-	}
-	else if (strlen(prefsFile) > 0)
-	{
-		// ROM file not in the list of known ROMs
-		auto* newrom = new AvailableROM();
-		newrom->Path = prefsFile;
-		newrom->Name = extract_filename(prefsFile);
-		newrom->Name = remove_file_extension(newrom->Name);
-		newrom->ROMType = romType;
-		lstAvailableROMs.push_back(newrom);
-		RefreshPanelROM();
-	}
+	delete chkKickShifter;
 }
 
 void RefreshPanelROM()
 {
-	refresh_rom_list(mainROMList, cboMainROM, changed_prefs.romfile, ROMTYPE_KICK);
-	refresh_rom_list(extROMList, cboExtROM, changed_prefs.romextfile, ROMTYPE_EXTCDTV);
-	refresh_rom_list(cartROMList, cboCartROM, changed_prefs.cartfile, ROMTYPE_CD32CART);
+	UAEREG* fkey = regcreatetree(NULL, _T("DetectedROMs"));
+
+	load_keyring(&changed_prefs, NULL);
+
+	addromfiles(fkey, cboMainROM, changed_prefs.romfile,
+		ROMTYPE_KICK | ROMTYPE_KICKCD32, 0);
+	addromfiles(fkey, cboExtROM, changed_prefs.romextfile,
+		ROMTYPE_EXTCD32 | ROMTYPE_EXTCDTV | ROMTYPE_ARCADIABIOS | ROMTYPE_ALG, 0);
+	addromfiles(fkey, cboCartROM, changed_prefs.cartfile,
+		ROMTYPE_FREEZER | ROMTYPE_ARCADIAGAME | ROMTYPE_CD32CART, 0);
+
+	regclosetree(fkey);
+
+	//TODO add flashfile and rtcfile options
+
+	chkKickShifter->setSelected(changed_prefs.kickshifter);
+	chkMapRom->setSelected(changed_prefs.maprom);
 
 	if (changed_prefs.boot_rom == 1) {
 		cboUAEROM->setSelected(0);
@@ -379,8 +292,6 @@ void RefreshPanelROM()
 		cboUAEROM->setSelected(changed_prefs.uaeboard + 1);
 	}
 	cboUAEROM->setEnabled(!emulating);
-	chkMapRom->setSelected(changed_prefs.maprom);
-	chkShapeShifter->setSelected(changed_prefs.kickshifter);
 }
 
 bool HelpPanelROM(std::vector<std::string>& helptext)

--- a/src/osdep/gui/StringListModel.h
+++ b/src/osdep/gui/StringListModel.h
@@ -27,7 +27,8 @@ namespace gcn {
 			return mStrings.at(i);
 		}
 
-		void add(const std::string &str) {
+		void add(const std::string &str) override
+		{
 			mStrings.push_back(str);
 		}
 

--- a/src/osdep/gui/StringListModel.h
+++ b/src/osdep/gui/StringListModel.h
@@ -35,6 +35,9 @@ namespace gcn {
 		void clear() {
 			mStrings.clear();
 		}
+		void clear_elements() override {
+			mStrings.clear();
+		}
 
 		void swap_first(const std::string &str) {
 			mStrings.erase(mStrings.begin());

--- a/src/osdep/gui/gui_handling.h
+++ b/src/osdep/gui/gui_handling.h
@@ -6,6 +6,7 @@
 #include "amiberry_input.h"
 #include "filesys.h"
 #include "options.h"
+#include "registry.h"
 
 enum
 {
@@ -437,5 +438,7 @@ extern void apply_theme();
 extern void apply_theme_extras();
 
 extern void SetLastActiveConfig(const char* filename);
+
+extern void addromfiles(UAEREG* fkey, gcn::DropDown* d, const TCHAR* path, int type1, int type2);
 
 #endif // GUI_HANDLING_H

--- a/src/osdep/registry.cpp
+++ b/src/osdep/registry.cpp
@@ -1,0 +1,555 @@
+
+#include "sysconfig.h"
+#include "sysdeps.h"
+#ifdef _WIN32
+#include <windows.h>
+#include <shlwapi.h>
+#include "win32.h"
+#endif
+#include "registry.h"
+#include "ini.h"
+#include "uae.h"
+
+#include <filesystem>
+
+#ifdef _WIN32
+static int inimode = 0;
+#else
+static int inimode = 1;
+#endif
+static TCHAR* inipath;
+
+#define ROOT_TREE _T("Amiberry")
+
+static struct ini_data* inidata;
+
+static HKEY gr(UAEREG* root)
+{
+#ifdef _WIN32
+	if (!root)
+		return hWinUAEKey;
+#else
+	if (!root)
+		return NULL;
+#endif
+	return root->fkey;
+}
+static const TCHAR* gs(UAEREG* root)
+{
+	if (!root)
+		return ROOT_TREE;
+	return root->inipath;
+}
+static TCHAR* gsn(UAEREG* root, const TCHAR* name)
+{
+	const TCHAR* r;
+	TCHAR* s;
+	if (!root)
+		return my_strdup(name);
+	r = gs(root);
+	s = xmalloc(TCHAR, _tcslen(r) + 1 + _tcslen(name) + 1);
+	_stprintf(s, _T("%s/%s"), r, name);
+	return s;
+}
+
+int regsetstr(UAEREG* root, const TCHAR* name, const TCHAR* str)
+{
+	if (inimode) {
+		int ret = ini_addstring(inidata, gs(root), name, str);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		return RegSetValueEx(rk, name, 0, REG_SZ, (CONST BYTE*)str, (uaetcslen(str) + 1) * sizeof(TCHAR)) == ERROR_SUCCESS;
+	}
+#endif
+}
+
+int regsetint(UAEREG* root, const TCHAR* name, int val)
+{
+	if (inimode) {
+		int ret;
+		TCHAR tmp[100];
+		_stprintf(tmp, _T("%d"), val);
+		ret = ini_addstring(inidata, gs(root), name, tmp);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		DWORD v = val;
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		return RegSetValueEx(rk, name, 0, REG_DWORD, (CONST BYTE*) & v, sizeof(DWORD)) == ERROR_SUCCESS;
+	}
+#endif
+}
+
+int regqueryint(UAEREG* root, const TCHAR* name, int* val)
+{
+	if (inimode) {
+		int ret = 0;
+		TCHAR* tmp = NULL;
+		if (ini_getstring(inidata, gs(root), name, &tmp)) {
+			*val = _tstol(tmp);
+			ret = 1;
+		}
+		xfree(tmp);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		DWORD dwType = REG_DWORD;
+		DWORD size = sizeof(int);
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		return RegQueryValueEx(rk, name, 0, &dwType, (LPBYTE)val, &size) == ERROR_SUCCESS;
+	}
+#endif
+}
+
+int regsetlonglong(UAEREG* root, const TCHAR* name, unsigned long long val)
+{
+	if (inimode) {
+		int ret;
+		TCHAR tmp[100];
+		_stprintf(tmp, _T("%I64d"), val);
+		ret = ini_addstring(inidata, gs(root), name, tmp);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		ULONGLONG v = val;
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		return RegSetValueEx(rk, name, 0, REG_QWORD, (CONST BYTE*) & v, sizeof(ULONGLONG)) == ERROR_SUCCESS;
+	}
+#endif
+}
+
+int regquerylonglong(UAEREG* root, const TCHAR* name, unsigned long long* val)
+{
+	*val = 0;
+	if (inimode) {
+		int ret = 0;
+		TCHAR* tmp = NULL;
+		if (ini_getstring(inidata, gs(root), name, &tmp)) {
+			*val = _tstoi64(tmp);
+			ret = 1;
+		}
+		xfree(tmp);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		DWORD dwType = REG_QWORD;
+		DWORD size = sizeof(ULONGLONG);
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		return RegQueryValueEx(rk, name, 0, &dwType, (LPBYTE)val, &size) == ERROR_SUCCESS;
+	}
+#endif
+}
+
+int regquerystr(UAEREG* root, const TCHAR* name, TCHAR* str, int* size)
+{
+	if (inimode) {
+		int ret = 0;
+		TCHAR* tmp = NULL;
+		if (ini_getstring(inidata, gs(root), name, &tmp)) {
+			if (_tcslen(tmp) >= *size)
+				tmp[(*size) - 1] = 0;
+			_tcscpy(str, tmp);
+			*size = uaetcslen(str);
+			ret = 1;
+		}
+		xfree(tmp);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		DWORD size2 = *size * sizeof(TCHAR);
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		int v = RegQueryValueEx(rk, name, 0, NULL, (LPBYTE)str, &size2) == ERROR_SUCCESS;
+		*size = size2 / sizeof(TCHAR);
+		return v;
+	}
+#endif
+}
+
+int regenumstr(UAEREG* root, int idx, TCHAR* name, int* nsize, TCHAR* str, int* size)
+{
+	name[0] = 0;
+	str[0] = 0;
+	if (inimode) {
+		TCHAR* name2 = NULL;
+		TCHAR* str2 = NULL;
+		int ret = ini_getsectionstring(inidata, gs(root), idx, &name2, &str2);
+		if (ret) {
+			if (_tcslen(name2) >= *nsize) {
+				name2[(*nsize) - 1] = 0;
+			}
+			if (_tcslen(str2) >= *size) {
+				str2[(*size) - 1] = 0;
+			}
+			_tcscpy(name, name2);
+			_tcscpy(str, str2);
+		}
+		xfree(str2);
+		xfree(name2);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		DWORD nsize2 = *nsize;
+		DWORD size2 = *size;
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		int v = RegEnumValue(rk, idx, name, &nsize2, NULL, NULL, (LPBYTE)str, &size2) == ERROR_SUCCESS;
+		*nsize = nsize2;
+		*size = size2;
+		return v;
+	}
+#endif
+}
+
+int regquerydatasize(UAEREG* root, const TCHAR* name, int* size)
+{
+	if (inimode) {
+		int ret = 0;
+		int csize = 65536;
+		TCHAR* tmp = xmalloc(TCHAR, csize);
+		if (regquerystr(root, name, tmp, &csize)) {
+			*size = uaetcslen(tmp) / 2;
+			ret = 1;
+		}
+		xfree(tmp);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		DWORD size2 = *size;
+		int v = RegQueryValueEx(rk, name, 0, NULL, NULL, &size2) == ERROR_SUCCESS;
+		*size = size2;
+		return v;
+	}
+#endif
+}
+
+int regsetdata(UAEREG* root, const TCHAR* name, const void* str, int size)
+{
+	if (inimode) {
+		uae_u8* in = (uae_u8*)str;
+		int ret;
+		TCHAR* tmp = xmalloc(TCHAR, size * 2 + 1);
+		for (int i = 0; i < size; i++)
+			_stprintf(tmp + i * 2, _T("%02X"), in[i]);
+		ret = ini_addstring(inidata, gs(root), name, tmp);
+		xfree(tmp);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		return RegSetValueEx(rk, name, 0, REG_BINARY, (BYTE*)str, size) == ERROR_SUCCESS;
+	}
+#endif
+}
+int regquerydata(UAEREG* root, const TCHAR* name, void* str, int* size)
+{
+	if (inimode) {
+		int csize = (*size) * 2 + 1;
+		int i, j;
+		int ret = 0;
+		TCHAR* tmp = xmalloc(TCHAR, csize);
+		uae_u8* out = (uae_u8*)str;
+
+		if (!regquerystr(root, name, tmp, &csize))
+			goto err;
+		j = 0;
+		for (i = 0; i < _tcslen(tmp); i += 2) {
+			TCHAR c1 = _totupper(tmp[i + 0]);
+			TCHAR c2 = _totupper(tmp[i + 1]);
+			if (c1 >= 'A')
+				c1 -= 'A' - 10;
+			else if (c1 >= '0')
+				c1 -= '0';
+			if (c1 > 15)
+				goto err;
+			if (c2 >= 'A')
+				c2 -= 'A' - 10;
+			else if (c2 >= '0')
+				c2 -= '0';
+			if (c2 > 15)
+				goto err;
+			out[j++] = c1 * 16 + c2;
+		}
+		ret = 1;
+	err:
+		xfree(tmp);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		DWORD size2 = *size;
+		int v = RegQueryValueEx(rk, name, 0, NULL, (LPBYTE)str, &size2) == ERROR_SUCCESS;
+		*size = size2;
+		return v;
+	}
+#endif
+}
+
+int regdelete(UAEREG* root, const TCHAR* name)
+{
+	if (inimode) {
+		ini_delete(inidata, gs(root), name);
+		return 1;
+	}
+#ifdef _WIN32
+	else {
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		return RegDeleteValue(rk, name) == ERROR_SUCCESS;
+	}
+#endif
+}
+
+int regexists(UAEREG* root, const TCHAR* name)
+{
+	if (inimode) {
+		if (!inidata)
+			return 0;
+		int ret = ini_getstring(inidata, gs(root), name, NULL);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		return RegQueryValueEx(rk, name, 0, NULL, NULL, NULL) == ERROR_SUCCESS;
+	}
+#endif
+}
+
+void regdeletetree(UAEREG* root, const TCHAR* name)
+{
+	if (inimode) {
+		TCHAR* s = gsn(root, name);
+		if (!s)
+			return;
+		ini_delete(inidata, s, NULL);
+		xfree(s);
+	}
+#ifdef _WIN32
+	else {
+		HKEY rk = gr(root);
+		if (!rk)
+			return;
+		SHDeleteKey(rk, name);
+	}
+#endif
+}
+
+int regexiststree(UAEREG* root, const TCHAR* name)
+{
+	if (inimode) {
+		int ret = 0;
+		TCHAR* s = gsn(root, name);
+		if (!s)
+			return 0;
+		ret = ini_getstring(inidata, s, NULL, NULL);
+		xfree(s);
+		return ret;
+	}
+#ifdef _WIN32
+	else {
+		int ret = 0;
+		HKEY k = NULL;
+		HKEY rk = gr(root);
+		if (!rk)
+			return 0;
+		if (RegOpenKeyEx(rk, name, 0, KEY_READ, &k) == ERROR_SUCCESS)
+			ret = 1;
+		if (k)
+			RegCloseKey(k);
+		return ret;
+	}
+#endif
+}
+
+UAEREG* regcreatetree(UAEREG* root, const TCHAR* name)
+{
+	UAEREG* fkey;
+	HKEY rkey;
+
+	if (inimode) {
+		TCHAR* ininame;
+		if (!root) {
+			if (!name)
+				ininame = my_strdup(gs(NULL));
+			else
+				ininame = my_strdup(name);
+		}
+		else {
+			ininame = xmalloc(TCHAR, _tcslen(root->inipath) + 1 + _tcslen(name) + 1);
+			_stprintf(ininame, _T("%s/%s"), root->inipath, name);
+		}
+		fkey = xcalloc(UAEREG, 1);
+		fkey->inipath = ininame;
+	}
+#ifdef _WIN32
+	else {
+		DWORD err;
+		HKEY rk = gr(root);
+		if (!rk) {
+			rk = HKEY_CURRENT_USER;
+			name = _T("Software\\Arabuusimiehet\\WinUAE");
+		}
+		else if (!name) {
+			name = _T("");
+		}
+		err = RegCreateKeyEx(rk, name, 0, NULL, REG_OPTION_NON_VOLATILE,
+			KEY_READ | KEY_WRITE, NULL, &rkey, NULL);
+		if (err != ERROR_SUCCESS)
+			return 0;
+		fkey = xcalloc(UAEREG, 1);
+		fkey->fkey = rkey;
+	}
+#endif
+	return fkey;
+}
+
+void regclosetree(UAEREG* key)
+{
+	if (inimode) {
+		if (inidata->modified) {
+			ini_save(inidata, inipath);
+		}
+	}
+	if (!key)
+		return;
+#ifdef _WIN32
+	if (key->fkey)
+		RegCloseKey(key->fkey);
+#endif
+	xfree(key->inipath);
+	xfree(key);
+}
+
+int reginitializeinit(TCHAR** pppath)
+{
+	UAEREG* r = NULL;
+	TCHAR path[MAX_DPATH], fpath[MAX_DPATH];
+	FILE* f;
+	TCHAR* ppath = *pppath;
+
+	inimode = 0;
+	if (!ppath) {
+		int ok = 0;
+		TCHAR* posn;
+		path[0] = 0;
+#ifdef _WIN32
+		GetFullPathName(executable_path, sizeof path / sizeof(TCHAR), path, NULL);
+		if (_tcslen(path) > 4 && !_tcsicmp(path + _tcslen(path) - 4, _T(".exe"))) {
+			_tcscpy(path + _tcslen(path) - 3, _T("ini"));
+			if (GetFileAttributes(path) != INVALID_FILE_ATTRIBUTES)
+				ok = 1;
+		}
+		if (!ok) {
+			path[0] = 0;
+			GetFullPathName(executable_path, sizeof path / sizeof(TCHAR), path, NULL);
+			if ((posn = _tcsrchr(path, '\\')))
+				posn[1] = 0;
+			_tcscat(path, _T("amiberry.ini"));
+		}
+		if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES)
+			return 0;
+#else
+		std::string ini_file_path = get_ini_file_path();
+		if (std::filesystem::exists(ini_file_path)) {
+			_tcscpy(path, ini_file_path.c_str());
+			ok = 1;
+		}
+		else
+			return 0;
+#endif
+	}
+	else {
+		_tcscpy(path, ppath);
+	}
+
+	fpath[0] = 0;
+#ifdef _WIN32
+	GetFullPathName(path, sizeof fpath / sizeof(TCHAR), fpath, NULL);
+	if (_tcslen(fpath) < 5 || _tcsicmp(fpath + _tcslen(fpath) - 4, _T(".ini")))
+		return 0;
+#else
+	std::string ini_file_path = get_ini_file_path();
+	_tcscpy(fpath, ini_file_path.c_str());
+#endif
+
+	inimode = 1;
+	inipath = my_strdup(fpath);
+	inidata = ini_load(inipath, true);
+	if (!regexists(NULL, _T("Version")))
+		goto fail;
+	return 1;
+fail:
+	regclosetree(r);
+#ifdef _WIN32
+	if (GetFileAttributes(path) != INVALID_FILE_ATTRIBUTES)
+		DeleteFile(path);
+	if (GetFileAttributes(path) != INVALID_FILE_ATTRIBUTES)
+		goto end;
+#else
+	if (std::filesystem::exists(path))
+		std::filesystem::remove(path);
+	if (std::filesystem::exists(path))
+		goto end;
+#endif
+	f = fopen(path, _T("wb"));
+	if (f) {
+		uae_u8 bom[3] = { 0xef, 0xbb, 0xbf };
+		fwrite(bom, sizeof(bom), 1, f);
+		fclose(f);
+	}
+	if (*pppath == NULL)
+		*pppath = my_strdup(path);
+	return 1;
+end:
+	inimode = 0;
+	xfree(inipath);
+	return 0;
+}
+
+void regstatus(void)
+{
+	if (inimode)
+		write_log(_T("'%s' enabled\n"), inipath);
+}
+
+const TCHAR* getregmode(void)
+{
+	if (!inimode)
+		return NULL;
+	return inipath;
+}

--- a/src/osdep/registry.h
+++ b/src/osdep/registry.h
@@ -1,0 +1,31 @@
+#pragma once
+typedef struct UAEREG {
+    HKEY fkey;
+    TCHAR* inipath;
+} UAEREG;
+
+extern const TCHAR* getregmode(void);
+extern int reginitializeinit(TCHAR** path);
+extern void regstatus(void);
+
+extern int regsetstr(UAEREG*, const TCHAR* name, const TCHAR* str);
+extern int regsetint(UAEREG*, const TCHAR* name, int val);
+extern int regqueryint(UAEREG*, const TCHAR* name, int* val);
+extern int regquerystr(UAEREG*, const TCHAR* name, TCHAR* str, int* size);
+extern int regsetlonglong(UAEREG* root, const TCHAR* name, unsigned long long val);
+extern int regquerylonglong(UAEREG* root, const TCHAR* name, unsigned long long* val);
+
+extern int regdelete(UAEREG*, const TCHAR* name);
+extern void regdeletetree(UAEREG*, const TCHAR* name);
+
+extern int regexists(UAEREG*, const TCHAR* name);
+extern int regexiststree(UAEREG*, const TCHAR* name);
+
+extern int regquerydatasize(UAEREG* root, const TCHAR* name, int* size);
+extern int regsetdata(UAEREG*, const TCHAR* name, const void* str, int size);
+extern int regquerydata(UAEREG* root, const TCHAR* name, void* str, int* size);
+
+extern int regenumstr(UAEREG*, int idx, TCHAR* name, int* nsize, TCHAR* str, int* size);
+
+extern UAEREG* regcreatetree(UAEREG*, const TCHAR* name);
+extern void regclosetree(UAEREG* key);

--- a/src/osdep/target.h
+++ b/src/osdep/target.h
@@ -140,9 +140,8 @@ extern std::string extract_path(const std::string& filename);
 extern void remove_file_extension(char* filename);
 extern std::string remove_file_extension(const std::string& filename);
 extern void ReadConfigFileList(void);
-extern void RescanROMs(void);
+extern void scan_roms(void);
 extern void SymlinkROMs(void);
-extern void ClearAvailableROMList(void);
 
 extern bool resumepaused(int priority);
 extern bool setpaused(int priority);
@@ -154,15 +153,6 @@ void init_colors(int monid);
 
 #include <vector>
 #include <string>
-
-typedef struct
-{
-	std::string Name;
-	std::string Path;
-	int ROMType;
-} AvailableROM;
-
-extern std::vector<AvailableROM*> lstAvailableROMs;
 
 #define MAX_MRU_LIST 40
 

--- a/src/osdep/target.h
+++ b/src/osdep/target.h
@@ -140,7 +140,8 @@ extern std::string extract_path(const std::string& filename);
 extern void remove_file_extension(char* filename);
 extern std::string remove_file_extension(const std::string& filename);
 extern void ReadConfigFileList(void);
-extern void scan_roms(void);
+extern void read_rom_list(bool);
+extern int scan_roms(int show);
 extern void SymlinkROMs(void);
 
 extern bool resumepaused(int priority);


### PR DESCRIPTION
Fixes #1480 

- Refactored the way ROMs are scanned, to match WinUAE
- The `DetectedROMs` section is now saved to a separate file: `$XDG_CONFIG_HOME/amiberry.ini`. The format of the entries matches that of WinUAE (including the ROM ids), in order to make things work without having to change everything around
- Fixed a few bugs in the StringListModel, which became apparent while working on this solution
- Create the XDG_* directories on startup, if they don't exist. This happened at least once in WSL2 + Debian12
- Enabled support for multiple RTG boards in the cfgfile
- Implemented (hopefully) all of the functionality of the Expansion panel, matching the equivalent on WinUAE.

@midwan
