### PR TITLE
enhancement: added portable mode detection (fixes #1527)

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4019,7 +4019,8 @@ void create_missing_amiberry_folders()
 		}
     }
 #endif
-
+	if (!my_existsdir(config_path.c_str()))
+		my_mkdir(config_path.c_str());
 	if (!my_existsdir(controllers_path.c_str()))
 	{
 		my_mkdir(controllers_path.c_str());


### PR DESCRIPTION


Fixes #1527 

Changes proposed in this pull request:
- Check for the existence of a file named "amiberry.portable" in the current directory, when starting up. If found, switch to portable mode, expecting all related directories under the current dir.

@midwan
