### PR TITLE
bugfix: fix bundled plugins on MacOS (#1540)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -58,6 +58,11 @@ jobs:
               codesign -s "Developer ID Application: Dimitris Panokostas (5GQP72592A)" -f -o runtime,hard $file
             fi
           done
+          for file in build/Amiberry.app/Contents/Resources/plugins/*.dylib; do
+            if [ -f "$file" ]; then
+              codesign -s "Developer ID Application: Dimitris Panokostas (5GQP72592A)" -f -o runtime,hard $file
+            fi
+          done
 
       - name: Codesign the app
         run: |
@@ -136,6 +141,11 @@ jobs:
       - name: Codesign the dylibs
         run: |
           for file in build/Amiberry.app/Contents/Frameworks/*.dylib; do
+            if [ -f "$file" ]; then
+              codesign -s "Developer ID Application: Dimitris Panokostas (5GQP72592A)" -f -o runtime,hard $file
+            fi
+          done
+          for file in build/Amiberry.app/Contents/Resources/plugins/*.dylib; do
             if [ -f "$file" ]; then
               codesign -s "Developer ID Application: Dimitris Panokostas (5GQP72592A)" -f -o runtime,hard $file
             fi

--- a/cmake/macos/CMakeLists.txt
+++ b/cmake/macos/CMakeLists.txt
@@ -21,11 +21,11 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:capsimage>
-        $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Frameworks/$<TARGET_FILE_NAME:capsimage>)
+        $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/plugins/$<TARGET_FILE_NAME:capsimage>)
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:floppybridge>
-        $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Frameworks/$<TARGET_FILE_NAME:floppybridge>)
+        $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/plugins/$<TARGET_FILE_NAME:floppybridge>)
 
 # Gather all dependencies with dylibbundler
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
@@ -33,9 +33,9 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 
 if (NOT "${CMAKE_GENERATOR}" MATCHES "Xcode")
     install(FILES $<TARGET_FILE:capsimage>
-            DESTINATION $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Frameworks/)
+            DESTINATION $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/plugins/)
     install(FILES $<TARGET_FILE:floppybridge>
-            DESTINATION $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Frameworks/)
+            DESTINATION $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/plugins/)
 
     # This one contains the gamecontrollersdb.txt file
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/controllers

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4006,7 +4006,17 @@ void create_missing_amiberry_folders()
 	if (!my_existsdir(config_path.c_str()))
 		my_mkdir(config_path.c_str());
 	if (!my_existsdir(plugins_dir.c_str()))
-        my_mkdir(plugins_dir.c_str());
+	{
+		my_mkdir(plugins_dir.c_str());
+#ifdef __MACH__
+		const std::string bundled_plugins_path = app_directory + "/Resources/plugins/";
+		if (my_existsdir(bundled_plugins_path.c_str()))
+		{
+			const std::string command = "cp -r " + bundled_plugins_path + "* " + plugins_dir;
+			system(command.c_str());
+		}
+#endif
+	}
 	if (!my_existsdir(controllers_path.c_str()))
 	{
 		my_mkdir(controllers_path.c_str());


### PR DESCRIPTION
The bundled plugins of capsimg and floppybridge, were not included in the final app bundle. Furthermore, they need to be signed with the same digital certificate, otherwise MacOS will block them from loading.

Fixes #1540 .

Changes proposed in this pull request:
- include bundled plugins in a separate folder
- digitally sign bundled plugins during the build step
- during the first run, if the plugins directory did not exist, copy the bundled files in there as well.

@midwan
