### PR TITLE
Fix tcp serial ports

### DIFF
--- a/src/osdep/amiberry_serial.cpp
+++ b/src/osdep/amiberry_serial.cpp
@@ -337,11 +337,8 @@ static int opentcp (const TCHAR *sername)
 
 int openser (const TCHAR *sername)
 {
-	if (!_tcsnicmp(sername, _T("TCP://"), 6)) {
-		return opentcp(sername + 6);
-	}
 	if (!_tcsnicmp(sername, _T("TCP:"), 4)) {
-		return opentcp(sername + 4);
+		return opentcp(sername);
 	}
 
 	if (sp_get_port_by_name(sername, &port) != SP_OK) {


### PR DESCRIPTION
I tried using TCP serial port functionality and found that it would never end up listening on the port
After some digging I've traced it down to this:

Here in `openser()`, `sername` is passed to `opentcp()` skipping the "TCP://" part
https://github.com/BlitterStudio/amiberry/blob/8196671d573c07d45fa90f9d3d55d3e67d4ad959/src/osdep/amiberry_serial.cpp#L338C1-L345C3

`opentcp()` calls `uae_tcp_listen_uri()` which expects the protocol to be part of the URI, otherwise it returns with `UAE_SOCKET_INVALID`
https://github.com/BlitterStudio/amiberry/blob/8196671d573c07d45fa90f9d3d55d3e67d4ad959/src/osdep/socket.cpp#L131C1-L137C3

This pull request fixes this issue by passing the full sername through to opentcp