### PR TITLE
Add FreeBSD support: sysconfig, timezone, build fixes, platform macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,56 +1,93 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Project setup
 project(amiberry
-        VERSION 7.1.0
-        LANGUAGES C CXX
-        DESCRIPTION "Optimized Amiga emulator for various platforms"
-        HOMEPAGE_URL "https://amiberry.com"
+    VERSION 7.1.0
+    LANGUAGES C CXX
+    DESCRIPTION "Optimized Amiga emulator for various platforms"
+    HOMEPAGE_URL "https://amiberry.com"
 )
+
+# Prevent in-tree builds
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
+    message(FATAL_ERROR "In-tree builds are not supported. Use a separate build directory.")
+endif()
 
 # Set CMake module path
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
-# Prevent in-tree build (recommended for out-of-source builds)
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
-    message(FATAL_ERROR "Prevented in-tree build. Please create a build directory outside of the amiberry source code and run \"cmake -S ${CMAKE_SOURCE_DIR} -B .\" from there")
-endif ()
-
-# --- Feature Options ---
-# Emulation features
+# Feature options
 option(USE_LIBSERIALPORT "Use LibSerialPort for serial port emulation" ON)
-option(USE_LIBENET "Use LibENET for network emulation" ON)
-option(USE_PORTMIDI "Use PortMidi for MIDI emulation" ON)
-option(USE_LIBMPEG2 "Use LibMPEG2 for MPEG2 decoding (CD32 FMV)" ON)
-option(USE_UAENET_PCAP "Use libpcap for uaenet (Linux/macOS)" ON)
+option(USE_LIBENET       "Use LibENET for network emulation" ON)
+option(USE_PORTMIDI      "Use PortMidi for MIDI emulation" ON)
+option(USE_LIBMPEG2      "Use LibMPEG2 for CD32 FMV support" ON)
+option(USE_UAENET_PCAP   "Use libpcap for uaenet (Linux/macOS)" ON)
+option(USE_GPIOD         "Use GPIOD to control GPIO LEDs" OFF)
+option(USE_DBUS          "Use DBus to control the emulator" OFF)
+option(USE_OPENGL        "Use OpenGL for rendering (currently BROKEN)" OFF)
+option(WITH_LTO          "Enable Link Time Optimization" OFF)
 
-# Platform/Integration features
-option(USE_GPIOD "Use GPIOD to control GPIO LEDs" OFF)
-option(USE_DBUS "Use DBus to control the emulator" OFF)
-option(USE_OPENGL "Use OpenGL for rendering (currently BROKEN)" OFF)
-
-# Build options
-option(WITH_LTO "Enable Link Time Optimization" OFF)
-
-# --- Versioning ---
+# Versioning
 set(VERSION_MAJOR "7" CACHE STRING "Major version")
 set(VERSION_MINOR "1" CACHE STRING "Minor version")
 set(VERSION_PATCH "0" CACHE STRING "Patch version")
 set(VERSION_PRE_RELEASE "" CACHE STRING "Pre-release version")
 set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
-# Platform-specific settings
-if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+# Required packages via pkg-config
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(SDL2 REQUIRED sdl2)
+pkg_check_modules(SDL2_TTF REQUIRED SDL2_ttf)
+pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
+pkg_check_modules(FLAC REQUIRED flac)
+pkg_check_modules(PNG REQUIRED libpng)
+
+include_directories(
+    ${SDL2_INCLUDE_DIRS}
+    ${SDL2_TTF_INCLUDE_DIRS}
+    ${SDL2_IMAGE_INCLUDE_DIRS}
+    ${FLAC_INCLUDE_DIRS}
+    ${PNG_INCLUDE_DIRS}
+)
+
+link_libraries(
+    ${SDL2_LIBRARIES}
+    ${SDL2_TTF_LIBRARIES}
+    ${SDL2_IMAGE_LIBRARIES}
+    ${FLAC_LIBRARIES}
+    ${PNG_LIBRARIES}
+)
+
+# macOS-specific identifier (optional cosmetic)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(PROJECT_NAME "Amiberry")
     set(CMAKE_PROJECT_NAME "Amiberry")
-endif ()
+endif()
+
+# Project identity
 set(PROJECT_COMPANY_NAME "BlitterStudio")
-set(PROJECT_COMPANY_NAMESPACE "com.blitterstudio")  # Reverse domain name notation
+set(PROJECT_COMPANY_NAMESPACE "com.blitterstudio")
 
+# Global definitions
+add_definitions(-DLIBICONV_PLUG)
+
+# FreeBSD-specific linking and paths
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    link_directories(/usr/local/lib)
+
+    find_library(LIBUSB_LIBRARY NAMES usb PATHS /usr/lib REQUIRED)
+    if(NOT LIBUSB_LIBRARY)
+        message(FATAL_ERROR "libusb not found in /usr/lib")
+    endif()
+endif()
+
+# Install system and packaging
 include(GNUInstallDirs)
-
 include(cmake/StandardProjectSettings.cmake)
 include(cmake/SourceFiles.cmake)
 include(cmake/Dependencies.cmake)
-
 add_subdirectory(packaging)
+
+# Link libraries (FreeBSD needs correct order)
+if(TARGET amiberry AND CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    target_link_libraries(amiberry PRIVATE ${LIBUSB_LIBRARY} serialport ${EXTRA_LIBS})
+endif()

--- a/external/floppybridge/src/FloppyBridge.cpp
+++ b/external/floppybridge/src/FloppyBridge.cpp
@@ -25,7 +25,10 @@
 #include <cstring>
 #include "FloppyBridge.h"
 #include "resource.h"
-
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
 
 // For compatibility with older methods
 #define ROMTYPE_ARDUINOREADER_WRITER

--- a/src/cdtvcr.cpp
+++ b/src/cdtvcr.cpp
@@ -727,7 +727,17 @@ static uae_u8 cdtvcr_bget2 (uaecptr addr)
 		struct timeval tv;
 		struct mytimeval mtv;
 		gettimeofday (&tv, NULL);
-		tv.tv_sec -= _timezone;
+		#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+		// On BSD/macOS use tm_gmtoff
+		struct tm *lt = localtime(&tv.tv_sec);
+		tv.tv_sec -= lt->tm_gmtoff;
+		#elif defined(__linux__)
+		// On Linux use timezone variable
+		extern long timezone;
+		tv.tv_sec -= timezone;
+		#else
+		// fallback or no adjustment
+		#endif
 		mtv.tv_sec = tv.tv_sec;
 		mtv.tv_usec = tv.tv_usec;
 		timeval_to_amiga(&mtv, &days, &mins, &ticks, tickcount);

--- a/src/disk.cpp
+++ b/src/disk.cpp
@@ -330,7 +330,16 @@ static void disk_date (uae_u8 *p)
 
 	gettimeofday (&tv, NULL);
 #ifndef __PSP2__
-	tv.tv_sec -= _timezone;
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    struct tm *lt = localtime(&tv.tv_sec);
+    tv.tv_sec -= lt->tm_gmtoff;
+#elif defined(__linux__)
+    extern long timezone;
+    tv.tv_sec -= timezone;
+#else
+    // fallback or no adjustment
+#endif
+
 #endif
 	mtv.tv_sec = tv.tv_sec;
 	mtv.tv_usec = tv.tv_usec;

--- a/src/fsusage.cpp
+++ b/src/fsusage.cpp
@@ -28,7 +28,7 @@ Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
 #if defined(STAT_STATVFS) && !defined(__ANDROID__)
 #include <sys/statvfs.h>
 // For osx, sigurbjornl
-#elif defined (__MACH__)
+#elif defined (__MACH__) || defined(__FreeBSD__)
 #include <sys/mount.h>
 #else
 #include <sys/vfs.h>
@@ -109,8 +109,12 @@ int statfs ();
 # include <sys/mount.h>
 #endif
 
-#if HAVE_SYS_VFS_H and !defined(__MACH__)
-# include <sys/vfs.h>
+#if defined(__linux__)
+#include <sys/vfs.h>
+#elif defined(__FreeBSD__) || defined(__APPLE__)
+#include <sys/mount.h>
+#else
+#error "Filesystem header not supported on this platform"
 #endif
 
 #if HAVE_SYS_FS_S5PARAM_H	/* Fujitsu UXP/V */
@@ -125,8 +129,12 @@ int statfs ();
 # include <fcntl.h>
 #endif
 
-#if HAVE_SYS_STATFS_H and !defined(__MACH__)
-# include <sys/statfs.h>
+#if defined(__linux__)
+#include <sys/statfs.h>
+#elif defined(__FreeBSD__) || defined(__APPLE__)
+#include <sys/mount.h>
+#else
+#error "Platform not supported for filesystem stats"
 #endif
 
 #if HAVE_DUSTAT_H		/* AIX PS/2 */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,7 +67,7 @@
 #endif
 
 #include <iostream>
-#ifndef __MACH__
+#if defined(__linux__)
 #include <linux/kd.h>
 #endif
 #include <sys/ioctl.h>

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -300,9 +300,10 @@ extern void set_last_active_config(const char* filename);
 std::string home_dir;
 std::string current_dir;
 
-#ifndef __MACH__
+#if defined(__linux__)
 #include <linux/kd.h>
-#else
+#endif
+#ifdef __APPLE__
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 #include <sys/ioctl.h>
@@ -4945,7 +4946,7 @@ int main(int argc, char* argv[])
 	normalcursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
 	clipboard_init();
 
-#ifndef __MACH__
+#if defined( __linux__)
 	// set capslock state based upon current "real" state
 	ioctl(0, KDGKBLED, &kbd_flags);
 	ioctl(0, KDGETLED, &kbd_led_status);
@@ -5013,7 +5014,7 @@ int main(int argc, char* argv[])
 
 	gpiod_chip_close(chip);
 #endif
-#ifndef __MACH__
+#if defined(__linux__)
 	// restore keyboard LEDs to normal state
 	ioctl(0, KDSETLED, 0xFF);
 #else

--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -45,7 +45,7 @@
 #include "target.h"
 
 #ifdef AMIBERRY
-#ifndef __MACH__
+#if defined(__linux__)
 #include <linux/kd.h>
 #endif
 #include <sys/ioctl.h>
@@ -1165,7 +1165,7 @@ void gui_led(int led, int on, int brightness)
 	if (currprefs.kbd_led_scr != changed_prefs.kbd_led_scr) currprefs.kbd_led_scr = changed_prefs.kbd_led_scr;
 	if (currprefs.kbd_led_cap != changed_prefs.kbd_led_cap) currprefs.kbd_led_cap = changed_prefs.kbd_led_cap;
 
-#ifndef __MACH__
+#if defined(__linux__)
 	// Temperature sensor initialization
 	if (want_temp > 0 && temp_fd < 0) {
 		temp_fd = open(TEMPERATURE, O_RDONLY);

--- a/src/osdep/amiberry_mem.cpp
+++ b/src/osdep/amiberry_mem.cpp
@@ -193,7 +193,7 @@ bool jit_direct_compatible_memory;
 
 bool can_have_1gb()
 {
-	#ifndef __MACH__
+	#if defined(__linux__)
 	struct sysinfo mem_info{};
 	sysinfo(&mem_info);
 	long long total_phys_mem = mem_info.totalram;

--- a/src/osdep/blkdev_ioctl.cpp
+++ b/src/osdep/blkdev_ioctl.cpp
@@ -26,6 +26,7 @@
 #include <sys/stat.h>
 
 #ifdef __MACH__
+// macOS
 #include <errno.h>
 #include <IOKit/storage/IODVDMediaBSDClient.h>
 #include <IOKit/storage/IODVDMedia.h>
@@ -33,11 +34,20 @@
 #include <IOKit/storage/IOCDMediaBSDClient.h>
 #include <IOKit/storage/IOCDMedia.h>
 #include <IOKit/storage/IOCDTypes.h>
+
+#elif defined(__FreeBSD__)
+// FreeBSD
+#include <sys/cdio.h>
+#include <cam/scsi/scsi_all.h>
+#include <sys/errno.h>
+
 #else
+// Linux
 #include <linux/cdrom.h>
 #include <linux/hdreg.h>
 #include <linux/errno.h>
 #include <scsi/sg.h>
+
 #endif
 
 #include <cstring>

--- a/src/osdep/sysconfig.h
+++ b/src/osdep/sysconfig.h
@@ -14,7 +14,7 @@
 #define PACKAGE_STRING "Amiberry"
 
 #if defined(__x86_64__) || defined(_M_AMD64)
-#ifndef __MACH__ // not for macOS
+#if defined(__linux__) // not for macOS
 #define JIT /* JIT compiler support */
 #define USE_JIT_FPU
 #endif
@@ -628,7 +628,7 @@ typedef char TCHAR;
 #define _timezone           timezone
 #define _daylight           daylight
 // Ftello and fseeko on OSX are alerady 64bit
-#if defined ANDROID || defined __MACH__
+#if defined ANDROID || defined __MACH__ || defined __FreeBSD__ || defined __NetBSD__ || defined __OpenBSD__
 #define _ftelli64(x)        ftello(x)
 #define _fseeki64(x,y,z)    fseeko(x,y,z)
 #else


### PR DESCRIPTION
Fixes # Will compile and run on FreeBSD now, but without JIT currently due to the already discussed problem with memory addressing

Changes proposed in this pull request:
I've changed a few #ifndef __Mach__ to #if defined(__linux__) so it works with FreeBSDs and other macros that detect if FreeBSD, Mach, NetBSD, or OpenBSD
I've changed the JIT check to only enable linux if defined __linux__
I've updated files that use timezone and daylight to check if it is linux or not. If it isn't linux i've added code that will work with the BSDs instead
I've updated the CMakeLists.txt file to detect if FreeBSD and adjust linking priorities accordingly.
I've tested compiling all of this on Linux as well and everything as worked for me.

@midwan
