### PR TITLE
Fix all C++ string constant conversion warnings

### DIFF
--- a/src/calc.cpp
+++ b/src/calc.cpp
@@ -310,7 +310,7 @@ static TCHAR *stacktostring(struct calcstack *st)
 }
 
 
-static TCHAR *docalcxs(unsigned char op, TCHAR *v1, TCHAR *v2, double *voutp)
+static TCHAR *docalcxs(unsigned char op, const TCHAR *v1, const TCHAR *v2, double *voutp)
 {
     TCHAR tmp[MAX_DPATH];
     tmp[0] = 0;

--- a/src/kbmcu/m6805/m68_internal.h
+++ b/src/kbmcu/m6805/m68_internal.h
@@ -27,7 +27,7 @@ typedef enum {
 
 
 typedef struct M68_OPTABLE_ENT {
-	char *			mnem;		/* instruction mnemonic */
+	const char *		mnem;		/* instruction mnemonic */
 	M68_AMODE		amode;		/* addressing mode */
 	uint8_t			cycles;		/* number of cycles to execute */
 	bool			write_only;	/* is write-only?  only supported for direct, extended and indexed */

--- a/src/pcem/vid_cl5429.cpp
+++ b/src/pcem/vid_cl5429.cpp
@@ -2815,7 +2815,7 @@ static void cl_pci_write(int func, int addr, uint8_t val, void *p)
         }
 }
 
-static void *cl_init(int type, char *fn, int pci_card, uint32_t force_vram_size)
+static void *cl_init(int type, const char *fn, int pci_card, uint32_t force_vram_size)
 {
         gd5429_t *gd5429 = (gd5429_t*)malloc(sizeof(gd5429_t));
         svga_t *svga = &gd5429->svga;

--- a/src/pcem/vid_ncr.cpp
+++ b/src/pcem/vid_ncr.cpp
@@ -1094,7 +1094,7 @@ static void ncr_io_set(ncr_t *ncr)
         io_sethandlerx(0x03c0, 0x0020, ncr_in, NULL, NULL, ncr_out, NULL, NULL, ncr);
 }
 
-static void *ncr_init(char *bios_fn, int chip)
+static void *ncr_init(const char *bios_fn, int chip)
 {
         ncr_t *ncr = (ncr_t*)calloc(sizeof(ncr_t), 1);
         svga_t *svga = &ncr->svga;

--- a/src/pcem/vid_permedia2.cpp
+++ b/src/pcem/vid_permedia2.cpp
@@ -1891,7 +1891,7 @@ void permedia2_pci_write(int func, int addr, uint8_t val, void *p)
 }
 
 
-static void *permedia2_init(char *bios_fn, int chip)
+static void *permedia2_init(const char *bios_fn, int chip)
 {
         permedia2_t *permedia2 = (permedia2_t*)calloc(sizeof(permedia2_t), 1);
         svga_t *svga = &permedia2->svga;

--- a/src/pcem/vid_s3.cpp
+++ b/src/pcem/vid_s3.cpp
@@ -2787,7 +2787,7 @@ static int vram_sizes[] =
         3 /*8 MB*/
 };
 
-static void *s3_init(char *bios_fn, int chip)
+static void *s3_init(const char *bios_fn, int chip)
 {
         s3_t *s3 = (s3_t*)malloc(sizeof(s3_t));
         svga_t *svga = &s3->svga;

--- a/src/pcem/vid_voodoo_banshee.cpp
+++ b/src/pcem/vid_voodoo_banshee.cpp
@@ -2809,7 +2809,7 @@ void voodoo_update_vram(void *p)
     banshee->voodoo->tex_mem_w[1] = (uint16_t*)banshee->svga.vram;
 }
 
-static void *banshee_init_common(char *fn, int has_sgram, int type, int voodoo_type)
+static void *banshee_init_common(const char *fn, int has_sgram, int type, int voodoo_type)
 {
         int mem_size;
         banshee_t *banshee = (banshee_t*)malloc(sizeof(banshee_t));

--- a/src/pcem/x86seg.cpp
+++ b/src/pcem/x86seg.cpp
@@ -184,7 +184,7 @@ void x86gpf_expected(const char *s, uint16_t error)
         cpu_state.abrt = int8_t(ABRT_GPF) | ABRT_EXPECTED;
         abrt_error = error;
 }
-void x86ss(char *s, uint16_t error)
+void x86ss(const char *s, uint16_t error)
 {
 //        pclog("SS %04X\n", error);
         cpu_state.abrt = ABRT_SS;


### PR DESCRIPTION
Fixes the typical string constant conversion warnings if former C code is compiled by a C++ compiler.

warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]

@midwan
