### PR TITLE
fix all volatile variable breaking chained assignments

### DIFF
--- a/src/a2065.cpp
+++ b/src/a2065.cpp
@@ -1044,7 +1044,9 @@ static void a2065_reset(int hardreset)
 	for (int i = 0; i < RAP_SIZE; i++)
 		csr[i] = 0;
 	csr[0] = CSR0_STOP;
-	csr[1] = csr[2] = csr[3] = 0;
+	csr[1] = 0;
+	csr[2] = 0;
+	csr[3] = 0;
 	csr[4] = 0x0115;
 	dbyteswap = 0;
 	rap = 0;

--- a/src/akiko.cpp
+++ b/src/akiko.cpp
@@ -572,7 +572,8 @@ static void subfunc (uae_u8 *data, int cnt)
 #endif
 	if (subcodebufferinuse[subcodebufferoffsetw]) {
 		memset (subcodebufferinuse, 0,sizeof (subcodebufferinuse));
-		subcodebufferoffsetw = subcodebufferoffset = 0;
+		subcodebufferoffsetw = 0;
+		subcodebufferoffset = 0;
 		uae_sem_post (&sub_sem);
 		//write_log (_T("CD32: subcode buffer overflow 1\n"));
 		return;
@@ -1981,7 +1982,8 @@ static void akiko_bput2 (uaecptr addr, uae_u32 v, int msg)
 		if ((cdrom_flags & CDFLAG_SUBCODE) && !(tmp & CDFLAG_SUBCODE)) {
 			uae_sem_wait (&sub_sem);
 			memset (subcodebufferinuse, 0, sizeof subcodebufferinuse);
-			subcodebufferoffset = subcodebufferoffsetw = 0;
+			subcodebufferoffset = 0;
+			subcodebufferoffsetw = 0;
 			uae_sem_post (&sub_sem);
 		}
 		cdrom_flags &= 0xff800000;

--- a/src/blkdev_cdimage.cpp
+++ b/src/blkdev_cdimage.cpp
@@ -486,7 +486,8 @@ static bool cdda_play_func2 (struct cdunit *cdu, int *outpos)
 		sleep_millis(10);
 	oldplay = -1;
 
-	cdu->cda_bufon[0] = cdu->cda_bufon[1] = 0;
+	cdu->cda_bufon[0] = 0;
+	cdu->cda_bufon[1] = 0;
 	bufnum = 0;
 
 	cdu->cda = new cda_audio (CDDA_BUFFERS, 2352, 44100);

--- a/src/cd32_fmv.cpp
+++ b/src/cd32_fmv.cpp
@@ -1410,7 +1410,8 @@ static void cd32_fmv_audio_handler(void)
 		cd_audio_mode_changed = false;
 		if (cl450_play) {
 			audio_cda_new_buffer(&cas, NULL, -1, -1, NULL, NULL);
-			fmv_bufon[0] = fmv_bufon[1] = 0;
+			fmv_bufon[0] = 0;
+			fmv_bufon[1] = 0;
 			delete cda;
 			cda = new cda_audio(PCM_SECTORS, KJMP2_SAMPLES_PER_FRAME * 4, 44100);
 			l64111_setvolume();

--- a/src/cdtv.cpp
+++ b/src/cdtv.cpp
@@ -122,7 +122,8 @@ static void subreset (void)
 {
 	uae_sem_wait (&sub_sem);
 	memset (subcodebufferinuse, 0, sizeof subcodebufferinuse);
-	subcodebufferoffsetw = subcodebufferoffset = 0;
+	subcodebufferoffsetw = 0;
+	subcodebufferoffset = 0;
 	subcodeoffset = -1;
 	sbcp = 0;
 	scor = 0;
@@ -239,7 +240,8 @@ static void subfunc (uae_u8 *data, int cnt)
 #endif
 	if (subcodebufferinuse[subcodebufferoffsetw]) {
 		memset (subcodebufferinuse, 0, sizeof subcodebufferinuse);
-		subcodebufferoffsetw = subcodebufferoffset = 0;
+		subcodebufferoffsetw = 0;
+		subcodebufferoffset = 0;
 		subcodeoffset = -1;
 		uae_sem_post (&sub_sem);
 #ifdef CDTV_SUB_DEBUG
@@ -1254,7 +1256,8 @@ static void cdtv_reset_int (void)
 {
 	write_log (_T("CDTV: reset\n"));
 	cdaudiostop ();
-	cd_playing = cd_paused = 0;
+	cd_playing = 0;
+	cd_paused = 0;
 	cd_motor = 0;
 	cd_media = 0;
 	cd_error = 0;
@@ -1733,7 +1736,10 @@ bool cdtv_init(struct autoconfig_info *aci)
 	write_comm_pipe_u32 (&requests, 0x0104, 1);
 
 	cdrom_command_cnt_out = -1;
-	cmd = enable = xaen = dten = 0;
+	cmd = 0;
+	enable = 0;
+	xaen = 0;
+	dten = 0;
 
 	/* KS autoconfig handles the rest */
 	if (!savestate_state) {

--- a/src/cdtvcr.cpp
+++ b/src/cdtvcr.cpp
@@ -243,7 +243,8 @@ static void cdtvcr_4510_reset(uae_u8 v)
 	cdtvcr_4510_ram[CDTVCR_PLAYLIST_TIME_MODE] = 2;
 	uae_sem_wait (&sub_sem);
 	memset (subcodebufferinuse, 0, sizeof subcodebufferinuse);
-	subcodebufferoffsetw = subcodebufferoffset = 0;
+	subcodebufferoffsetw = 0;
+	subcodebufferoffset = 0;
 	uae_sem_post (&sub_sem);
 
 	if (ismedia())
@@ -403,7 +404,8 @@ static void subfunc(uae_u8 *data, int cnt)
 	uae_sem_wait(&sub_sem);
 	if (subcodebufferinuse[subcodebufferoffsetw]) {
 		memset (subcodebufferinuse, 0,sizeof (subcodebufferinuse));
-		subcodebufferoffsetw = subcodebufferoffset = 0;
+		subcodebufferoffsetw = 0;
+		subcodebufferoffset = 0;
 	} else {
 		int offset = subcodebufferoffsetw;
 		while (cnt > 0) {

--- a/src/include/commpipe.h
+++ b/src/include/commpipe.h
@@ -40,7 +40,8 @@ STATIC_INLINE void init_comm_pipe (smp_comm_pipe *p, int size, int chunks)
 	p->data = (uae_pt *)malloc (size*sizeof (uae_pt));
 	p->size = size;
 	p->chunks = chunks;
-	p->rdp = p->wrp = 0;
+	p->rdp = 0;
+	p->wrp = 0;
 	p->reader_waiting = 0;
 	p->writer_waiting = 0;
 	uae_sem_init (&p->lock, 0, 1);

--- a/src/native2amiga.cpp
+++ b/src/native2amiga.cpp
@@ -37,7 +37,8 @@ void native2amiga_install (void)
 void native2amiga_reset (void)
 {
 	smp_comm_pipe *p = &native2amiga_pending;
-	p->rdp = p->wrp = 0;
+	p->rdp = 0;
+	p->wrp = 0;
 	p->reader_waiting = 0;
 	p->writer_waiting = 0;
 }

--- a/src/osdep/cda_play.cpp
+++ b/src/osdep/cda_play.cpp
@@ -130,7 +130,8 @@ static bool cdda_play2(struct cda_play* ciw, int* outpos)
 		sleep_millis(10);
 	oldplay = -1;
 
-	ciw->cda_bufon[0] = ciw->cda_bufon[1] = 0;
+	ciw->cda_bufon[0] = 0;
+	ciw->cda_bufon[1] = 0;
 	bufnum = 0;
 	buffered = 0;
 

--- a/src/qemuvga/ne2000.cpp
+++ b/src/qemuvga/ne2000.cpp
@@ -1226,7 +1226,8 @@ static uae_u32 REGPARAM2 ne2000_lget(struct pci_board_state *pcibs, uaecptr addr
 static void ne2000_reset(struct pci_board_state *pcibs)
 {
 	ne2000_reset2(&ne2000state);
-	receive_buffer_read = receive_buffer_write = 0;
+	receive_buffer_read = 0;
+	receive_buffer_write = 0;
 }
 
 static void ne2000_free(struct pci_board_state *pcibs)


### PR DESCRIPTION
warning: using value of assignment with ‘volatile’-qualified left
         operand is deprecated [-Wvolatile]

Chained assignments of volatile variables (var1 = var2 = var3 = 0;) result in a read-modify-write opcode chain which breaks the idea behind using volatile. Here during the modify phase the volatile variable can be modified by an external source (the software running inside the emulator), then the volatile variable is written again with the former read value, completely dropping the value from the external source. It is a rare scenario, but it happens, hence the warning from the compiler. The fix is easy, break up the chained assignments.

@midwan
