### PR TITLE
changes for JIT support for freebsd x86_64

### DIFF
--- a/src/jit/x86/exception_handler.cpp
+++ b/src/jit/x86/exception_handler.cpp
@@ -167,6 +167,28 @@ typedef void *CONTEXT_T;
 #define CONTEXT_RSI(context) (((ucontext_t *) context)->uc_mcontext->__ss.__esi)
 #define CONTEXT_RDI(context) (((ucontext_t *) context)->uc_mcontext->__ss.__edi)
 
+#elif defined (AMIBERRY) && defined(CPU_x86_64) && defined(__FreeBSD__)
+
+typedef void *CONTEXT_T;
+#define HAVE_CONTEXT_T 1
+#define CONTEXT_RIP(context) ((( ucontext_t *) context)->uc_mcontext.mc_rip)
+#define CONTEXT_RAX(context) ((( ucontext_t *) context)->uc_mcontext.mc_rax)
+#define CONTEXT_RCX(context) ((( ucontext_t *) context)->uc_mcontext.mc_rcx)
+#define CONTEXT_RDX(context) ((( ucontext_t *) context)->uc_mcontext.mc_rdx)
+#define CONTEXT_RBX(context) ((( ucontext_t *) context)->uc_mcontext.mc_rbx)
+#define CONTEXT_RSP(context) ((( ucontext_t *) context)->uc_mcontext.mc_rsp)
+#define CONTEXT_RBP(context) ((( ucontext_t *) context)->uc_mcontext.mc_rbp)
+#define CONTEXT_RSI(context) ((( ucontext_t *) context)->uc_mcontext.mc_rsi)
+#define CONTEXT_RDI(context) ((( ucontext_t *) context)->uc_mcontext.mc_rdi)
+#define CONTEXT_R8(context)  ((( ucontext_t *) context)->uc_mcontext.mc_r8)
+#define CONTEXT_R9(context)  ((( ucontext_t *) context)->uc_mcontext.mc_r9)
+#define CONTEXT_R10(context) ((( ucontext_t *) context)->uc_mcontext.mc_r10)
+#define CONTEXT_R11(context) ((( ucontext_t *) context)->uc_mcontext.mc_r11)
+#define CONTEXT_R12(context) ((( ucontext_t *) context)->uc_mcontext.mc_r12)
+#define CONTEXT_R13(context) ((( ucontext_t *) context)->uc_mcontext.mc_r13)
+#define CONTEXT_R14(context) ((( ucontext_t *) context)->uc_mcontext.mc_r14)
+#define CONTEXT_R15(context) ((( ucontext_t *) context)->uc_mcontext.mc_r15)
+
 #elif defined (AMIBERRY) && defined(CPU_x86_64)
 
 typedef void *CONTEXT_T;

--- a/src/osdep/sysconfig.h
+++ b/src/osdep/sysconfig.h
@@ -14,7 +14,7 @@
 #define PACKAGE_STRING "Amiberry"
 
 #if defined(__x86_64__) || defined(_M_AMD64)
-#if defined(__linux__) // not for macOS
+#if defined(__FreeBSD__) || defined(__linux__) // not for macOS
 #define JIT /* JIT compiler support */
 #define USE_JIT_FPU
 #endif

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -299,6 +299,13 @@ static void *try_reserve(uintptr_t try_addr, uae_u32 size, int flags)
 	}
 #else
 	int mmap_flags = MAP_PRIVATE | MAP_ANON;
+    #if defined(__FreeBSD__)
+    // On FreeBSD, force the main memory reservation into the low 32-bit space.
+    // This is critical for the JIT's direct memory access model.
+    // We use a fixed hint and explicitly add MAP_32BIT.
+    try_addr = 0x10000000;
+    mmap_flags |= MAP_32BIT;
+    #endif
 	address = mmap((void *) try_addr, size, PROT_NONE, mmap_flags, -1, 0);
 	if (address == MAP_FAILED) {
 		return NULL;


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
-added a needed hint and MAP_32BIT flag for FreeBSD
-added a CONTEXT_T layout supported by fbsd x86 ucontext
-these changes should be enough to get jit working on a fbsd x86_64 system

@midwan

This PR is generously sponsored by @ut316ab 