### PR TITLE
Fix FloppyBridge for Apple architecture

### DIFF
--- a/external/floppybridge/src/SerialIO.cpp
+++ b/external/floppybridge/src/SerialIO.cpp
@@ -712,7 +712,9 @@ SerialIO::Response SerialIO::configurePort(const Configuration& configuration) {
 	serial.flags |= ASYNC_LOW_LATENCY;
 	ioctl(m_portHandle, TIOCSSERIAL, &serial);
 #endif
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__)
+    if (ioctl(m_portHandle, IOSSIOSPEED, &baud) == -1) return Response::rUnknownError;
+#elif defined(__FreeBSD__)
     // FreeBSD does not support IOSSIOSPEED, use termios instead
     if (cfsetispeed(&term, baud) != 0 || cfsetospeed(&term, baud) != 0)
         return Response::rUnknownError;


### PR DESCRIPTION
Changes proposed in this pull request:

DrawBridge (Arduino Reader/Writer) support was not working on my Apple M2 laptop running MacOS Sequoia. Amiberry was able to correctly list the usb serial ports, but was unable to read data from the correct port when selected, timing out with a port error.

I compared the FloppyBridge code in Amiberry with the code located at https://github.com/RobSmithDev/FloppyDriveBridge and discovered that one of the commands that configures the port is slightly different when compiled for Apple architecture. 

This PR reverts the change for Apple architecture while keeping the FreeBSD command intact.

I have built this on my laptop and drive support is now working. Please bear in mind that I haven't tested it on other systems such as FreeBSD so you may wish to do that.

Thanks for a great project - I can now finally read my Amiga disks natively on my Mac!

@midwan
