### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,5 +1,8 @@
 name: C/C++ CI
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BlitterStudio/amiberry/security/code-scanning/25](https://github.com/BlitterStudio/amiberry/security/code-scanning/25)

The safest and most future-proof way to fix this issue is to explicitly declare a `permissions` block at the root of the workflow file (`.github/workflows/c-cpp.yml`). Since most CI jobs do not require `write` permissions (unless they create releases, modify the codebase, etc.), setting the default to `contents: read` at the workflow root ensures all jobs only have read access by default.

For jobs that require more permissions (for example, the `create-release` or `create-prerelease` jobs may need `contents: write` or `packages: write` if they publish releases), you may in the future override permissions at the job level. For now, a minimal and safe starting point is to set:

```yaml
permissions:
  contents: read
```

immediately after the workflow `name:` and before the `on:` key (as close to the top as possible).

No imports or additional methods are needed. Only a single YAML insertion is necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
