### PR TITLE
fix(input): make mouse release sticky until user re-engages

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -1199,6 +1199,8 @@ static void setmouseactive2(AmigaMonitor* mon, int active, const bool allowpause
 		active = 1;
 
 	mouseactive = active ? mon->monitor_id + 1 : 0;
+	// Any successful capture transition clears the user-release intent so
+	// later focus events can apply capture_always normally again.
 	if (mouseactive)
 		user_released_capture = false;
 
@@ -1508,15 +1510,19 @@ int isfocus()
 void activationtoggle(const int monid, const bool inactiveonly)
 {
 	if (mouseactive) {
-		user_released_capture = true;
 		if ((isfullscreen() > 0) || (isfullscreen() < 0 && currprefs.minimize_inactive)) {
+			// disablecapture() sets user_released_capture itself.
 			disablecapture();
 			minimizewindow(monid);
 		} else {
+			user_released_capture = true;
 			setmouseactive(monid, 0);
 		}
 	} else {
 		if (!inactiveonly) {
+			// Pre-clear so that if setmouseactive2 rejects this re-capture
+			// attempt (e.g. window hidden, cursor not normalcursor), the
+			// next focus_gained can still apply capture_always normally.
 			user_released_capture = false;
 			setmouseactive(monid, 1);
 		}

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -146,6 +146,11 @@ static int focus;
 static int mouseinside;
 static int pending_mousecapture_monid = -1;
 static int pending_mousecapture_active;
+// Sticky flag: set when the user explicitly releases the mouse (Ctrl-Alt,
+// middle-button untrap, magic-mouse edge release). Suppresses automatic
+// recapture on focus_gained and the window-position snap-back heuristic
+// so that release sticks until the user clicks back inside the window.
+static bool user_released_capture;
 int mouseactive;
 int mouse_monid;
 int minimized;
@@ -1194,6 +1199,8 @@ static void setmouseactive2(AmigaMonitor* mon, int active, const bool allowpause
 		active = 1;
 
 	mouseactive = active ? mon->monitor_id + 1 : 0;
+	if (mouseactive)
+		user_released_capture = false;
 
 	mon->mouseposx = mon->mouseposy = 0;
 
@@ -1323,7 +1330,7 @@ static void amiberry_active(const AmigaMonitor* mon, const int is_minimized)
 	}
 	getcapslock();
 	wait_keyrelease();
-	if (isfullscreen() > 0 || currprefs.capture_always) {
+	if (isfullscreen() > 0 || (currprefs.capture_always && !user_released_capture)) {
 		setmouseactive(mon->monitor_id, 1);
 		inputdevice_acquire(TRUE);
 	}
@@ -1409,6 +1416,7 @@ void enablecapture(const int monid)
 {
 	if (pause_emulation > 2)
 		return;
+	user_released_capture = false;
 	setmouseactive(monid, 1);
 	if (sound_closed < 0) {
 		resumesoundpaused();
@@ -1420,6 +1428,7 @@ void enablecapture(const int monid)
 
 void disablecapture()
 {
+	user_released_capture = true;
 	setmouseactive(0, 0);
 	focus = 0;
 	mouseinside = false;
@@ -1499,6 +1508,7 @@ int isfocus()
 void activationtoggle(const int monid, const bool inactiveonly)
 {
 	if (mouseactive) {
+		user_released_capture = true;
 		if ((isfullscreen() > 0) || (isfullscreen() < 0 && currprefs.minimize_inactive)) {
 			disablecapture();
 			minimizewindow(monid);
@@ -1506,8 +1516,10 @@ void activationtoggle(const int monid, const bool inactiveonly)
 			setmouseactive(monid, 0);
 		}
 	} else {
-		if (!inactiveonly)
+		if (!inactiveonly) {
+			user_released_capture = false;
 			setmouseactive(monid, 1);
+		}
 	}
 }
 
@@ -1918,7 +1930,12 @@ static void handle_focus_gained_event(AmigaMonitor* mon)
 			// position and persist it to prefs, since handle_moved_event
 			// skipped setsizemove during the transition.
 			setsizemove(mon, mon->amiga_window);
-		} else {
+		} else if (!user_released_capture) {
+			// Snap-back is only safe for involuntary focus losses such as
+			// alt-tab. If the user explicitly released capture, treat any
+			// position change as deliberate (e.g. a title-bar drag whose
+			// MOVED events are still queued behind this focus_gained on
+			// Windows' modal drag loop) and leave the new position alone.
 			int cur_x, cur_y;
 			SDL_GetWindowPosition(mon->amiga_window, &cur_x, &cur_y);
 			if (cur_x != mon->pre_focus_x || cur_y != mon->pre_focus_y) {


### PR DESCRIPTION
## Summary

- On Windows, Ctrl-Alt / middle-button release did not stick: any focus_gained event (title-bar click, re-focus after clicking outside, alt-tab back) immediately reasserted capture via `amiberry_active()`'s unconditional honoring of `capture_always`.
- Dragging the title bar right after a release would snap the window back to its pre-focus position, because `handle_focus_gained_event` runs before the MOVED events queued behind the Windows modal drag loop.

## Fix

Add a sticky `user_released_capture` flag set on explicit user release (`activationtoggle` / `disablecapture`) and cleared on any successful capture transition in `setmouseactive2` (covering click-inside-window, GUI close, explicit menu re-capture). While the flag is set:

- `amiberry_active()` skips the `capture_always` auto-grab on focus-gained
- `handle_focus_gained_event()` skips the window-position snap-back

Result: release behaves like VMware - it stays released until the user clicks back inside the emulation window. The alt-tab snap-back fix from 9bd57165 still applies for involuntary focus losses (no user release), and the title-bar drag fix from #1969 is unchanged (still in the `moved_during_focus_transition` branch).

## Test plan

- [x] Windowed mode: Ctrl-Alt to release; cursor stays free when moving outside the window and clicking elsewhere
- [x] Windowed mode: Ctrl-Alt to release; click on the title bar to drag - capture does not re-engage and the window stays at the new position
- [x] Windowed mode: Ctrl-Alt to release; alt-tab away and back - capture stays released
- [x] Windowed mode: middle-button release behaves the same as Ctrl-Alt
- [x] Windowed mode: after release, clicking inside the emulation client area re-captures
- [x] Open / close GUI after a release: capture is restored on GUI close
- [x] Alt-tab away and back without releasing: window position snap-back from 9bd57165 still works
- [x] Fullscreen mode: Ctrl-Alt to minimize behaves as before; restoring re-captures only on click inside