### PR TITLE
Flush Windows ARM64 JIT code patches

### DIFF
--- a/src/jit/arm/compemu_midfunc_arm64.cpp
+++ b/src/jit/arm/compemu_midfunc_arm64.cpp
@@ -708,7 +708,9 @@ STATIC_INLINE void flush_cpu_icache(void *start, void *stop)
   }
 #endif
 
-#if defined(__APPLE__) && defined(CPU_AARCH64)
+#if defined(_WIN32) && defined(CPU_AARCH64)
+	FlushInstructionCache(GetCurrentProcess(), start, (SIZE_T)((char *)stop - (char *)start));
+#elif defined(__APPLE__) && defined(CPU_AARCH64)
 	sys_icache_invalidate(start, (char *)stop - (char *)start);
 #else
 	__builtin___clear_cache((char *)start, (char *)stop);

--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -34,6 +34,12 @@
 #if defined(CPU_AARCH64) && !defined(_WIN32)
 #include <sys/mman.h>
 #endif
+#if defined(CPU_AARCH64) && defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
 
 #ifdef JIT_DEBUG_MEM_CORRUPTION
 #include <signal.h>

--- a/src/osdep/sigsegv_handler.cpp
+++ b/src/osdep/sigsegv_handler.cpp
@@ -423,11 +423,48 @@ static LONG CALLBACK windows_arm64_jit_exception_handler(PEXCEPTION_POINTERS inf
 	return EXCEPTION_CONTINUE_SEARCH;
 }
 
+static const TCHAR* windows_arm64_av_type(const ULONG_PTR access_type)
+{
+	switch (access_type) {
+	case 0:
+		return _T("read");
+	case 1:
+		return _T("write");
+	case 8:
+		return _T("execute");
+	default:
+		return _T("unknown");
+	}
+}
+
+static LONG WINAPI windows_arm64_jit_unhandled_exception_filter(PEXCEPTION_POINTERS info)
+{
+	const auto* er = info->ExceptionRecord;
+	const auto* ctx = info->ContextRecord;
+	const uintptr fault_pc = static_cast<uintptr>(ctx->Pc);
+	write_log(_T("JIT: Windows ARM64 unhandled exception code=%08lx PC=%p in_jit=%d\n"),
+		er->ExceptionCode, reinterpret_cast<void*>(fault_pc), windows_arm64_jit_pc(fault_pc) ? 1 : 0);
+	if (er->ExceptionCode == EXCEPTION_ACCESS_VIOLATION && er->NumberParameters >= 2) {
+		const uintptr fault_addr = static_cast<uintptr>(er->ExceptionInformation[1]);
+		write_log(_T("JIT: Windows ARM64 unhandled AV type=%s target=%p natmem=%p amiga=%08x\n"),
+			windows_arm64_av_type(er->ExceptionInformation[0]), reinterpret_cast<void*>(fault_addr),
+			natmem_offset, natmem_offset ? static_cast<uaecptr>(fault_addr - reinterpret_cast<uintptr>(natmem_offset)) : 0);
+	}
+	write_log(_T("JIT: Windows ARM64 ranges compiled=%p current=%p popall=%p-%p M68K PC=%08x pc_p=%p spcflags=%08x\n"),
+		compiled_code, current_compile_p, popallspace, popallspace ? popallspace + POPALLSPACE_SIZE : nullptr,
+		static_cast<uae_u32>(M68K_GETPC), regs.pc_p, regs.spcflags);
+	if (windows_arm64_jit_pc(fault_pc)) {
+		write_log(_T("JIT: Windows ARM64 instruction at PC=%08x\n"), *reinterpret_cast<uae_u32*>(fault_pc));
+	}
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+
 static void install_windows_arm64_jit_exception_handler()
 {
 	if (!installed_arm64_vector_handler) {
 		write_log(_T("JIT: Installing Windows ARM64 vectored exception handler\n"));
 		installed_arm64_vector_handler = AddVectoredExceptionHandler(0, windows_arm64_jit_exception_handler);
+		SetUnhandledExceptionFilter(windows_arm64_jit_unhandled_exception_filter);
 	}
 }
 #endif


### PR DESCRIPTION
Follow-up for #1991 after the first Windows ARM64 hardware log showed JIT reaching a dummy-bank direct-memory fault and then crashing.\n\nChanges:\n- Use Windows FlushInstructionCache() for ARM64 JIT code/cache patch flushes instead of relying only on the compiler builtin.\n- Add Windows ARM64 unhandled-exception diagnostics so future logs include the failing native PC, AV type, natmem/Amiga address, and JIT code ranges.\n\nLocal validation:\n- git diff --check\n\nNote: local Windows ARM64 configure/build was not run because LLVM_MINGW_ROOT is not configured on this machine; the PR CI windows-11-arm job is the compile/smoke gate.