### PR TITLE
Rename Reset/Restart buttons to Reboot/Reload with tooltips

### DIFF
--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -2455,26 +2455,32 @@ void run_gui()
 		ImGui::Dummy(ImVec2(0, 2.0f));
 
 		// Button bar
-		// Left-aligned buttons (Shutdown, Reset, Quit, Restart, Help)
+		// Left-aligned buttons (Shutdown, Reboot, Quit, Reload, Help)
 		if (!amiberry_options.disable_shutdown_button) {
 			if (AmigaButton(ICON_FA_POWER_OFF " Shutdown", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT))) {
 				uae_quit();
 				gui_running = false;
 				host_poweroff = true;
 			}
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip("Shut down the host system");
 			ImGui::SameLine();
 		}
-		if (AmigaButton(ICON_FA_ROTATE_RIGHT " Reset", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT))) {
+		if (AmigaButton(ICON_FA_ROTATE_RIGHT " Reboot", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT))) {
 			uae_reset(1, 1);
 			gui_running = false;
 		}
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("Cold reset the emulated Amiga");
 		ImGui::SameLine();
 		if (AmigaButton(ICON_FA_RIGHT_FROM_BRACKET " Quit", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT))) {
 			uae_quit();
 			gui_running = false;
 		}
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("Exit Amiberry");
 		ImGui::SameLine();
-		if (AmigaButton(ICON_FA_ARROWS_ROTATE " Restart", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT))) {
+		if (AmigaButton(ICON_FA_ARROWS_ROTATE " Reload", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT))) {
 			char tmp[MAX_DPATH] = {0};
 			get_configuration_path(tmp, sizeof tmp);
 			if (strlen(last_loaded_config) > 0) {
@@ -2487,6 +2493,8 @@ void run_gui()
 			uae_restart(&changed_prefs, -1, tmp);
 			gui_running = false;
 		}
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("Reload current configuration and restart emulation");
 
 		// Right-aligned buttons
 		float right_buttons_width = (BUTTON_WIDTH * 2) + style.ItemSpacing.x;

--- a/src/osdep/imgui/imgui_help_text.h
+++ b/src/osdep/imgui/imgui_help_text.h
@@ -19,7 +19,7 @@ static const char* help_text_about =
 	"\n"
 	"\"Quit\": This quits Amiberry, as you'd expect.\n"
 	"\n"
-	"\"Restart\": This button will stop emulation (if running), reload Amiberry and reset\n"
+	"\"Reload\": This button will stop emulation (if running), reload Amiberry and reset\n"
 	" the currently loaded configuration. This has a similar effect as if you Quit and start\n"
 	" Amiberry again.\n"
 	" It can be useful if you want to change a setting that cannot be changed on-the-fly,\n"
@@ -28,7 +28,7 @@ static const char* help_text_about =
 	"\"Help\": This will display some on-screen help/documentation, relating to the Panel\n"
 	" you are currently in.\n"
 	"\n"
-	"\"Reset\": This button will trigger a hard reset of the emulation, which will reboot\n"
+	"\"Reboot\": This button will trigger a hard reset of the emulation, which will reboot\n"
 	" with the current settings.\n"
 	"\n"
 	"\"Start\": This button starts the emulation, using the current settings you have set.\n";


### PR DESCRIPTION
## Summary

- Renames the easily-confused **Reset** → **Reboot** and **Restart** → **Reload** buttons in the GUI button bar for clearer distinction
- Adds hover tooltips to all button bar buttons (Shutdown, Reboot, Quit, Reload)
- Updates help text to reflect the new names

## Rationale (from #2008)

"Reset" and "Restart" are semantically adjacent verbs that are easy to misclick. The new names provide immediate visual distinction:

| Old | New | What it does |
|-----|-----|--------------|
| Reset | **Reboot** | Cold reset of the emulated Amiga |
| Restart | **Reload** | Reload current `.uae` config and restart emulation |

**Why these names beat the user suggestions:**
- `Reboot` / `Reload` — completely different first syllables, distinguishable at a glance
- `Reset Amiga` / `Restart Amiberry` — verbose, both start with "Re", differ by one letter in the second word
- `Restart Amiga` / `Restart Amiberry` — same problem, both start with "Restart"

## Changes

- `src/osdep/gui/main_window.cpp` — button labels + tooltips
- `src/osdep/imgui/imgui_help_text.h` — help text updated to match
- Wiki test script updated in `amiberry.wiki` repo

Closes #2008