### PR TITLE
Fix chip name typo and add missing tooltips in CPU panel

### DIFF
--- a/src/osdep/imgui/adv_chipset.cpp
+++ b/src/osdep/imgui/adv_chipset.cpp
@@ -47,7 +47,7 @@ void render_panel_adv_chipset()
 		ShowHelpMarker("MSM6242B RTC chip (used in A2000)");
 		ImGui::SameLine();
 		AmigaRadioButton("RF5C01A", &changed_prefs.cs_rtc, 2);
-		ShowHelpMarker("RP5C01A RTC chip (used in A3000/A4000)");
+		ShowHelpMarker("RF5C01A RTC chip (used in A3000/A4000)");
 		ImGui::SameLine();
 		AmigaRadioButton("A2000 MSM6242B", &changed_prefs.cs_rtc, 3);
 		ShowHelpMarker("MSM6242B with A2000-specific behavior");

--- a/src/osdep/imgui/cpu.cpp
+++ b/src/osdep/imgui/cpu.cpp
@@ -501,6 +501,7 @@ void render_panel_cpu() {
         ImGui::SliderInt("##PPC Idle", &changed_prefs.ppc_cpu_idle, 0, 10);
         AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
         ImGui::EndDisabled();
+        ShowHelpMarker("How much the M68K CPU sleeps while PPC is running. Higher values reduce host CPU usage.");
 
         ImGui::Dummy(ImVec2(right_group_min_width, 0.0f));
         }
@@ -521,6 +522,7 @@ void render_panel_cpu() {
                 changed_prefs.x86_speed_throttle = 0; // Mirroring safety logic? Maybe not needed for x86 but safe.
         }
         AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
+        ShowHelpMarker("x86 CPU speed as a percentage of maximum. Only has an effect when not running at fastest possible speed.");
         ImGui::EndDisabled();
 
         ImGui::Dummy(ImVec2(right_group_min_width, 0.0f));


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix a one-character typo in the Adv. Chipset panel: the tooltip for the
  RF5C01A radio button was showing "RP5C01A", while the button label, the
  RF5C01A_RAM_SIZE constant in rtc.h, and the clock bank name in cia.cpp
  all use "RF5C01A".
- Add missing ShowHelpMarker calls for the PPC Idle and x86 Speed sliders
  in the CPU panel. These were the only two sliders in the panel without
  a tooltip while all neighbouring controls had one.

@midwan