### PR TITLE
fix(jit): x86-64 32-bit address wrapping causes spurious bus errors

### DIFF
--- a/src/jit/x86/codegen_x86.cpp
+++ b/src/jit/x86/codegen_x86.cpp
@@ -814,10 +814,19 @@ LOWFUNC(NONE,READ,3,raw_mov_b_rR,(W1 d, R4 s, IMM offset))
 LOWFUNC(NONE,READ,3,raw_mov_l_brR,(W4 d, R4 s, IMM offset))
 {
 #if X86_TARGET_64BIT
-	/* Use [R_MEMSTART + s + offset] — R_MEMSTART holds natmem_offset.
-	   Caller passes only the accumulated register offset (not MEMBaseDiff)
-	   on x86-64, since R_MEMSTART already provides the natmem base. */
-	MOVLmr(offset, R_MEMSTART, s, 1, d);
+	/* Use LEA+MOV to ensure M68K 32-bit address wrapping.
+	   x86-64 [base + index + disp32] computes in 64-bit, so when the
+	   M68K register + displacement wraps past 32 bits, the host address
+	   is 4GB off.  LEA r32,[r64+disp32] truncates to 32 bits (zeroing
+	   the upper half), giving the correct M68K effective address.
+	   Skip the LEA when offset==0 — the register already holds the
+	   full M68K address and no wrapping is possible. */
+	if (offset != 0) {
+		LEALmr(offset, s, X86_NOREG, 1, d);
+		MOVLmr(0, R_MEMSTART, d, 1, d);
+	} else {
+		MOVLmr(0, R_MEMSTART, s, 1, d);
+	}
 #else
 	ADDR32 MOVLmr(offset, s, X86_NOREG, 1, d);
 #endif
@@ -826,7 +835,13 @@ LOWFUNC(NONE,READ,3,raw_mov_l_brR,(W4 d, R4 s, IMM offset))
 LOWFUNC(NONE,READ,3,raw_mov_w_brR,(W2 d, R4 s, IMM offset))
 {
 #if X86_TARGET_64BIT
-	MOVWmr(offset, R_MEMSTART, s, 1, d);
+	/* See raw_mov_l_brR for the LEA+MOV rationale. */
+	if (offset != 0) {
+		LEALmr(offset, s, X86_NOREG, 1, d);
+		MOVWmr(0, R_MEMSTART, d, 1, d);
+	} else {
+		MOVWmr(0, R_MEMSTART, s, 1, d);
+	}
 #else
 	ADDR32 MOVWmr(offset, s, X86_NOREG, 1, d);
 #endif
@@ -835,7 +850,12 @@ LOWFUNC(NONE,READ,3,raw_mov_w_brR,(W2 d, R4 s, IMM offset))
 LOWFUNC(NONE,READ,3,raw_mov_b_brR,(W1 d, R4 s, IMM offset))
 {
 #if X86_TARGET_64BIT
-	MOVBmr(offset, R_MEMSTART, s, 1, d);
+	if (offset != 0) {
+		LEALmr(offset, s, X86_NOREG, 1, d);
+		MOVBmr(0, R_MEMSTART, d, 1, d);
+	} else {
+		MOVBmr(0, R_MEMSTART, s, 1, d);
+	}
 #else
 	ADDR32 MOVBmr(offset, s, X86_NOREG, 1, d);
 #endif

--- a/src/jit/x86/exception_handler.cpp
+++ b/src/jit/x86/exception_handler.cpp
@@ -544,7 +544,11 @@ static int handle_access(uintptr_t fault_addr, CONTEXT_T context)
 	 * Amiga address itself is always 32-bit. */
 	uintptr_t amiga_addr_wide = fault_addr - (uintptr_t) NATMEM_OFFSET;
 	if (amiga_addr_wide > (uintptr_t) 0xffffffff) {
-		return 0;
+		if (amiga_addr_wide < 0x200000000ULL) {
+			/* Single 32-bit wrap from JIT address computation. */
+		} else {
+			return 0;
+		}
 	}
 #endif
 
@@ -673,10 +677,22 @@ static int handle_access(uintptr_t fault_addr, CONTEXT_T context)
 	/* Compute Amiga address first, then range-check. The host fault address
 	 * can exceed 32-bit when natmem_offset + amiga_addr > 4GB, but the
 	 * Amiga address itself is always 32-bit. Example: natmem at 0x80000000,
-	 * Amiga addr 0x80000004 -> host 0x100000004 (>32-bit on host, valid Amiga). */
+	 * Amiga addr 0x80000004 -> host 0x100000004 (>32-bit on host, valid Amiga).
+	 *
+	 * The x86-64 JIT uses [R_MEMSTART + index + disp32] which computes in
+	 * 64-bit.  When the M68K 32-bit (index + displacement) wraps past 32
+	 * bits, the 64-bit sum is exactly 4GB too high.  The lower 32 bits of
+	 * amiga_addr_wide give the correct M68K address.  Reject addresses that
+	 * are too far out — a single 32-bit wrap can produce at most
+	 * 0xFFFFFFFF + 0x7FFFFFFF = 0x17FFFFFFE. */
 	uintptr_t amiga_addr_wide = fault_addr - (uintptr_t) NATMEM_OFFSET;
 	if (amiga_addr_wide > (uintptr_t) 0xffffffff) {
-		return 0;
+		if (amiga_addr_wide < 0x200000000ULL) {
+			/* Single 32-bit wrap — fall through, addr=(uae_u32) gives the
+			 * correct M68K address via truncation. */
+		} else {
+			return 0;
+		}
 	}
 #endif
 


### PR DESCRIPTION
## Summary

Fixes #2000

The x86-64 JIT generates memory accesses as `[R_MEMSTART + index + disp32]` which computes in 64-bit. When the M68K 32-bit effective address wraps past 32 bits (e.g. `register=0xFFFFFFFC + displacement=0x41583374 = 0x41583370` mod 2³²), the 64-bit sum is 4GB too high (`0x141583370`). This caused `handle_access()` to reject the fault and `comp_catchfault` to deliver a spurious bus error, crashing software like mpega.library.

## Root Cause

On x86-64, 32-bit register writes implicitly zero-extend to 64 bits. When a M68K register holds a value like `0xFFFFFFFC` (-4), the physical register holds `0x00000000FFFFFFFC`. Adding a positive displacement in the SIB addressing mode produces `0x141583370` instead of the correct wrapped `0x41583370` — exactly 4GB off.

## Changes

### `src/jit/x86/codegen_x86.cpp` — Primary fix (reads)
- `raw_mov_l_brR`, `raw_mov_w_brR`, `raw_mov_b_brR`: when `offset != 0`, emit `LEA r32,[r64+disp32]` before `MOV r,[R_MEMSTART + r]`. The LEA truncates to 32 bits (zeroing upper half), giving the correct M68K effective address. When `offset == 0`, emit the original single MOV (no wrapping possible, zero cost).

### `src/jit/x86/exception_handler.cpp` — Safety net (both reads and writes)
- Both `handle_access()` variants (Windows and non-Windows): when `amiga_addr_wide > 0xFFFFFFFF` but `< 0x200000000` (single 32-bit wrap — max possible is `0xFFFFFFFF + 0x7FFFFFFF = 0x17FFFFFFE`), allow the access using the truncated lower 32 bits as the correct M68K address. This catches any remaining wrapping issues including writes.

## Testing

- Linux x86-64 build compiles cleanly
- The fix should be tested with mpega_libmad under AmigaOS on Linux x86-64 with JIT enabled