### PR TITLE
fix(input): hotkey stuck after minimize and hotkey clearing fallback bug

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -326,19 +326,18 @@ amiberry_hotkey get_hotkey_from_config(const std::string& config_option)
 
 static void set_key_configs(const uae_prefs* p)
 {
-	if (strncmp(p->open_gui, "", 1) != 0)
-		// If we have a value in the config, we use that instead
-		enter_gui_key = get_hotkey_from_config(p->open_gui);
-	else
-		// Otherwise we go for the default found in amiberry.conf
-		enter_gui_key = get_hotkey_from_config(amiberry_options.default_open_gui_key);
-	// if nothing was found in amiberry.conf either, we default back to F12
+	// amiberry.conf defaults are already applied via target_default_options()
+	// during config loading, so p->* already contains the system defaults if
+	// the .uae config didn't override them. Always use p->* directly — the
+	// previous fallback to amiberry_options prevented users from clearing
+	// hotkeys (empty string was treated as "not set" and the default was
+	// re-applied, even though the user explicitly cleared it).
+
+	enter_gui_key = get_hotkey_from_config(p->open_gui);
 	if (enter_gui_key.scancode == 0)
 		enter_gui_key.scancode = SDL_SCANCODE_F12;
 
 	enter_gui_button = SDL_GetGamepadButtonFromString(p->open_gui);
-	if (enter_gui_button == SDL_GAMEPAD_BUTTON_INVALID)
-		enter_gui_button = SDL_GetGamepadButtonFromString(amiberry_options.default_open_gui_key);
 #ifdef __ANDROID__
 	// Android: default Start button as pause/GUI toggle for hardware controllers
 	// (no F12 key available, and software back button isn't accessible from gamepads)
@@ -358,22 +357,13 @@ static void set_key_configs(const uae_prefs* p)
 		}
 	}
 	
-	if (strncmp(p->quit_amiberry, "", 1) != 0)
-		quit_key = get_hotkey_from_config(p->quit_amiberry);
-	else
-		quit_key = get_hotkey_from_config(amiberry_options.default_quit_key);
+	quit_key = get_hotkey_from_config(p->quit_amiberry);
 
-	if (strncmp(p->action_replay, "", 1) != 0)
-		action_replay_key = get_hotkey_from_config(p->action_replay);
-	else
-		action_replay_key = get_hotkey_from_config(amiberry_options.default_ar_key);
+	action_replay_key = get_hotkey_from_config(p->action_replay);
 	if (action_replay_key.scancode == 0)
 		action_replay_key.scancode = SDL_SCANCODE_PAUSE;
 
-	if (strncmp(p->fullscreen_toggle, "", 1) != 0)
-		fullscreen_key = get_hotkey_from_config(p->fullscreen_toggle);
-	else
-		fullscreen_key = get_hotkey_from_config(amiberry_options.default_fullscreen_toggle_key);
+	fullscreen_key = get_hotkey_from_config(p->fullscreen_toggle);
 
 	minimize_key = get_hotkey_from_config(p->minimize);
 	left_amiga_key = get_hotkey_from_config(p->left_amiga);
@@ -382,14 +372,9 @@ static void set_key_configs(const uae_prefs* p)
 
 	debugger_key = get_hotkey_from_config(p->debugger_trigger);
 
-	if (strncmp(p->vkbd_toggle, "", 1) != 0)
-		vkbd_key = get_hotkey_from_config(p->vkbd_toggle);
-	else
-		vkbd_key = get_hotkey_from_config(amiberry_options.default_vkbd_toggle);
+	vkbd_key = get_hotkey_from_config(p->vkbd_toggle);
 
 	vkbd_button = SDL_GetGamepadButtonFromString(p->vkbd_toggle);
-	if (vkbd_button == SDL_GAMEPAD_BUTTON_INVALID)
-		vkbd_button = SDL_GetGamepadButtonFromString(amiberry_options.default_vkbd_toggle);
 	if (vkbd_button != SDL_GAMEPAD_BUTTON_INVALID)
 	{
 		for (int port = 0; port < 2; port++)

--- a/src/osdep/keyboard.cpp
+++ b/src/osdep/keyboard.cpp
@@ -422,7 +422,7 @@ bool my_kbd_handler(int keyboard, int scancode, int newstate, bool alwaysrelease
 				&& (enter_gui_key.modifiers.lgui || enter_gui_key.modifiers.rgui) == win_state)
 			{
 				inputdevice_add_inputcode(AKS_ENTERGUI, 1, nullptr);
-				scancode = 0;
+				return true;
 			}
 			
 		}
@@ -435,7 +435,7 @@ bool my_kbd_handler(int keyboard, int scancode, int newstate, bool alwaysrelease
 				&& (action_replay_key.modifiers.lgui || action_replay_key.modifiers.rgui) == win_state)
 			{
 				inputdevice_add_inputcode(AKS_FREEZEBUTTON, 1, nullptr);
-				scancode = 0;
+				return true;
 			}
 		}
 
@@ -447,7 +447,7 @@ bool my_kbd_handler(int keyboard, int scancode, int newstate, bool alwaysrelease
 				&& (fullscreen_key.modifiers.lgui || fullscreen_key.modifiers.rgui) == win_state)
 			{
 				inputdevice_add_inputcode(AKS_TOGGLEWINDOWFULLWINDOW, 1, nullptr);
-				scancode = 0;
+				return true;
 			}
 		}
 
@@ -459,7 +459,7 @@ bool my_kbd_handler(int keyboard, int scancode, int newstate, bool alwaysrelease
 				&& (minimize_key.modifiers.lgui || minimize_key.modifiers.rgui) == win_state)
 			{
 				minimizewindow(0);
-				scancode = 0;
+				return true;
 			}
 		}
 
@@ -471,7 +471,7 @@ bool my_kbd_handler(int keyboard, int scancode, int newstate, bool alwaysrelease
 				&& (vkbd_key.modifiers.lgui || vkbd_key.modifiers.rgui) == win_state)
 			{
 				inputdevice_add_inputcode(AKS_OSK, 1, nullptr);
-				scancode = 0;
+				return true;
 			}
 		}
 
@@ -483,7 +483,7 @@ bool my_kbd_handler(int keyboard, int scancode, int newstate, bool alwaysrelease
 				&& (screenshot_key.modifiers.lgui || screenshot_key.modifiers.rgui) == win_state)
 			{
 				inputdevice_add_inputcode(AKS_SCREENSHOT_FILE, 1, nullptr);
-				scancode = 0;
+				return true;
 			}
 		}
 
@@ -495,7 +495,7 @@ bool my_kbd_handler(int keyboard, int scancode, int newstate, bool alwaysrelease
 				&& (debugger_key.modifiers.lgui || debugger_key.modifiers.rgui) == win_state)
 			{
 				inputdevice_add_inputcode(AKS_ENTERDEBUGGER, 1, nullptr);
-				scancode = 0;
+				return true;
 			}
 		}
 


### PR DESCRIPTION
## Summary

Fixes #2013

Two related hotkey bugs:

1. **Minimize hotkey causes stuck key repeat**: All hotkey handlers in `my_kbd_handler()` set `scancode = 0` to suppress the key, but the original scancode was restored later at line 575 (`scancode = scancode_new`), causing the key-down to leak into the Amiga emulation anyway. For the minimize hotkey specifically, F11→backslash was sent to the Amiga, the window minimized before key-up arrived, and on restore the Amiga thought backslash was held down. Fixed by making all hotkey handlers `return true` immediately (matching the existing `quit_key` pattern).

2. **Clearing a hotkey falls back to amiberry.conf default**: `set_key_configs()` used `amiberry_options.default_*` as fallback when the prefs string was empty. But `target_default_options()` already copies those defaults into the prefs struct during config loading, so the fallback was redundant. Worse, it prevented users from actually disabling a hotkey — setting it to empty in the GUI was treated as "not set" and the default was re-applied. This caused conflicting hotkeys (e.g., cleared `quit_key=F11` still triggered quit instead of `minimize_key=F11`). Fixed by removing all `amiberry_options` fallback branches.

## Testing

- Verified both bugs with manual testing on Linux
- Minimize hotkey (F11) no longer spams backslash after restore
- Cleared quit key now stays cleared; minimize key takes precedence correctly
- Clean build with no regressions