### PR TITLE
Windows ARM64 stabilisation, installer, and release-pipeline integration (#1991)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1077,9 +1077,12 @@ jobs:
 
   # Windows ARM64 bring-up: native build on the GitHub-hosted
   # windows-11-arm runner using llvm-mingw. Kept separate
-  # from build-windows because the toolchain and shell differ. Non-blocking
-  # during shakeout (continue-on-error: true) and intentionally NOT in the
-  # create-release job's needs list — promote once stable.
+  # from build-windows because the toolchain and shell differ.  Still
+  # non-blocking during shakeout (continue-on-error: true); listed as a
+  # create-release dependency so tagged releases can pick up the ARM64
+  # installer/ZIP when the job succeeds, but a failed ARM64 job does
+  # not block the release (continue-on-error lets the downstream job
+  # proceed regardless of conclusion).
   build-windows-arm64:
     runs-on: windows-11-arm
     timeout-minutes: 90
@@ -1524,7 +1527,7 @@ jobs:
           path: amiberry/libretro/amiberry_libretro.info
 
   create-release:
-    needs: [merge-macOS-universal, build-fedora, build-ubuntu, build-debian-amd64, build-debian-arm64, build-windows, build-libretro]
+    needs: [merge-macOS-universal, build-fedora, build-ubuntu, build-debian-amd64, build-debian-arm64, build-windows, build-windows-arm64, build-libretro]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: github.ref_type == 'tag' && (startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'preview-v'))

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1087,6 +1087,13 @@ jobs:
     permissions:
       contents: read
       actions: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: arm64
+            artifact_name: amiberry-windows-arm64
+            release_suffix: windows-arm64
     env:
       LLVM_MINGW_TAG: "20250910"
       LLVM_MINGW_FLAVOR: "ucrt-aarch64"
@@ -1219,11 +1226,184 @@ jobs:
           }
           Write-Host "ARM64 Amiberry.exe ran --jit-selftest successfully."
 
-      - name: Upload artifact
+      - name: Ensure InnoSetup is available
+        shell: pwsh
+        run: |
+          # InnoSetup ships as an x86 binary; it runs under WoA x86 emulation
+          # on windows-11-arm runners.  If ISCC is already on PATH (e.g. via
+          # a future preinstall), use it; otherwise install via Chocolatey.
+          $iscc = Get-Command iscc.exe -ErrorAction SilentlyContinue
+          if ($iscc) {
+            Write-Host "ISCC already available at $($iscc.Source)"
+          } else {
+            Write-Host "ISCC not found, installing InnoSetup via Chocolatey..."
+            # Chocolatey is preinstalled on all GitHub-hosted Windows runners.
+            choco install innosetup --no-progress --yes | Out-Null
+            # Chocolatey shims go to C:\ProgramData\chocolatey\bin which is
+            # already on PATH; verify ISCC is reachable.
+            $iscc = Get-Command iscc.exe -ErrorAction SilentlyContinue
+            if (-not $iscc) {
+              # Fallback: add the standard install dir explicitly.
+              $programFiles = ${env:ProgramFiles(x86)}
+              $fallback = Join-Path $programFiles "Inno Setup 6"
+              if (Test-Path $fallback) {
+                "$fallback" | Out-File -FilePath $env:GITHUB_PATH -Append
+                Write-Host "Added $fallback to PATH"
+              } else {
+                throw "InnoSetup install succeeded but ISCC not found on PATH or in $fallback."
+              }
+            }
+          }
+
+      - name: Package (InnoSetup)
+        shell: pwsh
+        run: |
+          cpack -G INNOSETUP --config out/build/windows-arm64-release/CPackConfig.cmake
+
+      - name: Detect SignPath configuration
+        id: signpath-config
+        shell: pwsh
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+          SIGNPATH_ORGANIZATION_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          SIGNPATH_PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          SIGNPATH_SIGNING_POLICY_SLUG: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+        run: |
+          if ($env:GITHUB_EVENT_NAME -eq "pull_request") {
+            "enabled=false" >> $env:GITHUB_OUTPUT
+            Write-Host "SignPath disabled for pull_request events."
+            exit 0
+          }
+
+          $required = @{
+            SIGNPATH_API_TOKEN = $env:SIGNPATH_API_TOKEN
+            SIGNPATH_ORGANIZATION_ID = $env:SIGNPATH_ORGANIZATION_ID
+            SIGNPATH_PROJECT_SLUG = $env:SIGNPATH_PROJECT_SLUG
+            SIGNPATH_SIGNING_POLICY_SLUG = $env:SIGNPATH_SIGNING_POLICY_SLUG
+            SIGNPATH_ARTIFACT_CONFIGURATION_SLUG = $env:SIGNPATH_ARTIFACT_CONFIGURATION_SLUG
+          }
+          $missing = @(
+            $required.GetEnumerator() |
+            Where-Object { [string]::IsNullOrWhiteSpace($_.Value) } |
+            ForEach-Object { $_.Key } |
+            Sort-Object
+          )
+
+          if ($missing.Count -gt 0) {
+            "enabled=false" >> $env:GITHUB_OUTPUT
+            Write-Host "SignPath disabled because the following settings are missing: $($missing -join ', ')"
+            exit 0
+          }
+
+          "enabled=true" >> $env:GITHUB_OUTPUT
+          Write-Host "SignPath enabled for this run."
+
+      - name: Upload unsigned Windows artifacts for SignPath
+        if: steps.signpath-config.outputs.enabled == 'true'
+        id: signpath-unsigned
         uses: actions/upload-artifact@v6
         with:
-          name: amiberry-windows-arm64
-          path: amiberry-*-windows-arm64-portable.zip
+          name: ${{ matrix.artifact_name }}-signpath-unsigned
+          path: |
+            amiberry-*.zip
+            amiberry-*.exe
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+      - name: Submit SignPath signing request
+        if: steps.signpath-config.outputs.enabled == 'true'
+        id: signpath
+        uses: SignPath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.signpath-unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          wait-for-completion-timeout-in-seconds: 1200
+          output-artifact-directory: signpath-signed
+
+      - name: Replace unsigned artifacts with signed outputs
+        if: steps.signpath-config.outputs.enabled == 'true'
+        shell: pwsh
+        run: |
+          $downloadDir = Join-Path $PWD "signpath-signed"
+          if (-not (Test-Path $downloadDir)) {
+            throw "Signed artifact directory '$downloadDir' was not created."
+          }
+
+          $portableZip = Get-ChildItem $downloadDir -Recurse -File -Filter "amiberry-*-portable.zip" | Select-Object -First 1
+          if (-not $portableZip) {
+            throw "Signed portable ZIP was not found in '$downloadDir'."
+          }
+
+          $installer = Get-ChildItem $downloadDir -Recurse -File -Filter "amiberry-*.exe" | Select-Object -First 1
+          if (-not $installer) {
+            throw "Signed installer EXE was not found in '$downloadDir'."
+          }
+
+          Copy-Item $portableZip.FullName $PWD -Force
+          Copy-Item $installer.FullName $PWD -Force
+          Write-Host "Replaced workspace artifacts with SignPath-signed outputs."
+
+      - name: Verify SignPath-signed artifacts
+        if: steps.signpath-config.outputs.enabled == 'true'
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem "$PWD/amiberry-*.exe" | Select-Object -First 1
+          if (-not $installer) {
+            throw "Signed installer EXE not found in workspace."
+          }
+
+          $installerSignature = Get-AuthenticodeSignature $installer.FullName
+          if ($installerSignature.Status -eq "NotSigned" -or -not $installerSignature.SignerCertificate) {
+            throw "Installer EXE is missing an Authenticode signature."
+          }
+          Write-Host "Installer EXE signature status: $($installerSignature.Status)"
+
+          $portableZip = Get-ChildItem "$PWD/amiberry-*-windows-arm64-portable.zip" | Select-Object -First 1
+          if (-not $portableZip) {
+            throw "Signed portable ZIP not found in workspace."
+          }
+
+          $verifyRoot = Join-Path $PWD "portable-signed-smoke"
+          Remove-Item -Recurse -Force $verifyRoot -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $verifyRoot | Out-Null
+          Expand-Archive -Path $portableZip.FullName -DestinationPath $verifyRoot
+
+          $portableExe = Get-ChildItem $verifyRoot -Recurse -File -Filter "Amiberry.exe" | Select-Object -First 1
+          if (-not $portableExe) {
+            throw "Portable ZIP is missing Amiberry.exe after SignPath signing."
+          }
+
+          $portableSignature = Get-AuthenticodeSignature $portableExe.FullName
+          if ($portableSignature.Status -eq "NotSigned" -or -not $portableSignature.SignerCertificate) {
+            throw "Portable ZIP Amiberry.exe is missing an Authenticode signature."
+          }
+          Write-Host "Portable EXE signature status: $($portableSignature.Status)"
+
+      - name: Upload artifact
+        if: github.ref_type != 'tag'
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: |
+            amiberry-*.zip
+            amiberry-*.exe
+          retention-days: 7
+
+      - name: Upload artifact for release
+        if: github.ref_type == 'tag'
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: |
+            amiberry-*.zip
+            amiberry-*.exe
           retention-days: 7
 
   build-libretro:

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ brew install --cask amiberry
 
 ### Windows
 
-Download the [installer or portable ZIP](https://github.com/BlitterStudio/amiberry/releases/latest).
-The portable ZIP includes the `amiberry.portable` marker, so writable paths stay next to `Amiberry.exe` without extra setup.
+Download the [installer or portable ZIP](https://github.com/BlitterStudio/amiberry/releases/latest).  x64 and ARM64 (Windows-on-ARM / Snapdragon X, Copilot+) builds are both published.  The portable ZIP includes the `amiberry.portable` marker, so writable paths stay next to `Amiberry.exe` without extra setup.
+
+> **Windows ARM64 in a VM (VMware Fusion / Parallels / Hyper-V):** the guest usually has no OpenGL ICD installed, so Amiberry's GL init fails at startup.  Drop Mesa3D's `opengl32.dll` (`mesa-llvmpipe-arm64` from [mmozeiko/build-mesa](https://github.com/mmozeiko/build-mesa/releases)) next to `Amiberry.exe` — that gives you software OpenGL 3.3+ and the GUI comes up.  Native WoA hardware doesn't need this workaround.
 
 ### Android
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -152,11 +152,14 @@ sudo apt install amiberry</code></pre>
 
   <div class="platform-card windows">
     <h3>🪟 Windows</h3>
-    <p>Download from <a href="https://github.com/BlitterStudio/amiberry/releases/latest">Releases</a>:</p>
+    <p>Download from <a href="https://github.com/BlitterStudio/amiberry/releases/latest">Releases</a>. Both <strong>x64</strong> and <strong>ARM64</strong> (Windows-on-ARM / Snapdragon&nbsp;X, Copilot+) builds are published:</p>
     <ul>
-      <li><strong>Installer</strong> — run the <code>.exe</code> installer for a guided setup</li>
+      <li><strong>Installer</strong> — run the <code>.exe</code> installer for a guided setup (pick the one matching your CPU)</li>
       <li><strong>Portable ZIP</strong> — extract the <code>*-portable.zip</code> archive and run <code>Amiberry.exe</code>; it already includes the <code>amiberry.portable</code> marker</li>
     </ul>
+    <p class="platform-alt">
+      Running ARM64 in a VM (VMware Fusion / Parallels / Hyper-V)?  Drop <code>opengl32.dll</code> from <a href="https://github.com/mmozeiko/build-mesa/releases"><code>mesa-llvmpipe-arm64</code></a> next to <code>Amiberry.exe</code> so the GUI can start — guest VMs typically lack an OpenGL ICD.
+    </p>
   </div>
 
   <div class="platform-card android">

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -171,15 +171,24 @@ elseif (WIN32)
 	set(CPACK_PACKAGE_INSTALL_DIRECTORY "${CPACK_PACKAGE_NAME}")
 	if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
 		set(CPACK_INNOSETUP_ARCHITECTURE arm64)
+		set(_innosetup_arch_suffix "arm64")
 	elseif (CMAKE_SIZEOF_VOID_P EQUAL 8)
 		set(CPACK_INNOSETUP_ARCHITECTURE x64)
 		# Allow the x64 installer to run on Windows 11 ARM64 under x64
 		# emulation. Plain "x64" excludes ARM64 machines.
 		set(CPACK_INNOSETUP_SETUP_ArchitecturesAllowed "x64compatible")
 		set(CPACK_INNOSETUP_SETUP_ArchitecturesInstallIn64BitMode "x64compatible")
+		set(_innosetup_arch_suffix "win64")
 	else()
 		set(CPACK_INNOSETUP_ARCHITECTURE x86)
+		set(_innosetup_arch_suffix "win32")
 	endif()
+	# Override CPack's default "<name>-<version>-win64.exe" so the ARM64
+	# installer doesn't get the misleading win64 suffix when produced on
+	# the same packaging code path.  Matches the portable-ZIP naming
+	# convention used by the CI workflow (windows-arm64 / windows-x64).
+	set(CPACK_PACKAGE_FILE_NAME
+		"${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${_innosetup_arch_suffix}")
     set(CPACK_INNOSETUP_SETUP_PrivilegesRequired "lowest")
     set(CPACK_INNOSETUP_SETUP_PrivilegesRequiredOverridesAllowed "dialog")
     # {autopf} expands to Program Files when the user elevates via the

--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -3024,6 +3024,8 @@ STATIC_INLINE void create_popalls(void)
         const uint32 cache_kb = currprefs.cachesize > 0 ? currprefs.cachesize : MAX_JIT_CACHE;
         const size_t cache_bytes = (size_t)cache_kb * 1024;
         const size_t combined_size = POPALLSPACE_SIZE + cache_bytes;
+        jit_log("ARM64: allocating popallspace+cache (cache=%u KB, total=%zu bytes)",
+            cache_kb, combined_size);
         popallspace = alloc_code(combined_size);
         if (popallspace) {
             popall_combined_alloc_size = combined_size;
@@ -3036,6 +3038,8 @@ STATIC_INLINE void create_popalls(void)
             popall_combined_alloc_size = 0;
             popall_combined_cache_start = NULL;
             popall_combined_cache_kb = 0;
+            jit_log("ARM64: combined popallspace+cache allocation failed; retrying popallspace-only (%u bytes)",
+                (unsigned)POPALLSPACE_SIZE);
             popallspace = alloc_code(POPALLSPACE_SIZE);
         }
         if (popallspace == NULL) {
@@ -3045,7 +3049,17 @@ STATIC_INLINE void create_popalls(void)
             jit_log("WARNING: Could not allocate popallspace!");
             if (currprefs.cachesize > 0)
             {
+#if defined(_WIN32) && defined(CPU_AARCH64)
+                /* Windows ARM64: RWX allocations can be denied by VBS/HVCI or
+                 * similar security policies (commonly seen in VMware WoA VMs).
+                 * Rather than jit_abort() (which kills the process), log
+                 * clearly and fall back to the interpreter — the caller will
+                 * call disable_jit_runtime() on our NULL pushall_call_handler. */
+                jit_log("ARM64: Windows RWX allocation denied — disabling JIT. "
+                    "Check VBS/HVCI/Arbitrary Code Guard policy in the VM.");
+#else
                 jit_abort("Could not allocate popallspace!");
+#endif
             }
             /* This is not fatal if JIT is not used. If JIT is
              * turned on, it will crash, but it would have crashed

--- a/src/newcpu.cpp
+++ b/src/newcpu.cpp
@@ -5808,6 +5808,18 @@ static int cpu_thread_run_jit(void *v)
 
 static void m68k_run_jit(void)
 {
+	/* Guard against a silent JIT init failure: calling a NULL
+	 * pushall_call_handler would crash at host PC=0.  Turn the cache
+	 * off and fall back to the interpreter on the next scheduler pass
+	 * instead.  Must run before the cpu_thread dispatch below. */
+	if (pushall_call_handler == NULL) {
+		write_log(_T("JIT: pushall_call_handler is NULL; disabling JIT and falling back to interpreter.\n"));
+		currprefs.cachesize = 0;
+		changed_prefs.cachesize = 0;
+		set_special(SPCFLAG_BRK);
+		return;
+	}
+
 #ifdef WITH_THREADED_CPU
 	if (currprefs.cpu_thread) {
 		run_cpu_thread(cpu_thread_run_jit);

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -1149,8 +1149,17 @@ bool doInit(AmigaMonitor* mon)
 
 					if (!create_windows(mon))
 					{
-						close_hwnds(mon, false);
-						return false;
+						/* SDL_CreateWindow can fail at this point with "No
+						 * matching GL pixel format available" when the GL
+						 * driver doesn't expose a pixel format compatible
+						 * with the attributes we just set (seen with Mesa
+						 * d3d12 on Windows ARM64 VMs).  Treat it as a
+						 * context-mode failure and retry with the next
+						 * mode rather than aborting the whole init. */
+						write_log("Window creation failed for renderer mode %d on monitor %d. Retrying with next mode...\n",
+							ctx_attempts, mon->monitor_id);
+						ctx_attempts++;
+						continue;
 					}
 
 					renderer = get_renderer(mon->monitor_id);
@@ -1375,7 +1384,13 @@ bool doInit(AmigaMonitor* mon)
 
 	// Sensible defaults.
 	success &= SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-	success &= SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 16);
+	/* Amiberry never uses the depth or stencil buffer (the renderer does
+	 * glDisable(GL_DEPTH_TEST) / glDisable(GL_STENCIL_TEST) at startup),
+	 * so request none of either.  Asking for DEPTH_SIZE>=16 narrowed the
+	 * set of compatible pixel formats and broke window creation on
+	 * Mesa3D's d3d12 backend in Windows ARM64 VMs ("No matching GL pixel
+	 * format available"). */
+	success &= SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0);
 	success &= SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 0);
 
 	// Optional: request RGBA8

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -1148,6 +1148,24 @@ bool doInit(AmigaMonitor* mon)
 				 * (e.g. Mesa3D d3d12 on Windows ARM64 VMs). */
 				constexpr int max_ctx_modes = 4;
 				while (ctx_attempts < max_ctx_modes && !ctx_success) {
+					/* Refresh the renderer pointer at the top of every
+					 * iteration.  A previous failed create_windows() may
+					 * have called close_hwnds() — which resets
+					 * mon->renderer for secondary monitors (monitor_id > 0)
+					 * — leaving any cached pointer dangling.  Re-fetching
+					 * here also lets the OpenGL attribute calls below
+					 * apply to the right (or freshly recreated) renderer.
+					 * SDL GL attributes are process-global so even the
+					 * fallback to g_renderer is safe — the attributes
+					 * affect the next SDL_CreateWindow regardless of
+					 * which IRenderer instance is used to set them. */
+					renderer = get_renderer(mon->monitor_id);
+					if (!renderer) {
+						write_log("No renderer available for monitor %d after retry; aborting doInit.\n",
+							mon->monitor_id);
+						return false;
+					}
+
 					if (!renderer->set_context_attributes(ctx_attempts))
 					{
 						write_log("Failed to set context attributes for mode %d\n", ctx_attempts);
@@ -1170,7 +1188,15 @@ bool doInit(AmigaMonitor* mon)
 						continue;
 					}
 
+					/* Re-fetch the renderer because create_windows() can
+					 * recreate mon->renderer for secondary monitors when
+					 * the previous one was reset. */
 					renderer = get_renderer(mon->monitor_id);
+					if (!renderer) {
+						write_log("Renderer disappeared for monitor %d after window creation; aborting doInit.\n",
+							mon->monitor_id);
+						return false;
+					}
 
 					renderer->destroy_shaders();
 					renderer->destroy_context();

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -1139,7 +1139,15 @@ bool doInit(AmigaMonitor* mon)
 				int ctx_attempts = 0;
 				bool ctx_success = false;
 
-				while (ctx_attempts < 2 && !ctx_success) {
+				/* Modes 0..3:
+				 *   0 = preferred  : GL 3.3 Core, RGBA8, no depth/stencil
+				 *   1 = legacy     : GL 2.1 Compat, RGBA8, no depth/stencil
+				 *   2 = minimal-3.3: GL 3.3 Core, only DOUBLEBUFFER set
+				 *   3 = minimal-2.1: GL 2.1 Compat, only DOUBLEBUFFER set
+				 * Modes 2/3 exist for drivers with a narrow pixel-format set
+				 * (e.g. Mesa3D d3d12 on Windows ARM64 VMs). */
+				constexpr int max_ctx_modes = 4;
+				while (ctx_attempts < max_ctx_modes && !ctx_success) {
 					if (!renderer->set_context_attributes(ctx_attempts))
 					{
 						write_log("Failed to set context attributes for mode %d\n", ctx_attempts);
@@ -1355,49 +1363,58 @@ bool doInit(AmigaMonitor* mon)
 	const bool likely_gles_only = (drv && (strcmp(drv, "KMSDRM") == 0));
 #endif
 
-	if (mode == 0) {
-		if (likely_gles_only) {
-			// GLES-only systems (e.g., Raspberry Pi with KMSDRM): Try GLES 3.0
-			write_log(_T("Requesting OpenGL ES 3.0 context (GLES-only driver detected)...\n"));
-			success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
-			success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-			success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
-		} else {
-			// Desktop OpenGL (x86, x86_64, ARM desktops, macOS): Try Core Profile 3.3
-			write_log(_T("Requesting OpenGL 3.3 Core context...\n"));
-			success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-			success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-			success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
-#ifdef AMIBERRY_MACOS
-			// macOS requires the forward-compatible flag for OpenGL 3.2+ Core Profile
-			success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
-#endif
-		}
-	} else {
-		// Fallback: Legacy OpenGL 2.1 Compatibility
-		write_log(_T("Requesting OpenGL 2.1 Compatibility context...\n"));
+	/* Mode 0 / 1 -> request a GL 3.3 Core context with sensible RGBA8
+	 * pixel-format hints.  Mode 2 / 3 -> retry with the bare minimum
+	 * (just the GL version + DOUBLEBUFFER), so a driver with a narrow
+	 * pixel-format set (e.g. Mesa3D d3d12 on Windows ARM64 VMs, which
+	 * does not expose a format with the 16-bit depth / RGBA8 / alpha
+	 * combination SDL would otherwise enforce) still has a chance. */
+	const bool minimal_attrs = (mode >= 2);
+	const bool legacy_profile = (mode == 1) || (mode == 3);
+
+	if (legacy_profile) {
+		write_log(_T("Requesting OpenGL 2.1 Compatibility context (mode=%d, minimal=%d)...\n"),
+			mode, minimal_attrs ? 1 : 0);
 		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, 0);
 		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
 		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
 		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+	} else if (likely_gles_only) {
+		// GLES-only systems (e.g., Raspberry Pi with KMSDRM): Try GLES 3.0
+		write_log(_T("Requesting OpenGL ES 3.0 context (GLES-only driver detected, mode=%d, minimal=%d)...\n"),
+			mode, minimal_attrs ? 1 : 0);
+		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+	} else {
+		// Desktop OpenGL (x86, x86_64, ARM desktops, macOS): Try Core Profile 3.3
+		write_log(_T("Requesting OpenGL 3.3 Core context (mode=%d, minimal=%d)...\n"),
+			mode, minimal_attrs ? 1 : 0);
+		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+#ifdef AMIBERRY_MACOS
+		// macOS requires the forward-compatible flag for OpenGL 3.2+ Core Profile
+		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
+#endif
 	}
 
-	// Sensible defaults.
+	/* Always request DOUBLEBUFFER so the GL renderer can present without
+	 * tearing.  Amiberry never uses the depth or stencil buffer
+	 * (opengl_renderer / shader_preset call glDisable(GL_DEPTH_TEST) and
+	 * glDisable(GL_STENCIL_TEST) at startup), so request none. */
 	success &= SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-	/* Amiberry never uses the depth or stencil buffer (the renderer does
-	 * glDisable(GL_DEPTH_TEST) / glDisable(GL_STENCIL_TEST) at startup),
-	 * so request none of either.  Asking for DEPTH_SIZE>=16 narrowed the
-	 * set of compatible pixel formats and broke window creation on
-	 * Mesa3D's d3d12 backend in Windows ARM64 VMs ("No matching GL pixel
-	 * format available"). */
 	success &= SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0);
 	success &= SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 0);
 
-	// Optional: request RGBA8
-	success &= SDL_GL_SetAttribute(SDL_GL_RED_SIZE,   8);
-	success &= SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
-	success &= SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE,  8);
-	success &= SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+	if (!minimal_attrs) {
+		// Optional: request RGBA8 (skipped on minimal mode for VM-friendly
+		// drivers like Mesa3D d3d12 that may only expose RGBX/RGB10A2 etc.)
+		success &= SDL_GL_SetAttribute(SDL_GL_RED_SIZE,   8);
+		success &= SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
+		success &= SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE,  8);
+		success &= SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+	}
 
 	return success;
 }

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -1189,6 +1189,14 @@ bool doInit(AmigaMonitor* mon)
 
 				if (!ctx_success) {
 					write_log("All renderer context attempts failed for monitor %d. Aborting doInit.\n", mon->monitor_id);
+#if defined(_WIN32)
+					write_log("HINT: If running inside a VM (VMware/Parallels/Hyper-V) without an OpenGL ICD,\n");
+					write_log("HINT: try the Mesa3D 'llvmpipe' build (mesa-llvmpipe-arm64 from\n");
+					write_log("HINT: https://github.com/mmozeiko/build-mesa/releases) — drop opengl32.dll\n");
+					write_log("HINT: next to Amiberry.exe.  llvmpipe is software-only but exposes a\n");
+					write_log("HINT: standard pixel-format set that SDL accepts; mesa-d3d12 trades that\n");
+					write_log("HINT: for hardware acceleration but exposes a much narrower format set.\n");
+#endif
 					return false;
 				}
 			}

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -122,13 +122,23 @@ bool OpenGLRenderer::init_context(SDL_Window* window)
 	// Load OpenGL extension functions (does nothing on Android/GLES3)
 	if (!gl_platform_init()) {
 		const GLubyte* ver = glGetString(GL_VERSION);
-		if (!ver) {
-			write_log(_T("!!! glGetString(GL_VERSION) is null; failing OpenGL init.\n"));
-			SDL_GL_DestroyContext(m_gl_context);
-			m_gl_context = nullptr;
-			return false;
-		}
-		write_log(_T("!!! OpenGL version: %hs\n"), ver);
+		const GLubyte* ren = glGetString(GL_RENDERER);
+		write_log(_T("!!! OpenGL extension loading failed (version=%hs renderer=%hs); "
+			"the host GL driver is too old (shaders/VBO/VAO required).\n"),
+			ver ? reinterpret_cast<const char*>(ver) : "<null>",
+			ren ? reinterpret_cast<const char*>(ren) : "<null>");
+#if defined(_WIN32)
+		write_log(_T("!!! On Windows this usually means the default \"GDI Generic\" "
+			"software OpenGL 1.1 implementation is being used (common in VMs without "
+			"GPU passthrough).  Install Mesa3D or use a hardware-accelerated GPU.\n"));
+#endif
+		/* gl_platform_init() failing leaves shader/VBO/VAO function pointers
+		 * NULL.  Continuing would crash later on the first draw call, so abort
+		 * GL context creation here and let the caller decide (either fall back
+		 * to the SDL renderer or exit cleanly). */
+		SDL_GL_DestroyContext(m_gl_context);
+		m_gl_context = nullptr;
+		return false;
 	}
 
 	const char* renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));

--- a/src/osdep/sigsegv_handler.cpp
+++ b/src/osdep/sigsegv_handler.cpp
@@ -449,12 +449,61 @@ static LONG WINAPI windows_arm64_jit_unhandled_exception_filter(PEXCEPTION_POINT
 		write_log(_T("JIT: Windows ARM64 unhandled AV type=%s target=%p natmem=%p amiga=%08x\n"),
 			windows_arm64_av_type(er->ExceptionInformation[0]), reinterpret_cast<void*>(fault_addr),
 			natmem_offset, natmem_offset ? static_cast<uaecptr>(fault_addr - reinterpret_cast<uintptr>(natmem_offset)) : 0);
+		/* Flag the classic "32-bit value with bit 31 set sign-extended
+		 * to 64-bit" pattern so we can correlate future reports with
+		 * natmem-placement regressions. */
+		if ((fault_addr >> 32) == 0xFFFFFFFFu) {
+			write_log(_T("JIT: Windows ARM64 fault target looks sign-extended (upper32=FFFFFFFF)\n"));
+		}
 	}
 	write_log(_T("JIT: Windows ARM64 ranges compiled=%p current=%p popall=%p-%p M68K PC=%08x pc_p=%p spcflags=%08x\n"),
 		compiled_code, current_compile_p, popallspace, popallspace ? popallspace + POPALLSPACE_SIZE : nullptr,
 		static_cast<uae_u32>(M68K_GETPC), regs.pc_p, regs.spcflags);
-	if (windows_arm64_jit_pc(fault_pc)) {
-		write_log(_T("JIT: Windows ARM64 instruction at PC=%08x\n"), *reinterpret_cast<uae_u32*>(fault_pc));
+	/* Dump X0..X30, SP, LR so we can inspect which register held the bad
+	 * effective-address base when the fault hit.  Grouped four per line to
+	 * keep the log readable. */
+	write_log(_T("JIT: Windows ARM64 X0=%016llx  X1=%016llx  X2=%016llx  X3=%016llx\n"),
+		(unsigned long long)ctx->X[0], (unsigned long long)ctx->X[1],
+		(unsigned long long)ctx->X[2], (unsigned long long)ctx->X[3]);
+	write_log(_T("JIT: Windows ARM64 X4=%016llx  X5=%016llx  X6=%016llx  X7=%016llx\n"),
+		(unsigned long long)ctx->X[4], (unsigned long long)ctx->X[5],
+		(unsigned long long)ctx->X[6], (unsigned long long)ctx->X[7]);
+	write_log(_T("JIT: Windows ARM64 X8=%016llx  X9=%016llx X10=%016llx X11=%016llx\n"),
+		(unsigned long long)ctx->X[8], (unsigned long long)ctx->X[9],
+		(unsigned long long)ctx->X[10], (unsigned long long)ctx->X[11]);
+	write_log(_T("JIT: Windows ARM64 X12=%016llx X13=%016llx X14=%016llx X15=%016llx\n"),
+		(unsigned long long)ctx->X[12], (unsigned long long)ctx->X[13],
+		(unsigned long long)ctx->X[14], (unsigned long long)ctx->X[15]);
+	write_log(_T("JIT: Windows ARM64 X16=%016llx X17=%016llx X18=%016llx X19=%016llx\n"),
+		(unsigned long long)ctx->X[16], (unsigned long long)ctx->X[17],
+		(unsigned long long)ctx->X[18], (unsigned long long)ctx->X[19]);
+	write_log(_T("JIT: Windows ARM64 X20=%016llx X21=%016llx X22=%016llx X23=%016llx\n"),
+		(unsigned long long)ctx->X[20], (unsigned long long)ctx->X[21],
+		(unsigned long long)ctx->X[22], (unsigned long long)ctx->X[23]);
+	write_log(_T("JIT: Windows ARM64 X24=%016llx X25=%016llx X26=%016llx X27=%016llx\n"),
+		(unsigned long long)ctx->X[24], (unsigned long long)ctx->X[25],
+		(unsigned long long)ctx->X[26], (unsigned long long)ctx->X[27]);
+	write_log(_T("JIT: Windows ARM64 X28=%016llx X29=%016llx LR=%016llx  SP=%016llx\n"),
+		(unsigned long long)ctx->X[28], (unsigned long long)ctx->X[29],
+		(unsigned long long)ctx->Lr, (unsigned long long)ctx->Sp);
+	/* Print the faulting instruction regardless of whether the PC is in
+	 * the JIT cache or in the main executable.  Probe the page with
+	 * VirtualQuery before the read so a nested fault while logging the
+	 * primary fault does not tear down the process. */
+	MEMORY_BASIC_INFORMATION mbi{};
+	bool pc_readable = false;
+	if (VirtualQuery(reinterpret_cast<LPCVOID>(fault_pc), &mbi, sizeof(mbi)) == sizeof(mbi)) {
+		const DWORD mask = PAGE_READONLY | PAGE_READWRITE | PAGE_EXECUTE_READ |
+			PAGE_EXECUTE_READWRITE | PAGE_WRITECOPY | PAGE_EXECUTE_WRITECOPY;
+		pc_readable = (mbi.State == MEM_COMMIT) && ((mbi.Protect & mask) != 0) &&
+			((mbi.Protect & PAGE_GUARD) == 0) && ((mbi.Protect & PAGE_NOACCESS) == 0);
+	}
+	if (pc_readable) {
+		const uae_u32 insn = *reinterpret_cast<const uae_u32*>(fault_pc);
+		write_log(_T("JIT: Windows ARM64 instruction at PC insn=%08x jit=%d\n"),
+			insn, windows_arm64_jit_pc(fault_pc) ? 1 : 0);
+	} else {
+		write_log(_T("JIT: Windows ARM64 could not read instruction at fault PC\n"));
 	}
 	return EXCEPTION_CONTINUE_SEARCH;
 }

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -229,6 +229,18 @@ static void *uae_vm_alloc_with_flags(size_t size, int flags, int protect)
 	}
 
 	if (address == NULL) {
+#ifdef _WIN32
+		const DWORD win_err = GetLastError();
+		write_log("VM: uae_vm_alloc(%zu, %d, %d) VirtualAlloc failed (GetLastError=%lu)\n",
+			size, flags, protect, (unsigned long)win_err);
+#if defined(CPU_AARCH64)
+		if (protect == UAE_VM_READ_WRITE_EXECUTE) {
+			write_log("VM: Windows ARM64 RWX allocation denied — likely blocked by "
+				"Virtualization-based Security (VBS) / Hypervisor-protected Code "
+				"Integrity (HVCI) or Arbitrary Code Guard in this VM/host.\n");
+		}
+#endif
+#else
 		const int err = errno;
 		if (flags & UAE_VM_JIT) {
 #if defined(__APPLE__) && defined(CPU_AARCH64)
@@ -251,6 +263,7 @@ static void *uae_vm_alloc_with_flags(size_t size, int flags, int protect)
 			}
 #endif
 		}
+#endif
 	    return NULL;
 	}
 #ifdef TRACK_ALLOCATIONS

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -396,7 +396,24 @@ void *uae_vm_reserve(size_t size, int flags)
 {
 	void *address = NULL;
 #ifdef _WIN32
+#if defined(CPU_AARCH64)
+	/* Windows ARM64: prefer an above-4GB natmem base so the low 32 bits of
+	 * every natmem-derived host pointer have bit 31 clear.  Mixing natmem
+	 * at 0x80000000 with ARM64 SXTW (sign-extend word) used in JIT branch
+	 * displacement handling turns a 32-bit value with bit 31 set (e.g.
+	 * 0x80F81EC8) into a 0xFFFFFFFF-prefixed kernel-space address.  macOS
+	 * ARM64 already benefits from this because the kernel allocates
+	 * natmem above 4GB; match that layout explicitly on WoA so the JIT
+	 * has the same pointer shape on both platforms. */
+	if ((flags & UAE_VM_32BIT) == 0) {
+		address = try_reserve(0x100000000ULL, size, flags);
+	}
+	if (address == NULL) {
+		address = try_reserve(0x80000000, size, flags);
+	}
+#else
 	address = try_reserve(0x80000000, size, flags);
+#endif
 	if (address == NULL && (flags & UAE_VM_32BIT)) {
 		if (size <= 768 * 1024 * 1024) {
 			address = try_reserve(0x78000000 - size, size, flags);


### PR DESCRIPTION
## Summary

Closes the open WoA work in #1991 by:

- Fixing the JIT/GL crashes the Phase 2 build hit on real Windows ARM64 hardware and inside VMware Fusion / Parallels-style guest VMs.
- Adding a proper InnoSetup installer to the `build-windows-arm64` CI job (alongside the portable ZIP we already produced).
- Wiring the ARM64 build into the SignPath signing pipeline + the `create-release` job so tagged releases ship ARM64 assets automatically.

### JIT + GL stability fixes

| Commit | What |
|---|---|
| `1ec9953a9` | `uae_vm_reserve()` was always trying `0x80000000` first on Windows. On ARM64 that placed natmem-derived host pointers in `0x80000000-0x180000000`, where SXTW in PC_P displacement handling produced `0xFFFFFFFF…` kernel-space addresses → exec-at-NULL on 68040/68060 JIT. ARM64 Windows now tries `0x100000000` first (matches macOS ARM64 layout). |
| `5f442f1e3` | When `create_popalls()` fails (RWX denied by VBS/HVCI on locked-down VMs), `m68k_run_jit()` now detects `pushall_call_handler == NULL`, clears `currprefs.cachesize`, and falls back to the interpreter instead of calling a NULL pointer. Adds GetLastError-based Win32 RWX diagnostics to `vm.cpp`. |
| `db0823d65` | `OpenGLRenderer::init_context()` previously kept going after `gl_platform_init()` reported missing extensions, leaving NULL function pointers for the first draw call. Now destroys the GL context, logs `(version=…  renderer=…)`, and on Windows hints at the GDI Generic / Mesa3D / GPU-passthrough situation. |
| `05640469d` | `SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 16)` narrowed the matchable pixel formats in WoA VMs (Mesa d3d12 doesn't expose 16-bit depth). The renderer always calls `glDisable(GL_DEPTH_TEST)`, so we now request `0`. The doInit() retry loop also treats a failed `create_windows()` as a mode-failure (try the next mode) instead of aborting graphics init. |
| `2f425c4dd` | The two retry modes were both still failing in some VMs because of explicit RGBA8 hints. Added two minimal-attribute modes (3.3 Core / 2.1 Compat × DOUBLEBUFFER-only). |
| `b87b5acc2` | If all four modes fail on Windows, log a one-paragraph hint pointing users at `mesa-llvmpipe-arm64` (https://github.com/mmozeiko/build-mesa/releases) as a known-working OpenGL fallback for VM testing. |

### Installer + release pipeline (Phase 2b)

| Commit | What |
|---|---|
| `3bc33a1e4` | New steps in `build-windows-arm64`: ensure ISCC available (Chocolatey fallback), `cpack -G INNOSETUP`, then the same SignPath detect/upload/submit/replace/verify pipeline the x64 job already uses. Both portable ZIP and EXE installer now ship as one combined artifact. |
| `bee4819d0` | Add `build-windows-arm64` to `create-release.needs:` so tagged releases pick up the ARM64 artifacts. `continue-on-error: true` stays on the ARM64 job, so a failed ARM64 build still won't block release. README + docs/index.md updated to advertise both x64 and ARM64 builds plus a one-line VM/Mesa note. |
| `1c862e60b` | CPack default named the ARM64 installer `…-win64.exe`. Now produces architecture-correct names: `amiberry-<v>-arm64.exe` / `amiberry-<v>-win64.exe` / `amiberry-<v>-win32.exe`. |

#### Test plan

- [x] **Native Windows ARM64 hardware** — @ozdemir-mehmet retested 68040 / 68060 JIT configs; emulator boots, Workbench runs, no JIT crashes.
- [x] **VMware Fusion Windows 11 ARM64 guest** — full A4000 + 68040 JIT + RTG + Workbench boot + clean quit cycle, with `mesa-llvmpipe-arm64` `opengl32.dll` dropped next to `Amiberry.exe`. Log clean, no spurious exceptions.
- [x] **CI run** (`build-windows-arm64` on `windows-11-arm`): https://github.com/BlitterStudio/amiberry/actions/runs/25379054175 — every step green including `Package (InnoSetup)`, the SignPath detect/sign/replace/verify pipeline, `--dump-paths`, `--jit-selftest`.
- [x] **Artifact contents** — `amiberry-windows-arm64` artifact ships `amiberry-<sha>-windows-arm64-portable.zip` + `amiberry-8.1.5-arm64.exe` (correctly named).
- [x] **Installer tested on real Windows ARM64 hardware** — installs as expected.
- [x] x64 build unchanged — still produces `amiberry-8.1.5-win64.exe`.

#### Follow-up (separate branches, not in this PR)

- Drop `continue-on-error: true` on `build-windows-arm64` after a few green runs on master.
- Phase 3 — unify the existing x64 build on llvm-mingw too (drop GCC-MinGW). Will be done on `feature/windows-llvm-mingw-unify`.