### PR TITLE
Windows: unify on llvm-mingw (x64 bring-up) and make windows-arm64 mandatory

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1097,7 +1097,7 @@ jobs:
             artifact_name: amiberry-windows-x64-llvm
             release_suffix: windows-x64-llvm
     env:
-      LLVM_MINGW_TAG: "20250910"
+      LLVM_MINGW_TAG: "20260421"
       LLVM_MINGW_FLAVOR: "ucrt-x86_64"
       VCPKG_DEFAULT_TRIPLET: x64-mingw-dynamic
       VCPKG_DEFAULT_HOST_TRIPLET: x64-mingw-dynamic
@@ -1148,9 +1148,14 @@ jobs:
         uses: actions/cache@v5
         with:
           path: out/build/windows-x64-release/vcpkg_installed
-          key: ${{ runner.os }}-x64-llvm-vcpkg-${{ hashFiles('vcpkg.json', 'cmake/Toolchain-x86_64-w64-mingw32.cmake') }}
+          # Include LLVM_MINGW_TAG so a toolchain bump invalidates the
+          # cache: deps built with one CRT/runtime can be ABI-incompatible
+          # with binaries linked by the new toolchain (the original
+          # x64-mingw-dynamic + 20250910 cache showed up as
+          # "undefined symbol: clock_gettime64" link errors).
+          key: ${{ runner.os }}-x64-llvm-vcpkg-${{ env.LLVM_MINGW_TAG }}-${{ hashFiles('vcpkg.json', 'cmake/Toolchain-x86_64-w64-mingw32.cmake') }}
           restore-keys: |
-            ${{ runner.os }}-x64-llvm-vcpkg-
+            ${{ runner.os }}-x64-llvm-vcpkg-${{ env.LLVM_MINGW_TAG }}-
 
       - name: Configure
         shell: bash
@@ -1258,7 +1263,7 @@ jobs:
             artifact_name: amiberry-windows-arm64
             release_suffix: windows-arm64
     env:
-      LLVM_MINGW_TAG: "20250910"
+      LLVM_MINGW_TAG: "20260421"
       LLVM_MINGW_FLAVOR: "ucrt-aarch64"
       VCPKG_DEFAULT_TRIPLET: arm64-mingw-dynamic
       VCPKG_DEFAULT_HOST_TRIPLET: arm64-mingw-dynamic
@@ -1309,9 +1314,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: out/build/windows-arm64-release/vcpkg_installed
-          key: ${{ runner.os }}-arm64-vcpkg-${{ hashFiles('vcpkg.json', 'cmake/Toolchain-aarch64-w64-mingw32.cmake') }}
+          # Include LLVM_MINGW_TAG so a toolchain bump invalidates the
+          # cache (avoids ABI mismatches between deps built with one
+          # toolchain and binaries linked with another).
+          key: ${{ runner.os }}-arm64-vcpkg-${{ env.LLVM_MINGW_TAG }}-${{ hashFiles('vcpkg.json', 'cmake/Toolchain-aarch64-w64-mingw32.cmake') }}
           restore-keys: |
-            ${{ runner.os }}-arm64-vcpkg-
+            ${{ runner.os }}-arm64-vcpkg-${{ env.LLVM_MINGW_TAG }}-
 
       - name: Configure
         shell: bash

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1075,6 +1075,166 @@ jobs:
             amiberry-*.exe
           retention-days: 7
 
+  # Windows x64 llvm-mingw bring-up: same architecture target as the
+  # build-windows MSYS2/GCC job but using the same llvm-mingw (clang)
+  # toolchain that build-windows-arm64 already uses.  Phase 3 of the
+  # WoA port plan — once this is stable for a few release cycles we
+  # can drop build-windows + the MSYS2 setup and unify Windows on a
+  # single compiler.  Non-blocking during shakeout, separate artifact
+  # name so it doesn't collide with the GCC-MinGW x64 artifact.
+  build-windows-x64-llvm:
+    runs-on: windows-latest
+    timeout-minutes: 90
+    continue-on-error: true
+    permissions:
+      contents: read
+      actions: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x64-llvm
+            artifact_name: amiberry-windows-x64-llvm
+            release_suffix: windows-x64-llvm
+    env:
+      LLVM_MINGW_TAG: "20250910"
+      LLVM_MINGW_FLAVOR: "ucrt-x86_64"
+      VCPKG_DEFAULT_TRIPLET: x64-mingw-dynamic
+      VCPKG_DEFAULT_HOST_TRIPLET: x64-mingw-dynamic
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Cache llvm-mingw toolchain
+        id: cache-llvm-mingw
+        uses: actions/cache@v5
+        with:
+          path: C:/llvm-mingw
+          key: llvm-mingw-${{ env.LLVM_MINGW_TAG }}-${{ env.LLVM_MINGW_FLAVOR }}
+
+      - name: Install llvm-mingw
+        if: steps.cache-llvm-mingw.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $tag = "${env:LLVM_MINGW_TAG}"
+          $flavor = "${env:LLVM_MINGW_FLAVOR}"
+          $base = "llvm-mingw-$tag-$flavor"
+          $url = "https://github.com/mstorsjo/llvm-mingw/releases/download/$tag/$base.zip"
+          Write-Host "Downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\llvm-mingw.zip"
+          Expand-Archive -Path "$env:RUNNER_TEMP\llvm-mingw.zip" -DestinationPath "$env:RUNNER_TEMP\llvm-mingw"
+          New-Item -ItemType Directory -Force -Path "C:/llvm-mingw" | Out-Null
+          # The archive extracts into a single subdir named $base; flatten.
+          Move-Item "$env:RUNNER_TEMP\llvm-mingw\$base\*" "C:/llvm-mingw" -Force
+
+      - name: Expose llvm-mingw to subsequent steps
+        shell: pwsh
+        run: |
+          "LLVM_MINGW_ROOT=C:/llvm-mingw" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "C:/llvm-mingw/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Bootstrap vcpkg
+        shell: pwsh
+        run: |
+          if (-not (Test-Path "C:/vcpkg/.git")) {
+            git clone --depth 1 https://github.com/microsoft/vcpkg.git C:/vcpkg
+          }
+          & C:/vcpkg/bootstrap-vcpkg.bat -disableMetrics
+          "VCPKG_ROOT=C:/vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Cache vcpkg installed packages
+        uses: actions/cache@v5
+        with:
+          path: out/build/windows-x64-release/vcpkg_installed
+          key: ${{ runner.os }}-x64-llvm-vcpkg-${{ hashFiles('vcpkg.json', 'cmake/Toolchain-x86_64-w64-mingw32.cmake') }}
+          restore-keys: |
+            ${{ runner.os }}-x64-llvm-vcpkg-
+
+      - name: Configure
+        shell: bash
+        run: |
+          cmake --preset windows-x64-release
+
+      - name: Build
+        shell: bash
+        run: |
+          cmake --build out/build/windows-x64-release -j$NUMBER_OF_PROCESSORS
+
+      - name: Install (portable layout)
+        shell: bash
+        run: |
+          rm -rf out/install/windows-x64-release
+          rm -rf out/package/windows-x64-release
+          cmake --install out/build/windows-x64-release --prefix out/install/windows-x64-release
+
+      - name: Package (Portable ZIP)
+        shell: bash
+        run: |
+          PORTABLE_ROOT="out/install/windows-x64-release"
+          test -f "$PORTABLE_ROOT/Amiberry.exe"
+          : > "$PORTABLE_ROOT/amiberry.portable"
+
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            ZIP_NAME="amiberry-${{ github.ref_name }}-windows-x64-llvm-portable.zip"
+          else
+            ZIP_NAME="amiberry-${{ github.sha }}-windows-x64-llvm-portable.zip"
+          fi
+
+          PACKAGE_ROOT="out/package/windows-x64-release/${ZIP_NAME%.zip}"
+          mkdir -p "$(dirname "$PACKAGE_ROOT")"
+          cmake -E copy_directory "$PORTABLE_ROOT" "$PACKAGE_ROOT"
+
+          ZIP_PATH="$PWD/$ZIP_NAME"
+          (cd out/package/windows-x64-release && cmake -E tar cf "$ZIP_PATH" --format=zip "${ZIP_NAME%.zip}")
+
+      - name: Smoke test (--dump-paths, --jit-selftest)
+        shell: pwsh
+        run: |
+          $zip = Get-ChildItem "$PWD/amiberry-*-windows-x64-llvm-portable.zip" | Select-Object -First 1
+          if (-not $zip) { throw "Portable ZIP not found." }
+
+          $verifyRoot = Join-Path $PWD "portable-smoke"
+          Remove-Item -Recurse -Force $verifyRoot -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $verifyRoot | Out-Null
+          Expand-Archive -Path $zip.FullName -DestinationPath $verifyRoot
+
+          $portableDir = Get-ChildItem $verifyRoot -Directory | Select-Object -First 1
+          $exePath = Join-Path $portableDir.FullName "Amiberry.exe"
+          if (-not (Test-Path $exePath)) { throw "Amiberry.exe missing from portable ZIP." }
+
+          $stdoutFile = Join-Path $verifyRoot "dump-paths.stdout"
+          $stderrFile = Join-Path $verifyRoot "dump-paths.stderr"
+          $proc = Start-Process -FilePath $exePath -ArgumentList "--dump-paths" `
+            -WorkingDirectory $portableDir.FullName -PassThru -Wait -NoNewWindow `
+            -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile
+          if ($proc.ExitCode -ne 0) {
+            Write-Host "STDOUT:"; if (Test-Path $stdoutFile) { Get-Content $stdoutFile }
+            Write-Host "STDERR:"; if (Test-Path $stderrFile) { Get-Content $stderrFile }
+            throw "--dump-paths failed with exit code $($proc.ExitCode)."
+          }
+          Write-Host "x64 (llvm-mingw) Amiberry.exe ran --dump-paths successfully."
+
+          $jitStdoutFile = Join-Path $verifyRoot "jit-selftest.stdout"
+          $jitStderrFile = Join-Path $verifyRoot "jit-selftest.stderr"
+          $jitProc = Start-Process -FilePath $exePath -ArgumentList "--jit-selftest" `
+            -WorkingDirectory $portableDir.FullName -PassThru -Wait -NoNewWindow `
+            -RedirectStandardOutput $jitStdoutFile -RedirectStandardError $jitStderrFile
+          if ($jitProc.ExitCode -ne 0) {
+            Write-Host "JIT SELFTEST STDOUT:"; if (Test-Path $jitStdoutFile) { Get-Content $jitStdoutFile }
+            Write-Host "JIT SELFTEST STDERR:"; if (Test-Path $jitStderrFile) { Get-Content $jitStderrFile }
+            throw "--jit-selftest failed with exit code $($jitProc.ExitCode)."
+          }
+          Write-Host "x64 (llvm-mingw) Amiberry.exe ran --jit-selftest successfully."
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: amiberry-*-windows-x64-llvm-portable.zip
+          retention-days: 7
+
   # Windows ARM64 bring-up: native build on the GitHub-hosted
   # windows-11-arm runner using llvm-mingw. Kept separate
   # from build-windows because the toolchain and shell differ.  Still

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1240,18 +1240,14 @@ jobs:
           path: amiberry-*-windows-x64-llvm-portable.zip
           retention-days: 7
 
-  # Windows ARM64 bring-up: native build on the GitHub-hosted
-  # windows-11-arm runner using llvm-mingw. Kept separate
-  # from build-windows because the toolchain and shell differ.  Still
-  # non-blocking during shakeout (continue-on-error: true); listed as a
-  # create-release dependency so tagged releases can pick up the ARM64
-  # installer/ZIP when the job succeeds, but a failed ARM64 job does
-  # not block the release (continue-on-error lets the downstream job
-  # proceed regardless of conclusion).
+  # Windows ARM64: native build on the GitHub-hosted windows-11-arm
+  # runner using llvm-mingw. Kept separate from build-windows because
+  # the toolchain and shell differ. Promoted out of the shakeout
+  # phase — this job is now mandatory and a failure blocks the
+  # workflow (and downstream create-release).
   build-windows-arm64:
     runs-on: windows-11-arm
     timeout-minutes: 90
-    continue-on-error: true
     permissions:
       contents: read
       actions: write

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -157,6 +157,43 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       }
+    },
+    {
+      "name": "windows-x64-debug",
+      "displayName": "Windows x64 Debug (llvm-mingw)",
+      "description": "Target Windows on x86_64 using llvm-mingw (clang). Requires LLVM_MINGW_ROOT env var. Parallel alternative to the GCC-MinGW windows-debug preset; will eventually replace it.",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/Toolchain-x86_64-w64-mingw32.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-mingw-dynamic",
+        "VCPKG_HOST_TRIPLET": "x64-mingw-dynamic"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "windows-x64-release",
+      "displayName": "Windows x64 Release (llvm-mingw)",
+      "description": "Target Windows on x86_64 using llvm-mingw (clang). Requires LLVM_MINGW_ROOT env var. Parallel alternative to the GCC-MinGW windows-release preset; will eventually replace it.",
+      "inherits": "base",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/Toolchain-x86_64-w64-mingw32.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-mingw-dynamic",
+        "VCPKG_HOST_TRIPLET": "x64-mingw-dynamic"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
     }
   ],
   "buildPresets": [
@@ -217,6 +254,18 @@
     {
       "name": "windows-arm64-release",
       "configurePreset": "windows-arm64-release",
+      "jobs": 0,
+      "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
+    },
+    {
+      "name": "windows-x64-debug",
+      "configurePreset": "windows-x64-debug",
+      "jobs": 0,
+      "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
+    },
+    {
+      "name": "windows-x64-release",
+      "configurePreset": "windows-x64-release",
       "jobs": 0,
       "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
     }

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -633,12 +633,13 @@ if (NOT ANDROID AND NOT WIN32)
     list(APPEND AMIBERRY_LIBS pthread)
 endif()
 
-# llvm-mingw on Windows ARM64 does not auto-link winpthread, so
+# llvm-mingw (clang) on Windows does not auto-link winpthread, so
 # clock_gettime / nanosleep (which live in libwinpthread-1 on mingw-w64)
-# come up as undefined at link time. On x86_64 MinGW-w64 GCC these are
-# pulled in implicitly, but that convenience is missing in the aarch64
-# clang driver. Link winpthread explicitly for WoA.
-if (WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+# come up as undefined at link time. MinGW-w64 GCC pulls these in
+# implicitly via its driver spec, but the clang driver does not — this
+# affects both Windows ARM64 and the x86_64 llvm-mingw build. Link
+# winpthread explicitly whenever the Windows compiler is Clang.
+if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     list(APPEND AMIBERRY_LIBS winpthread)
 endif()
 

--- a/cmake/Toolchain-x86_64-w64-mingw32.cmake
+++ b/cmake/Toolchain-x86_64-w64-mingw32.cmake
@@ -1,0 +1,54 @@
+# Toolchain file for Windows x86_64 builds using llvm-mingw.
+#
+# llvm-mingw ships clang wrappers named <triple>-clang / <triple>-clang++
+# which invoke `clang --target=<triple>` with the right sysroot already
+# configured. Download from: https://github.com/mstorsjo/llvm-mingw
+#
+# Usage via the windows-x64-* CMake presets; this file is loaded as
+# VCPKG_CHAINLOAD_TOOLCHAIN_FILE so vcpkg still runs on top.
+#
+# The llvm-mingw install root can be provided via the LLVM_MINGW_ROOT
+# environment variable. When set, its bin/ is prepended to the search
+# path so the prefixed wrappers are found regardless of PATH order.
+#
+# Mirrors cmake/Toolchain-aarch64-w64-mingw32.cmake — keep them in
+# sync if you change one.
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+if(DEFINED ENV{LLVM_MINGW_ROOT})
+    set(_LLVM_MINGW_BIN "$ENV{LLVM_MINGW_ROOT}/bin")
+    list(PREPEND CMAKE_PROGRAM_PATH "${_LLVM_MINGW_BIN}")
+endif()
+
+set(_TRIPLE x86_64-w64-mingw32)
+
+set(CMAKE_C_COMPILER    ${_TRIPLE}-clang)
+set(CMAKE_CXX_COMPILER  ${_TRIPLE}-clang++)
+set(CMAKE_RC_COMPILER   ${_TRIPLE}-windres)
+set(CMAKE_AR            ${_TRIPLE}-ar)
+set(CMAKE_RANLIB        ${_TRIPLE}-ranlib)
+set(CMAKE_STRIP         ${_TRIPLE}-strip)
+
+# Disable the default `-fuse-linker-plugin` / GCC-specific flags that CMake
+# may try on GNU-like drivers; clang picks LLD via its driver configuration.
+set(CMAKE_C_COMPILER_TARGET   ${_TRIPLE})
+set(CMAKE_CXX_COMPILER_TARGET ${_TRIPLE})
+
+# Constrain find_*() to the llvm-mingw per-target tree (headers, import
+# libs, CRT). Intentionally do NOT set CMAKE_SYSROOT: the clang driver
+# already knows where its libc++ headers live (<prefix>/lib/clang/<ver>/
+# and <prefix>/<triple>/include/c++/v1/), and forcing --sysroot to the
+# triple tree makes the driver miss the C++ standard library headers.
+if(DEFINED ENV{LLVM_MINGW_ROOT})
+    list(APPEND CMAKE_FIND_ROOT_PATH "$ENV{LLVM_MINGW_ROOT}/${_TRIPLE}")
+endif()
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+unset(_TRIPLE)
+unset(_LLVM_MINGW_BIN)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -886,12 +886,39 @@ static inline uae_u32 arm64_mov_w0_imm16(uae_u16 imm)
 	return 0x52800000u | (static_cast<uae_u32>(imm) << 5);
 }
 
-int run_jit_selftest_cli(void)
+#if defined(CPU_AARCH64) || defined(CPU_x86_64)
+// Emit a "return imm32" stub for the host architecture. Returns the number
+// of bytes written. The stub is the smallest function we can call from C++:
+//   ARM64:   MOV w0, #imm16 ; RET            (8 bytes, low 16 bits used)
+//   x86_64:  MOV EAX, imm32 ; RET            (6 bytes, full 32 bits used)
+// EAX/W0 is the integer return register on both ABIs.
+static size_t jit_selftest_emit_return_imm(uae_u8* dst, uae_u32 imm)
 {
 #if defined(CPU_AARCH64)
-	constexpr uae_u16 first_result = 0x1234;
-	constexpr uae_u16 patched_result = 0x4B1D;
 	constexpr uae_u32 arm64_ret = 0xD65F03C0u;
+	auto* code = reinterpret_cast<uae_u32*>(dst);
+	code[0] = arm64_mov_w0_imm16(static_cast<uae_u16>(imm));
+	code[1] = arm64_ret;
+	return 8;
+#else // CPU_x86_64
+	dst[0] = 0xB8; // MOV EAX, imm32
+	dst[1] = static_cast<uae_u8>(imm & 0xff);
+	dst[2] = static_cast<uae_u8>((imm >> 8) & 0xff);
+	dst[3] = static_cast<uae_u8>((imm >> 16) & 0xff);
+	dst[4] = static_cast<uae_u8>((imm >> 24) & 0xff);
+	dst[5] = 0xC3; // RET
+	return 6;
+#endif
+}
+#endif
+
+int run_jit_selftest_cli(void)
+{
+#if defined(CPU_AARCH64) || defined(CPU_x86_64)
+	// Use 16-bit-friendly values so the same constants work for the ARM64
+	// MOV w0, #imm16 path and the x86_64 MOV EAX, imm32 path.
+	constexpr uae_u32 first_result = 0x1234u;
+	constexpr uae_u32 patched_result = 0x4B1Du;
 	const int page_size = uae_vm_page_size();
 	if (page_size <= 0) {
 		write_log("JIT selftest: invalid VM page size (%d)\n", page_size);
@@ -907,14 +934,12 @@ int run_jit_selftest_cli(void)
 		return 3;
 	}
 
-	auto* code = reinterpret_cast<uae_u32*>(page);
 	using jit_fn_t = uae_u32 (*)();
 	auto* fn = reinterpret_cast<jit_fn_t>(page);
 
 	uae_vm_jit_write_protect(false);
-	code[0] = arm64_mov_w0_imm16(first_result);
-	code[1] = arm64_ret;
-	__builtin___clear_cache(reinterpret_cast<char*>(code), reinterpret_cast<char*>(code + 2));
+	const size_t code_size = jit_selftest_emit_return_imm(page, first_result);
+	__builtin___clear_cache(reinterpret_cast<char*>(page), reinterpret_cast<char*>(page + code_size));
 	uae_vm_jit_write_protect(true);
 
 	const uae_u32 first_value = fn();
@@ -925,8 +950,8 @@ int run_jit_selftest_cli(void)
 	}
 
 	uae_vm_jit_write_protect(false);
-	code[0] = arm64_mov_w0_imm16(patched_result);
-	__builtin___clear_cache(reinterpret_cast<char*>(code), reinterpret_cast<char*>(code + 2));
+	const size_t patched_size = jit_selftest_emit_return_imm(page, patched_result);
+	__builtin___clear_cache(reinterpret_cast<char*>(page), reinterpret_cast<char*>(page + patched_size));
 	uae_vm_jit_write_protect(true);
 
 	const uae_u32 patched_value = fn();
@@ -963,7 +988,7 @@ void usage()
 	std::cout << " -h                         Show this help." << '\n';
 	std::cout << " --help                     \n" << '\n';
 	std::cout << " --log                      Show log output to console." << '\n';
-	std::cout << " --jit-selftest             Run ARM64 JIT VM/write/execute selftest and exit." << '\n';
+	std::cout << " --jit-selftest             Run JIT VM/write/execute selftest (ARM64 or x86_64) and exit." << '\n';
 	std::cout << " --dump-paths               Resolve startup paths, print them, and exit." << '\n';
 	std::cout << " --download-whdboot         Download/update WHDBooter files and exit." << '\n';
 	std::cout << " -f <file>                  Load a configuration file." << '\n';


### PR DESCRIPTION
Follow-up to #2024 — picks up the two items left open under *\"Follow-up (separate branches, not in this PR)\"*:

1. Drop \`continue-on-error: true\` on \`build-windows-arm64\` now that the job is stable.
2. Phase 3 of the WoA port plan — build a parallel x64 llvm-mingw job alongside the existing GCC-MinGW (\`build-windows\`) job, so we can eventually retire MSYS2/GCC and land on a single Windows toolchain.

## Summary

### Phase 3 bring-up: parallel x64 llvm-mingw build

| Commit | What |
|---|---|
| \`cafdf7cfe\` | New \`cmake/Toolchain-x86_64-w64-mingw32.cmake\`, mirroring \`Toolchain-aarch64-w64-mingw32.cmake\` (same no-\`CMAKE_SYSROOT\` layout so clang still finds its libc++ headers). \`windows-x64-release\` / \`windows-x64-debug\` CMake presets routed through it. |
| \`15962fcfd\` | New \`build-windows-x64-llvm\` job on \`windows-latest\` using the same llvm-mingw archive the ARM64 job consumes (\`ucrt-x86_64\` flavour, \`x64-mingw-dynamic\` vcpkg triplet). Separate artifact name (\`amiberry-windows-x64-llvm\`) so it doesn't collide with the GCC job. Non-blocking (\`continue-on-error: true\`) during shakeout. |
| \`1158cfdd8\` | Bump pinned llvm-mingw tag to \`20260421\`. The vcpkg cache key for the x64-llvm + arm64 jobs now includes \`LLVM_MINGW_TAG\` so a toolchain bump invalidates the ABI-sensitive vcpkg artifact cache. |

### Link-time fix for x64 llvm-mingw

| Commit | What |
|---|---|
| \`198885bba\` | \`libwinpthread-1\` (owns \`clock_gettime\` / \`nanosleep\`) is auto-linked by GCC-MinGW but not by clang on mingw-w64. The condition in \`cmake/Dependencies.cmake\` only added \`winpthread\` for aarch64; widened it to *any* Windows clang build so the x64 llvm-mingw job also links cleanly. Without this, 20260421's time64 header redirects (\`clock_gettime64\` / \`nanosleep64\`) come up as \`ld.lld: undefined symbol\` at link time. |

### Smoke-test extension

| Commit | What |
|---|---|
| \`96b3bd191\` | \`--jit-selftest\` was ARM64-only (early-returned \`unsupported on this architecture\` on x86_64), which is why the x64-llvm smoke step reported exit code 1 with empty stdout/stderr. Refactored the instruction emission into a small \`jit_selftest_emit_return_imm\` helper so the same allocate / W^X toggle / exec / patch / re-exec flow covers both ARM64 (\`MOV w0,#imm16 ; RET\`) and x86_64 (\`MOV EAX,imm32 ; RET\`). \`uae_u32 (*)()\` reads the result via \`EAX\` / \`W0\` on both ABIs. |

### windows-arm64 enforcement

| Commit | What |
|---|---|
| \`fa4d49bc5\` | Drop \`continue-on-error: true\` from \`build-windows-arm64\`. The job has been stable across recent runs (consistent ~9 min green builds on \`windows-11-arm\` with all the JIT + GL fixes from #2024). A failed ARM64 build now blocks the workflow and the downstream \`create-release\` job — previously a SignPath/build failure could silently produce a release without ARM64 assets. \`build-windows-arm64\` was already in \`create-release.needs:\`, so no other workflow surface needed to change. |

### Test plan

- [x] **CI run** on the tip of this branch (run [25388375281](https://github.com/BlitterStudio/amiberry/actions/runs/25388375281), pre-\`fa4d49bc5\`): all three Windows jobs green for the first time on this branch — \`build-windows\` (GCC-MinGW x64) 19m46s, \`build-windows-x64-llvm\` (LLVM-MinGW x64) 24m32s *without* \`continue-on-error\` masking, \`build-windows-arm64\` (LLVM-MinGW arm64) 8m36s. \`--dump-paths\` and \`--jit-selftest\` both pass on the x64-llvm portable ZIP.
- [x] **Local macOS arm64**: \`run_jit_selftest_cli()\` refactor verified — \`JIT selftest: PASS (first=0x1234 patched=0x4B1D)\`, same values the ARM64 path has always produced.
- [x] **Artifact naming**: no overlap — GCC-MinGW still ships \`amiberry-windows-x64\`, the new llvm-mingw job ships \`amiberry-windows-x64-llvm\`, ARM64 unchanged as \`amiberry-windows-arm64\`. \`create-release\` globs are unchanged; the new x64-llvm artifact is intentionally *not* attached to releases while the job is in shakeout.
- [x] **Non-Windows impact**: cmake/Dependencies.cmake change is scoped to \`WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL \"Clang\"\`. macOS / Linux / Android / FreeBSD configures and the GCC-MinGW Windows path are untouched. Verified clean configure on macOS-15 arm64 locally.

### Follow-up (not in this PR)

- After a release cycle or two of green \`build-windows-x64-llvm\`, drop \`continue-on-error: true\` on it as well.
- Once x64-llvm is mandatory and has shipped in a release, retire \`build-windows\` + the MSYS2 toolchain setup and finish the unify (Phase 3 proper).
- Upstream fix / local patch for \`mpg123\` on \`aarch64-w64-mingw32\` — it's the last functional delta between Windows x64 and ARM64 builds (\`USE_MPG123 OFF\` on WoA, see top-level \`CMakeLists.txt\`).

@midwan