### PR TITLE
ci(windows): retire MSYS2/GCC, unify Windows on llvm-mingw

### DIFF
--- a/.agents/skills/troubleshoot-amiberry/SKILL.md
+++ b/.agents/skills/troubleshoot-amiberry/SKILL.md
@@ -21,7 +21,7 @@ The MCP server (`amiberry-mcp-server`) provides tools for runtime control.
 **Determine the platform** before building:
 - **macOS**: Build natively with `cmake`
 - **Linux / WSL2**: Build with `cmake` (use `wsl -e` prefix if on Windows host)
-- **Windows (native)**: Build with MinGW-w64/GCC via CMake presets and Ninja
+- **Windows (native)**: Build with llvm-mingw (clang + lld) via CMake presets and Ninja
 
 ## Build Commands
 
@@ -39,12 +39,13 @@ cmake --build build -j$(nproc)
 wsl -e bash -c "cd ~/amiberry && cmake --build build -j$(nproc)"
 ```
 
-### Windows (native MinGW-w64)
+### Windows (native llvm-mingw)
 ```powershell
-# Use the helper script (sets PATH for CLion's cmake/ninja/mingw, VCPKG_ROOT)
+# Use the helper script if present (sets PATH for cmake/ninja/llvm-mingw, VCPKG_ROOT, LLVM_MINGW_ROOT)
 powershell -ExecutionPolicy Bypass -File "build_and_run.ps1"
 
 # Or manually:
+$env:LLVM_MINGW_ROOT = "C:\llvm-mingw"
 $env:VCPKG_ROOT = "D:\Github\vcpkg"
 cmake --preset windows-debug
 cd out/build/windows-debug
@@ -56,6 +57,8 @@ ninja -j12
 
 **Windows build notes:**
 - Build dir: `out/build/windows-debug` (or `windows-release`)
+- Toolchain: llvm-mingw (clang + lld + libc++) via `cmake/Toolchain-x86_64-w64-mingw32.cmake`. The MinGW-w64 / GCC build was retired; do not try to mix GCC and clang outputs.
+- `LLVM_MINGW_ROOT` must point at an extracted llvm-mingw release (or `C:\llvm-mingw\bin` must be on PATH)
 - Kill stale `amiberry.exe` before rebuild if "permission denied"
 - `write_log()` is silent unless `--log` flag or `write_logfile` config is set
 - x86-64 JIT is supported on Windows; for high-natmem, pointer-width, or performance regressions use the `amiberry-x86-jit` skill

--- a/.agents/skills/winuae-amiberry-merge/SKILL.md
+++ b/.agents/skills/winuae-amiberry-merge/SKILL.md
@@ -100,7 +100,7 @@ For each identified issue:
 
 // To distinguish Amiberry from WinUAE on Windows:
 #if defined(_WIN32) && defined(AMIBERRY)
-    // Amiberry on Windows (MinGW-w64/GCC)
+    // Amiberry on Windows (llvm-mingw / Clang)
 #elif defined(_WIN32)
     // WinUAE (MSVC)
 #endif
@@ -112,11 +112,12 @@ For each identified issue:
 ```
 
 **Key difference: Amiberry on Windows vs WinUAE:**
-- Amiberry uses MinGW-w64 (GCC) — provides POSIX headers (`unistd.h`, `dirent.h`, etc.)
+- Amiberry uses llvm-mingw (Clang + lld + libc++ targeting the mingw-w64 ABI) — provides POSIX headers (`unistd.h`, `dirent.h`, etc.) and links against libc++. The previous MinGW-w64 / GCC build was retired.
 - WinUAE uses MSVC — requires `_MSC_VER`-specific code
 - Many `#ifdef _WIN32` blocks from WinUAE now activate in Amiberry on Windows
 - `sysconfig.h` previously `#undef _WIN32` to suppress this; that was removed
 - x86-64 JIT is supported on Windows; preserve pointer-width `uintptr`/`PC_P` handling when porting WinUAE code that assumes 32-bit host pointers
+- When porting code that depends on libstdc++-only behaviour (e.g. `__GLIBCXX__` checks, GNU libstdc++ ABI quirks), make sure the equivalent libc++ headers and types are used; both Windows and Android Amiberry builds now ship libc++.
 
 ### 3a. Preserve Upstream Merge Safety
 

--- a/.agents/skills/winuae-amiberry-merge/references/platform-mappings.md
+++ b/.agents/skills/winuae-amiberry-merge/references/platform-mappings.md
@@ -146,8 +146,8 @@ Uses the original Amiberry implementation — `select()` in a background thread,
 ### Distinguishing Amiberry from WinUAE on Windows
 ```cpp
 #if defined(_WIN32) && defined(AMIBERRY)
-    // Amiberry on Windows (MinGW-w64/GCC)
-    // Has POSIX headers (unistd.h, dirent.h) via MinGW
+    // Amiberry on Windows (llvm-mingw / Clang + libc++)
+    // Has POSIX headers (unistd.h, dirent.h) via mingw-w64 CRT
 #elif defined(_WIN32)
     // WinUAE (MSVC) - not built by Amiberry
 #endif

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -753,9 +753,13 @@ jobs:
         name: ${{ matrix.artifact_name }}
         path: "amiberry-*.zip"
 
+  # Windows x64: native build on windows-latest using llvm-mingw (clang).
+  # Shares the toolchain with build-windows-arm64 so Windows on Arm and x64
+  # use a single compiler stack. Replaced the previous MSYS2/MinGW-w64 GCC
+  # build once the llvm-mingw shakeout was stable.
   build-windows:
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     permissions:
       contents: read
       actions: write
@@ -766,45 +770,87 @@ jobs:
           - name: x64
             artifact_name: amiberry-windows-x64
             release_suffix: windows-x64
+    env:
+      LLVM_MINGW_TAG: "20260421"
+      LLVM_MINGW_FLAVOR: "ucrt-x86_64"
+      VCPKG_DEFAULT_TRIPLET: x64-mingw-dynamic
+      VCPKG_DEFAULT_HOST_TRIPLET: x64-mingw-dynamic
     steps:
       - name: Check out repository code
         uses: actions/checkout@v5
         with:
           submodules: recursive
 
-      - name: Setup MSYS2
-        uses: msys2/setup-msys2@v2
+      - name: Cache llvm-mingw toolchain
+        id: cache-llvm-mingw
+        uses: actions/cache@v5
         with:
-          msystem: MINGW64
-          update: false
-          install: >-
-            mingw-w64-x86_64-toolchain
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-ninja
+          path: C:/llvm-mingw
+          key: llvm-mingw-${{ env.LLVM_MINGW_TAG }}-${{ env.LLVM_MINGW_FLAVOR }}
+
+      - name: Install llvm-mingw
+        if: steps.cache-llvm-mingw.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $tag = "${env:LLVM_MINGW_TAG}"
+          $flavor = "${env:LLVM_MINGW_FLAVOR}"
+          $base = "llvm-mingw-$tag-$flavor"
+          $url = "https://github.com/mstorsjo/llvm-mingw/releases/download/$tag/$base.zip"
+          Write-Host "Downloading $url"
+          Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\llvm-mingw.zip"
+          Expand-Archive -Path "$env:RUNNER_TEMP\llvm-mingw.zip" -DestinationPath "$env:RUNNER_TEMP\llvm-mingw"
+          New-Item -ItemType Directory -Force -Path "C:/llvm-mingw" | Out-Null
+          # The archive extracts into a single subdir named $base; flatten.
+          Move-Item "$env:RUNNER_TEMP\llvm-mingw\$base\*" "C:/llvm-mingw" -Force
+
+      - name: Expose llvm-mingw to subsequent steps
+        shell: pwsh
+        run: |
+          "LLVM_MINGW_ROOT=C:/llvm-mingw" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "C:/llvm-mingw/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+
+      - name: Bootstrap vcpkg
+        shell: pwsh
+        run: |
+          if (-not (Test-Path "C:/vcpkg/.git")) {
+            git clone --depth 1 https://github.com/microsoft/vcpkg.git C:/vcpkg
+          }
+          & C:/vcpkg/bootstrap-vcpkg.bat -disableMetrics
+          "VCPKG_ROOT=C:/vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Cache vcpkg installed packages
         uses: actions/cache@v5
         with:
           path: out/build/windows-release/vcpkg_installed
-          key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+          # Include LLVM_MINGW_TAG so a toolchain bump invalidates the
+          # cache: deps built with one CRT/runtime can be ABI-incompatible
+          # with binaries linked by the new toolchain (the original
+          # x64-mingw-dynamic + 20250910 cache showed up as
+          # "undefined symbol: clock_gettime64" link errors).
+          key: ${{ runner.os }}-x64-vcpkg-${{ env.LLVM_MINGW_TAG }}-${{ hashFiles('vcpkg.json', 'cmake/Toolchain-x86_64-w64-mingw32.cmake') }}
           restore-keys: |
-            ${{ runner.os }}-vcpkg-
+            ${{ runner.os }}-x64-vcpkg-${{ env.LLVM_MINGW_TAG }}-
 
-      - name: Build for Windows (${{ matrix.name }})
-        shell: msys2 {0}
-        env:
-          VCPKG_ROOT: C:/vcpkg
+      - name: Configure
+        shell: bash
         run: |
           cmake --preset windows-release
-          cmake --build out/build/windows-release -j$(nproc)
 
-      - name: Package (Portable ZIP)
-        shell: msys2 {0}
+      - name: Build
+        shell: bash
+        run: |
+          cmake --build out/build/windows-release -j$NUMBER_OF_PROCESSORS
+
+      - name: Install (portable layout)
+        shell: bash
         run: |
           rm -rf out/install/windows-release
           rm -rf out/package/windows-release
           cmake --install out/build/windows-release --prefix out/install/windows-release
 
+      - name: Package (Portable ZIP)
+        shell: bash
+        run: |
           PORTABLE_ROOT="out/install/windows-release"
           test -f "$PORTABLE_ROOT/Amiberry.exe"
           : > "$PORTABLE_ROOT/amiberry.portable"
@@ -923,6 +969,20 @@ jobs:
           if (Test-Path (Join-Path $portableDir.FullName "conf")) {
             throw "--dump-paths should not create conf in the portable tree."
           }
+
+          # x86_64 builds include the JIT, so exercise --jit-selftest from the
+          # portable layout. Mirrors the build-windows-arm64 smoke test.
+          $jitStdoutFile = Join-Path $verifyRoot "jit-selftest.stdout"
+          $jitStderrFile = Join-Path $verifyRoot "jit-selftest.stderr"
+          $jitProc = Start-Process -FilePath $exePath -ArgumentList "--jit-selftest" `
+            -WorkingDirectory $portableDir.FullName -PassThru -Wait -NoNewWindow `
+            -RedirectStandardOutput $jitStdoutFile -RedirectStandardError $jitStderrFile
+          if ($jitProc.ExitCode -ne 0) {
+            Write-Host "JIT SELFTEST STDOUT:"; if (Test-Path $jitStdoutFile) { Get-Content $jitStdoutFile }
+            Write-Host "JIT SELFTEST STDERR:"; if (Test-Path $jitStderrFile) { Get-Content $jitStderrFile }
+            throw "--jit-selftest failed with exit code $($jitProc.ExitCode)."
+          }
+          Write-Host "x64 (llvm-mingw) Amiberry.exe ran --jit-selftest successfully."
 
       - name: Package (InnoSetup)
         shell: pwsh
@@ -1075,176 +1135,13 @@ jobs:
             amiberry-*.exe
           retention-days: 7
 
-  # Windows x64 llvm-mingw bring-up: same architecture target as the
-  # build-windows MSYS2/GCC job but using the same llvm-mingw (clang)
-  # toolchain that build-windows-arm64 already uses.  Phase 3 of the
-  # WoA port plan — once this is stable for a few release cycles we
-  # can drop build-windows + the MSYS2 setup and unify Windows on a
-  # single compiler.  Non-blocking during shakeout, separate artifact
-  # name so it doesn't collide with the GCC-MinGW x64 artifact.
-  build-windows-x64-llvm:
-    runs-on: windows-latest
-    timeout-minutes: 90
-    continue-on-error: true
-    permissions:
-      contents: read
-      actions: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: x64-llvm
-            artifact_name: amiberry-windows-x64-llvm
-            release_suffix: windows-x64-llvm
-    env:
-      LLVM_MINGW_TAG: "20260421"
-      LLVM_MINGW_FLAVOR: "ucrt-x86_64"
-      VCPKG_DEFAULT_TRIPLET: x64-mingw-dynamic
-      VCPKG_DEFAULT_HOST_TRIPLET: x64-mingw-dynamic
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v5
-        with:
-          submodules: recursive
-
-      - name: Cache llvm-mingw toolchain
-        id: cache-llvm-mingw
-        uses: actions/cache@v5
-        with:
-          path: C:/llvm-mingw
-          key: llvm-mingw-${{ env.LLVM_MINGW_TAG }}-${{ env.LLVM_MINGW_FLAVOR }}
-
-      - name: Install llvm-mingw
-        if: steps.cache-llvm-mingw.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          $tag = "${env:LLVM_MINGW_TAG}"
-          $flavor = "${env:LLVM_MINGW_FLAVOR}"
-          $base = "llvm-mingw-$tag-$flavor"
-          $url = "https://github.com/mstorsjo/llvm-mingw/releases/download/$tag/$base.zip"
-          Write-Host "Downloading $url"
-          Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\llvm-mingw.zip"
-          Expand-Archive -Path "$env:RUNNER_TEMP\llvm-mingw.zip" -DestinationPath "$env:RUNNER_TEMP\llvm-mingw"
-          New-Item -ItemType Directory -Force -Path "C:/llvm-mingw" | Out-Null
-          # The archive extracts into a single subdir named $base; flatten.
-          Move-Item "$env:RUNNER_TEMP\llvm-mingw\$base\*" "C:/llvm-mingw" -Force
-
-      - name: Expose llvm-mingw to subsequent steps
-        shell: pwsh
-        run: |
-          "LLVM_MINGW_ROOT=C:/llvm-mingw" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "C:/llvm-mingw/bin" | Out-File -FilePath $env:GITHUB_PATH -Append
-
-      - name: Bootstrap vcpkg
-        shell: pwsh
-        run: |
-          if (-not (Test-Path "C:/vcpkg/.git")) {
-            git clone --depth 1 https://github.com/microsoft/vcpkg.git C:/vcpkg
-          }
-          & C:/vcpkg/bootstrap-vcpkg.bat -disableMetrics
-          "VCPKG_ROOT=C:/vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Cache vcpkg installed packages
-        uses: actions/cache@v5
-        with:
-          path: out/build/windows-x64-release/vcpkg_installed
-          # Include LLVM_MINGW_TAG so a toolchain bump invalidates the
-          # cache: deps built with one CRT/runtime can be ABI-incompatible
-          # with binaries linked by the new toolchain (the original
-          # x64-mingw-dynamic + 20250910 cache showed up as
-          # "undefined symbol: clock_gettime64" link errors).
-          key: ${{ runner.os }}-x64-llvm-vcpkg-${{ env.LLVM_MINGW_TAG }}-${{ hashFiles('vcpkg.json', 'cmake/Toolchain-x86_64-w64-mingw32.cmake') }}
-          restore-keys: |
-            ${{ runner.os }}-x64-llvm-vcpkg-${{ env.LLVM_MINGW_TAG }}-
-
-      - name: Configure
-        shell: bash
-        run: |
-          cmake --preset windows-x64-release
-
-      - name: Build
-        shell: bash
-        run: |
-          cmake --build out/build/windows-x64-release -j$NUMBER_OF_PROCESSORS
-
-      - name: Install (portable layout)
-        shell: bash
-        run: |
-          rm -rf out/install/windows-x64-release
-          rm -rf out/package/windows-x64-release
-          cmake --install out/build/windows-x64-release --prefix out/install/windows-x64-release
-
-      - name: Package (Portable ZIP)
-        shell: bash
-        run: |
-          PORTABLE_ROOT="out/install/windows-x64-release"
-          test -f "$PORTABLE_ROOT/Amiberry.exe"
-          : > "$PORTABLE_ROOT/amiberry.portable"
-
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            ZIP_NAME="amiberry-${{ github.ref_name }}-windows-x64-llvm-portable.zip"
-          else
-            ZIP_NAME="amiberry-${{ github.sha }}-windows-x64-llvm-portable.zip"
-          fi
-
-          PACKAGE_ROOT="out/package/windows-x64-release/${ZIP_NAME%.zip}"
-          mkdir -p "$(dirname "$PACKAGE_ROOT")"
-          cmake -E copy_directory "$PORTABLE_ROOT" "$PACKAGE_ROOT"
-
-          ZIP_PATH="$PWD/$ZIP_NAME"
-          (cd out/package/windows-x64-release && cmake -E tar cf "$ZIP_PATH" --format=zip "${ZIP_NAME%.zip}")
-
-      - name: Smoke test (--dump-paths, --jit-selftest)
-        shell: pwsh
-        run: |
-          $zip = Get-ChildItem "$PWD/amiberry-*-windows-x64-llvm-portable.zip" | Select-Object -First 1
-          if (-not $zip) { throw "Portable ZIP not found." }
-
-          $verifyRoot = Join-Path $PWD "portable-smoke"
-          Remove-Item -Recurse -Force $verifyRoot -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path $verifyRoot | Out-Null
-          Expand-Archive -Path $zip.FullName -DestinationPath $verifyRoot
-
-          $portableDir = Get-ChildItem $verifyRoot -Directory | Select-Object -First 1
-          $exePath = Join-Path $portableDir.FullName "Amiberry.exe"
-          if (-not (Test-Path $exePath)) { throw "Amiberry.exe missing from portable ZIP." }
-
-          $stdoutFile = Join-Path $verifyRoot "dump-paths.stdout"
-          $stderrFile = Join-Path $verifyRoot "dump-paths.stderr"
-          $proc = Start-Process -FilePath $exePath -ArgumentList "--dump-paths" `
-            -WorkingDirectory $portableDir.FullName -PassThru -Wait -NoNewWindow `
-            -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile
-          if ($proc.ExitCode -ne 0) {
-            Write-Host "STDOUT:"; if (Test-Path $stdoutFile) { Get-Content $stdoutFile }
-            Write-Host "STDERR:"; if (Test-Path $stderrFile) { Get-Content $stderrFile }
-            throw "--dump-paths failed with exit code $($proc.ExitCode)."
-          }
-          Write-Host "x64 (llvm-mingw) Amiberry.exe ran --dump-paths successfully."
-
-          $jitStdoutFile = Join-Path $verifyRoot "jit-selftest.stdout"
-          $jitStderrFile = Join-Path $verifyRoot "jit-selftest.stderr"
-          $jitProc = Start-Process -FilePath $exePath -ArgumentList "--jit-selftest" `
-            -WorkingDirectory $portableDir.FullName -PassThru -Wait -NoNewWindow `
-            -RedirectStandardOutput $jitStdoutFile -RedirectStandardError $jitStderrFile
-          if ($jitProc.ExitCode -ne 0) {
-            Write-Host "JIT SELFTEST STDOUT:"; if (Test-Path $jitStdoutFile) { Get-Content $jitStdoutFile }
-            Write-Host "JIT SELFTEST STDERR:"; if (Test-Path $jitStderrFile) { Get-Content $jitStderrFile }
-            throw "--jit-selftest failed with exit code $($jitProc.ExitCode)."
-          }
-          Write-Host "x64 (llvm-mingw) Amiberry.exe ran --jit-selftest successfully."
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ matrix.artifact_name }}
-          path: amiberry-*-windows-x64-llvm-portable.zip
-          retention-days: 7
-
   # Windows ARM64: native build on the GitHub-hosted windows-11-arm
-  # runner using llvm-mingw. Kept separate from build-windows because
-  # the toolchain and shell differ. Promoted out of the shakeout
-  # phase — this job is now mandatory and a failure blocks the
-  # workflow (and downstream create-release).
+  # runner using the same llvm-mingw toolchain as build-windows.  Kept
+  # as a separate job because it cross-runs on a different runner image
+  # (windows-11-arm) and needs to install InnoSetup at runtime, but the
+  # toolchain, presets, and packaging are otherwise the same.  This job
+  # is mandatory and a failure blocks the workflow (and downstream
+  # create-release).
   build-windows-arm64:
     runs-on: windows-11-arm
     timeout-minutes: 90
@@ -1610,9 +1507,13 @@ jobs:
         if: runner.os == 'Windows'
         uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          # Use the CLANG64 subsystem so the libretro core is also built
+          # with llvm-mingw / clang, matching build-windows. The
+          # mingw-w64-clang-x86_64-toolchain package provides clang,
+          # clang++, lld, libc++, libunwind, libwinpthread.
+          msystem: CLANG64
           update: false
-          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-zlib make
+          install: mingw-w64-clang-x86_64-toolchain mingw-w64-clang-x86_64-zlib make
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,8 @@ amiberry/
 
 ### Windows Port
 
-- Windows builds use MinGW-w64/GCC with vcpkg dependencies; many WinUAE `_WIN32` code paths now compile in Amiberry.
+- Windows builds use llvm-mingw (clang + lld + libc++) with vcpkg dependencies; many WinUAE `_WIN32` code paths now compile in Amiberry. The previous MinGW-w64 / GCC toolchain has been retired — both x64 and ARM64 share a single Clang-based toolchain.
+- The CMake `windows-release` / `windows-debug` presets chainload `cmake/Toolchain-x86_64-w64-mingw32.cmake`; ARM64 uses `cmake/Toolchain-aarch64-w64-mingw32.cmake`. Both require `LLVM_MINGW_ROOT` (or the llvm-mingw `bin/` directory on `PATH`).
 - Include `<winsock2.h>` before Windows headers that can define conflicting `byte` symbols.
 - Use `std::filesystem::copy()` instead of symlinks on Windows and Android.
 - `data/` must exist beside the executable for normal runtime; use `--log` when expecting `write_log()` output.
@@ -138,7 +139,7 @@ amiberry/
 # Configure + build (Linux/macOS)
 cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)
 
-# Windows (MinGW-w64 + vcpkg)
+# Windows (llvm-mingw + vcpkg)
 cmake --preset windows-release && cmake --build out/build/windows-release
 
 # Android

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -88,13 +88,14 @@
     },
     {
       "name": "windows-debug",
-      "displayName": "Windows Debug (MinGW)",
-      "description": "Target Windows systems with MinGW-w64 and Debug build type.",
+      "displayName": "Windows x64 Debug (llvm-mingw)",
+      "description": "Target Windows on x86_64 using llvm-mingw (clang). Requires LLVM_MINGW_ROOT env var (or the llvm-mingw bin/ directory on PATH).",
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/Toolchain-x86_64-w64-mingw32.cmake",
         "VCPKG_TARGET_TRIPLET": "x64-mingw-dynamic",
         "VCPKG_HOST_TRIPLET": "x64-mingw-dynamic"
       },
@@ -106,12 +107,13 @@
     },
     {
       "name": "windows-release",
-      "displayName": "Windows Release (MinGW)",
-      "description": "Target Windows systems with MinGW-w64 and Release build type.",
+      "displayName": "Windows x64 Release (llvm-mingw)",
+      "description": "Target Windows on x86_64 using llvm-mingw (clang). Requires LLVM_MINGW_ROOT env var (or the llvm-mingw bin/ directory on PATH).",
       "inherits": "base",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/Toolchain-x86_64-w64-mingw32.cmake",
         "VCPKG_TARGET_TRIPLET": "x64-mingw-dynamic",
         "VCPKG_HOST_TRIPLET": "x64-mingw-dynamic"
       },
@@ -150,43 +152,6 @@
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/Toolchain-aarch64-w64-mingw32.cmake",
         "VCPKG_TARGET_TRIPLET": "arm64-mingw-dynamic",
-        "VCPKG_HOST_TRIPLET": "x64-mingw-dynamic"
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
-      "name": "windows-x64-debug",
-      "displayName": "Windows x64 Debug (llvm-mingw)",
-      "description": "Target Windows on x86_64 using llvm-mingw (clang). Requires LLVM_MINGW_ROOT env var. Parallel alternative to the GCC-MinGW windows-debug preset; will eventually replace it.",
-      "inherits": "base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/Toolchain-x86_64-w64-mingw32.cmake",
-        "VCPKG_TARGET_TRIPLET": "x64-mingw-dynamic",
-        "VCPKG_HOST_TRIPLET": "x64-mingw-dynamic"
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
-      "name": "windows-x64-release",
-      "displayName": "Windows x64 Release (llvm-mingw)",
-      "description": "Target Windows on x86_64 using llvm-mingw (clang). Requires LLVM_MINGW_ROOT env var. Parallel alternative to the GCC-MinGW windows-release preset; will eventually replace it.",
-      "inherits": "base",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/Toolchain-x86_64-w64-mingw32.cmake",
-        "VCPKG_TARGET_TRIPLET": "x64-mingw-dynamic",
         "VCPKG_HOST_TRIPLET": "x64-mingw-dynamic"
       },
       "condition": {
@@ -254,18 +219,6 @@
     {
       "name": "windows-arm64-release",
       "configurePreset": "windows-arm64-release",
-      "jobs": 0,
-      "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
-    },
-    {
-      "name": "windows-x64-debug",
-      "configurePreset": "windows-x64-debug",
-      "jobs": 0,
-      "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
-    },
-    {
-      "name": "windows-x64-release",
-      "configurePreset": "windows-x64-release",
       "jobs": 0,
       "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
     }

--- a/cmake/Toolchain-x86_64-w64-mingw32.cmake
+++ b/cmake/Toolchain-x86_64-w64-mingw32.cmake
@@ -4,8 +4,9 @@
 # which invoke `clang --target=<triple>` with the right sysroot already
 # configured. Download from: https://github.com/mstorsjo/llvm-mingw
 #
-# Usage via the windows-x64-* CMake presets; this file is loaded as
-# VCPKG_CHAINLOAD_TOOLCHAIN_FILE so vcpkg still runs on top.
+# Usage via the windows-* CMake presets (windows-debug / windows-release);
+# this file is loaded as VCPKG_CHAINLOAD_TOOLCHAIN_FILE so vcpkg still
+# runs on top.
 #
 # The llvm-mingw install root can be provided via the LLVM_MINGW_ROOT
 # environment variable. When set, its bin/ is prepended to the search

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -142,7 +142,16 @@ else
 endif
 
 ifeq ($(platform), win)
-   ifneq ($(shell command -v x86_64-w64-mingw32-gcc 2>/dev/null),)
+   # Prefer llvm-mingw / MSYS2 CLANG64 on Windows: the main Amiberry build is
+   # Clang/LLD-based, so the libretro core uses the same toolchain to keep ABI
+   # and runtime libs aligned. Fall back to MinGW-w64 GCC if clang isn't found.
+   ifneq ($(shell command -v x86_64-w64-mingw32-clang 2>/dev/null),)
+      CC ?= x86_64-w64-mingw32-clang
+      CXX ?= x86_64-w64-mingw32-clang++
+   else ifneq ($(wildcard /clang64/bin/clang.exe),)
+      CC ?= /clang64/bin/clang
+      CXX ?= /clang64/bin/clang++
+   else ifneq ($(shell command -v x86_64-w64-mingw32-gcc 2>/dev/null),)
       CC ?= x86_64-w64-mingw32-gcc
       CXX ?= x86_64-w64-mingw32-g++
    else ifneq ($(wildcard /mingw64/bin/gcc.exe),)
@@ -151,8 +160,11 @@ ifeq ($(platform), win)
    endif
 endif
 
-# Ensure Windows target macros are set when using MinGW, even if platform isn't detected.
-ifneq (,$(findstring mingw32,$(shell $(CXX) -dumpmachine 2>/dev/null)))
+# Ensure Windows target macros are set when using MinGW or llvm-mingw, even
+# if platform isn't detected. clang's -dumpmachine on a mingw target reports
+# e.g. x86_64-w64-windows-gnu, while GCC reports x86_64-w64-mingw32 — match
+# either by looking for the "mingw" or "windows-gnu" substrings.
+ifneq (,$(or $(findstring mingw,$(shell $(CXX) -dumpmachine 2>/dev/null)),$(findstring windows-gnu,$(shell $(CXX) -dumpmachine 2>/dev/null))))
    FLAGS += -D_WIN32 -DWIN32 -D__MINGW32__ -D__MINGW64__
 endif
 

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -207,7 +207,12 @@ LDFLAGS += -lm -lpthread
 endif
 
 ifeq ($(platform), win)
-LDFLAGS += -liconv -lws2_32 -lz -liphlpapi -lgdi32 -lwinmm
+# llvm-mingw / MSYS2 CLANG64: clang's mingw driver does not auto-link
+# libwinpthread the way GCC's does, so pthread/sem symbols (used by the
+# SDL stubs in libretro/sdl_stub.o etc.) come up undefined at link time.
+# Link winpthread explicitly. The link is also harmless under MinGW-w64
+# GCC, where it's normally pulled in implicitly.
+LDFLAGS += -liconv -lws2_32 -lz -liphlpapi -lgdi32 -lwinmm -lpthread
 endif
 
 # Source files - Core Amiga Emulation

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -145,18 +145,24 @@ ifeq ($(platform), win)
    # Prefer llvm-mingw / MSYS2 CLANG64 on Windows: the main Amiberry build is
    # Clang/LLD-based, so the libretro core uses the same toolchain to keep ABI
    # and runtime libs aligned. Fall back to MinGW-w64 GCC if clang isn't found.
+   #
+   # NOTE: use `=` (not `?=`) because GNU make's implicit defaults
+   # (CC=cc, CXX=g++) count as "already defined" for `?=`, so `?=` would be
+   # a no-op and we'd fall back to `g++` which doesn't exist in CLANG64.
+   # Command-line overrides like `make CC=foo CXX=bar` still win because the
+   # command line beats makefile assignments in GNU make.
    ifneq ($(shell command -v x86_64-w64-mingw32-clang 2>/dev/null),)
-      CC ?= x86_64-w64-mingw32-clang
-      CXX ?= x86_64-w64-mingw32-clang++
+      CC = x86_64-w64-mingw32-clang
+      CXX = x86_64-w64-mingw32-clang++
    else ifneq ($(wildcard /clang64/bin/clang.exe),)
-      CC ?= /clang64/bin/clang
-      CXX ?= /clang64/bin/clang++
+      CC = /clang64/bin/clang
+      CXX = /clang64/bin/clang++
    else ifneq ($(shell command -v x86_64-w64-mingw32-gcc 2>/dev/null),)
-      CC ?= x86_64-w64-mingw32-gcc
-      CXX ?= x86_64-w64-mingw32-g++
+      CC = x86_64-w64-mingw32-gcc
+      CXX = x86_64-w64-mingw32-g++
    else ifneq ($(wildcard /mingw64/bin/gcc.exe),)
-      CC ?= /mingw64/bin/gcc
-      CXX ?= /mingw64/bin/g++
+      CC = /mingw64/bin/gcc
+      CXX = /mingw64/bin/g++
    endif
 endif
 


### PR DESCRIPTION
## Summary

Take the [PR #2025 unification](https://github.com/BlitterStudio/amiberry/pull/2025) to its conclusion: the parallel `build-windows-x64-llvm` shakeout job has been stable for several release cycles, so retire the legacy MSYS2 + MinGW-w64 GCC build entirely. Both Windows x64 and Windows ARM64 now share a single clang + lld + libc++ stack via [llvm-mingw](https://github.com/mstorsjo/llvm-mingw).

### Workflow changes

- **`build-windows`** now runs with llvm-mingw on `windows-latest`, mirroring the toolchain, triplet (`x64-mingw-dynamic`), and packaging layout that `build-windows-arm64` already uses.
  - The previous `Setup MSYS2` / `mingw-w64-x86_64-toolchain` flow is replaced by the llvm-mingw download + cache + `LLVM_MINGW_ROOT` export from the ARM64 job.
  - The full `Verify Portable ZIP` (alternate-cwd `--dump-paths` portable-mode assertions), `Package (InnoSetup)`, SignPath signing flow, and signed-artifact verification from the old GCC job are preserved.
  - A `--jit-selftest` invocation is added alongside `--dump-paths` in the verify step, since x86_64 builds now ship the JIT.
  - Artifact name stays `amiberry-windows-x64` and the portable ZIP suffix stays `windows-x64` — the `-llvm` shakeout suffix is gone.
- **`build-windows-x64-llvm`** is removed. Its functionality is folded into `build-windows`.
- **`build-libretro` (Windows entry)** switches from MSYS2 `MINGW64` / `mingw-w64-x86_64-gcc` to MSYS2 `CLANG64` / `mingw-w64-clang-x86_64-toolchain`, so the libretro core is also built with clang/lld.
- **`build-windows-arm64`** comment refresh only — clarifies that it stays separate purely because of the `windows-11-arm` runner image and the runtime InnoSetup install.

### CMake presets

- Dropped the GCC `windows-debug` / `windows-release` presets.
- Renamed the llvm-mingw `windows-x64-debug` / `windows-x64-release` presets to `windows-debug` / `windows-release` so \`cmake --preset windows-release\` keeps working but now produces a Clang/LLD build that chainloads \`cmake/Toolchain-x86_64-w64-mingw32.cmake\`.

### Libretro Makefile

- Prefer \`x86_64-w64-mingw32-clang\` and the MSYS2 CLANG64 \`/clang64/bin/clang\` fallback before MinGW-w64 GCC.
- Broaden the \`-dumpmachine\` substring match to include both \`mingw32\` (GCC) and \`windows-gnu\` (clang) triples.

### Docs

- \`AGENTS.md\` — Windows Port section + \`windows-release\` command example call out llvm-mingw and \`LLVM_MINGW_ROOT\`.
- \`troubleshoot-amiberry\` skill — Windows build commands updated for \`LLVM_MINGW_ROOT\` + clang.
- \`winuae-amiberry-merge\` skill + reference — Amiberry-vs-WinUAE platform comments now reflect Clang + libc++ instead of MinGW-w64 GCC.
- Wiki \`Compile-from-source.md\` (separate repo, [already pushed](https://github.com/BlitterStudio/amiberry/wiki/Compile-from-source)) — Windows section + CLion instructions rewritten for llvm-mingw + \`LLVM_MINGW_ROOT\` + \`VCPKG_CHAINLOAD_TOOLCHAIN_FILE\`.

#### Test plan

- [ ] CI \`build-windows\` (x64 llvm-mingw) green on this branch — produces \`amiberry-*-windows-x64-portable.zip\` and \`amiberry-*-win64.exe\`, both signed by SignPath if secrets are configured.
- [ ] CI \`build-windows-arm64\` still green (untouched apart from the comment refresh).
- [ ] CI \`build-libretro\` (Windows matrix entry) green with CLANG64 — produces \`amiberry_libretro.dll\`.
- [ ] \`Verify Portable ZIP\` step asserts portable-mode paths (\`portable_root\`, \`home_dir\`, \`config_path\`, \`settings_dir\`, \`data_dir\`, \`plugins_dir\`) and runs \`--jit-selftest\` cleanly.
- [ ] No \`amiberry-windows-x64-llvm-*\` artifact gets uploaded any more.
- [ ] \`create-release\` dependency on \`build-windows\` (no longer optional) is satisfied — verify by tagging a preview build after merge.
- [ ] Local Windows developer flow: \`set LLVM_MINGW_ROOT=C:\llvm-mingw\` + \`cmake --preset windows-release\` + \`cmake --build out/build/windows-release\` succeeds and produces a runnable \`Amiberry.exe\`.