### PR TITLE
ci+cmake(windows): drop dead GCC code paths, tighten timeouts

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -759,7 +759,11 @@ jobs:
   # build once the llvm-mingw shakeout was stable.
   build-windows:
     runs-on: windows-latest
-    timeout-minutes: 90
+    # Cold-cache runs (vcpkg + llvm-mingw downloads) finish in ~24 min,
+    # warm-cache runs in ~10-15 min — see build-windows-arm64 for comparison.
+    # 60 min gives ~2.5x headroom over the cold-cache observation, plenty for
+    # SignPath round-trips and any transient slowness.
+    timeout-minutes: 60
     permissions:
       contents: read
       actions: write
@@ -1144,7 +1148,11 @@ jobs:
   # create-release).
   build-windows-arm64:
     runs-on: windows-11-arm
-    timeout-minutes: 90
+    # Cold-cache runs finish in ~24 min, warm-cache runs in ~8 min. The
+    # extra time vs. x64 mostly comes from the InnoSetup-via-Chocolatey
+    # install path (windows-11-arm doesn't preinstall ISCC). 60 min keeps
+    # us in line with build-windows.
+    timeout-minutes: 60
     permissions:
       contents: read
       actions: write

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -635,11 +635,11 @@ endif()
 
 # llvm-mingw (clang) on Windows does not auto-link winpthread, so
 # clock_gettime / nanosleep (which live in libwinpthread-1 on mingw-w64)
-# come up as undefined at link time. MinGW-w64 GCC pulls these in
-# implicitly via its driver spec, but the clang driver does not — this
-# affects both Windows ARM64 and the x86_64 llvm-mingw build. Link
-# winpthread explicitly whenever the Windows compiler is Clang.
-if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+# come up as undefined at link time. The legacy MinGW-w64 GCC build —
+# which pulled winpthread in implicitly via its driver spec — was retired
+# in PR #2026, so on Windows we now always need this explicit link for
+# both Windows ARM64 and x86_64.
+if (WIN32)
     list(APPEND AMIBERRY_LIBS winpthread)
 endif()
 

--- a/cmake/windows/install.cmake
+++ b/cmake/windows/install.cmake
@@ -73,23 +73,17 @@ install(CODE "
     endif()
 ")
 
-# Bundle MinGW runtime DLLs (not managed by vcpkg). Runtime list depends on
-# which MinGW flavor we're using:
-#   - GCC MinGW-w64: libgcc_s_seh-1 / libstdc++-6 / libwinpthread-1
-#   - llvm-mingw (clang): libc++ / libunwind / libwinpthread-1 (also SEH for aarch64)
-# We detect via CMAKE_CXX_COMPILER_ID — clang → llvm-mingw list, GNU → gcc list.
+# Bundle the llvm-mingw runtime DLLs (not managed by vcpkg). Amiberry on
+# Windows is built exclusively with llvm-mingw (clang + lld + libc++); the
+# legacy MSYS2 / MinGW-w64 GCC build was retired together with PR #2026, so
+# we only need the libc++ / libunwind / libwinpthread runtime here.
 get_filename_component(_MINGW_BIN_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
-
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(_MINGW_RUNTIME_DLLS libc++.dll libunwind.dll libwinpthread-1.dll)
-else()
-    set(_MINGW_RUNTIME_DLLS libgcc_s_seh-1.dll libstdc++-6.dll libwinpthread-1.dll)
-endif()
+set(_MINGW_RUNTIME_DLLS libc++.dll libunwind.dll libwinpthread-1.dll)
 
 install(CODE "
     foreach(_dll ${_MINGW_RUNTIME_DLLS})
         if(EXISTS \"${_MINGW_BIN_DIR}/\${_dll}\")
-            message(STATUS \"Installing MinGW runtime: \${_dll}\")
+            message(STATUS \"Installing llvm-mingw runtime: \${_dll}\")
             file(INSTALL \"${_MINGW_BIN_DIR}/\${_dll}\"
                  DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}\")
         endif()


### PR DESCRIPTION
## Summary

Three small follow-ups to [#2026](https://github.com/BlitterStudio/amiberry/pull/2026), which retired the MSYS2 / MinGW-w64 GCC Windows build and unified everything on llvm-mingw.

### 1. Drop dead GCC branches in CMake

- **`cmake/windows/install.cmake`** — the runtime-DLL bundling step had a `CMAKE_CXX_COMPILER_ID STREQUAL "Clang"` check that picked between `libc++ / libunwind / libwinpthread-1` (clang) and `libgcc_s_seh-1 / libstdc++-6 / libwinpthread-1` (GCC). Since the GCC build is gone, hardcode the llvm-mingw runtime list and drop the conditional.
- **`cmake/Dependencies.cmake`** — the explicit `winpthread` link was gated on `if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")`. There is no GCC-on-Windows fallback any more, so simplify to `if (WIN32)`. The comment is updated to reflect that Amiberry on Windows always needs the explicit link now.

### 2. Tighten Windows job timeouts (90 → 60 min)

Recent timing data on the `build-windows` job:

| Run | Cache | Duration |
|-----|-------|----------|
| PR #2026 (first LLVM cutover) | cold (vcpkg + llvm-mingw) | ~24 min |
| PR #2026 (after cache populated) | partial | ~13 min (cancelled) |
| `build-windows-arm64` post-PR-#2026 | warm | ~8.6 min |

`60 min` gives ~2.5× headroom over the cold-cache observation, plenty for SignPath round-trips and any transient slowness. The 90-min number was generous because we were running x64 LLVM as a parallel shakeout job alongside GCC; with the cutover done, that slack is no longer needed.

`build-windows-arm64` gets the same treatment for consistency. Comment updated to note that the slightly higher tail vs. x64 (when cold) mostly comes from installing InnoSetup via Chocolatey at runtime on the `windows-11-arm` image.

### 3. `LLVM_MINGW_TAG` bump — no-op

We already pin `20260421`, which is the latest [mstorsjo/llvm-mingw](https://github.com/mstorsjo/llvm-mingw/releases) release as of today (2026-05-05, ~2 weeks old). No bump in this PR; we'll bump in a follow-up when a newer tag drops.

#### Test plan

- [ ] `build-windows` passes within the new 60-min budget on this PR (worst case: cold-cache run).
- [ ] `build-windows-arm64` passes within the new 60-min budget.
- [ ] Resulting portable ZIP still contains `libc++.dll`, `libunwind.dll`, `libwinpthread-1.dll` (verify locally via `Verify Portable ZIP` step or by unpacking the artifact).
- [ ] `build-libretro` (Windows) still passes — it's MSYS2-CLANG64 driven, not affected by either CMake change.