### PR TITLE
fix(opengl): clamp RTG cursor texture to remove 1px fringe artifacts

### DIFF
--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -1539,8 +1539,15 @@ void OpenGLRenderer::render_software_cursor(const int monid, int x, int y, int w
 					glGenTextures(1, &m_overlay.cursor_texture);
 				}
 				glBindTexture(GL_TEXTURE_2D, m_overlay.cursor_texture);
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+				// Pixel-art cursor: GL_NEAREST keeps the sprite crisp when the
+				// RTG surface is scaled. GL_CLAMP_TO_EDGE prevents the default
+				// GL_REPEAT wrap from sampling the opposite edge at sub-pixel
+				// boundaries, which produced 1px fringe artifacts that
+				// flickered as the cursor moved (issue #2022).
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
 				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, s->w, s->h, 0, GL_RGBA, GL_UNSIGNED_BYTE, s->pixels);
 			}


### PR DESCRIPTION
## Summary

Fixes the 1-pixel fringe artifacts around the RTG mouse pointer when "Hardware sprite emulation" is enabled.

The RTG cursor overlay texture in `OpenGLRenderer::render_software_cursor()` was created with only the `GL_LINEAR` filter parameters set; the wrap mode was left at OpenGL's default `GL_REPEAT`. When the RTG surface is scaled to fit the window, the cursor quad samples the texture at sub-pixel positions, and `GL_LINEAR` + `GL_REPEAT` blended border texels with texels from the **opposite** edge of the sprite — the 1px lines that the user reported flickering in and out as the cursor moved.

Changes:

- Switch the cursor filter from `GL_LINEAR` to `GL_NEAREST` (the Amiga sprite is pixel art and should stay crisp at any scale).
- Add `GL_CLAMP_TO_EDGE` for both `WRAP_S` and `WRAP_T`, matching what the bezel and shader-input textures already do elsewhere in this file.

The SDL and Vulkan renderers are not affected — SDL3 textures effectively clamp by default, and Vulkan's `upload_overlay_texture` already uses `VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE`. Only the GL path was missing the wrap setup.

#### Test plan

- [x] Builds cleanly on macOS (release).
- [ ] Launch with an RTG-enabled config (Picasso96, Hardware sprite emulation = on) and verify the fringe lines around the pointer are gone and the cursor is crisp when the RTG surface is scaled.
- [ ] Repeat at native 1:1 RTG scale to confirm no visual regression.
- [ ] Confirm the chipset (non-RTG) cursor is unchanged.

Closes #2022