### PR TITLE
fix(libretro): isolate libretro paths from standalone install

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -227,19 +227,26 @@ static void libretro_debug_log(const char* fmt, ...)
 // lifecycle points (retro_set_environment, retro_init, retro_load_game, core_entry)
 // to guarantee AMIBERRY_HOME_DIR is set before amiberry_main() runs.
 //
+// Thread safety: this function calls setenv()/_putenv_s(), neither of which is
+// thread-safe on glibc when other threads call getenv/setenv concurrently. All
+// current call sites run on the libretro frontend thread before amiberry_main()
+// spins up its worker threads (audio, JIT, akiko, etc.), so there is no race in
+// the current codebase. If a future change moves any call site to a context where
+// emulation threads are already running, that change must add synchronization.
+//
 // Returns true if AMIBERRY_HOME_DIR is set after this call.
 static bool sync_amiberry_home_dir_from_frontend()
 {
-	// Always refresh system_dir / save_dir from the frontend, regardless of
-	// whether AMIBERRY_HOME_DIR is already set. These are consumed by other
+	// Refresh system_dir / save_dir from the frontend on every call, regardless
+	// of whether AMIBERRY_HOME_DIR is already set. These are consumed by other
 	// libretro paths (BIOS discovery, kickstart lookup, save data layout) and
-	// must reflect the frontend's current values, not be skipped just because
-	// the env var was inherited from a prior session or a parent shell.
+	// must reflect the frontend's current values — they must not be skipped just
+	// because the env var was inherited from a prior session or a parent shell.
 	if (environ_cb) {
 		const char* dir = nullptr;
-		if (system_dir.empty() && environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir) && dir)
+		if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir) && dir && dir[0] != '\0')
 			system_dir = dir;
-		if (save_dir.empty() && environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir) && dir)
+		if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir) && dir && dir[0] != '\0')
 			save_dir = dir;
 		if (save_dir.empty())
 			save_dir = system_dir;
@@ -249,7 +256,8 @@ static bool sync_amiberry_home_dir_from_frontend()
 	// amiberry consumes the env var once at startup, so re-exporting after that
 	// has no effect anyway, and respecting the inherited value lets advanced
 	// users/CIs pin a custom layout without code changes.
-	if (const char* existing = getenv("AMIBERRY_HOME_DIR"); existing && existing[0] != '\0')
+	const char* existing = getenv("AMIBERRY_HOME_DIR");
+	if (existing && existing[0] != '\0')
 		return true;
 
 	// Prefer save_dir (always writable per libretro spec); fall back to system_dir.
@@ -2649,9 +2657,9 @@ static void core_entry(void)
 				"Configure your frontend's system/save directories to avoid creating files in unexpected locations.\n");
 		libretro_debug_log("core_entry: AMIBERRY_HOME_DIR unset — frontend did not provide system/save dir\n");
 	}
+	const char* home_dir_env = getenv("AMIBERRY_HOME_DIR");
 	libretro_debug_log("core_entry start: game_path='%s' AMIBERRY_HOME_DIR='%s'\n",
-		game_path,
-		getenv("AMIBERRY_HOME_DIR") ? getenv("AMIBERRY_HOME_DIR") : "");
+		game_path, home_dir_env ? home_dir_env : "");
 	std::vector<char*> argv;
 	argv.reserve(32);
 	bool argv_alloc_failed = false;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -230,12 +230,11 @@ static void libretro_debug_log(const char* fmt, ...)
 // Returns true if AMIBERRY_HOME_DIR is set after this call.
 static bool sync_amiberry_home_dir_from_frontend()
 {
-	// Already set — nothing to do. We never overwrite a previously set value
-	// because amiberry consumes the env var only at startup, and re-exporting
-	// after that point has no effect.
-	if (const char* existing = getenv("AMIBERRY_HOME_DIR"); existing && existing[0] != '\0')
-		return true;
-
+	// Always refresh system_dir / save_dir from the frontend, regardless of
+	// whether AMIBERRY_HOME_DIR is already set. These are consumed by other
+	// libretro paths (BIOS discovery, kickstart lookup, save data layout) and
+	// must reflect the frontend's current values, not be skipped just because
+	// the env var was inherited from a prior session or a parent shell.
 	if (environ_cb) {
 		const char* dir = nullptr;
 		if (system_dir.empty() && environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir) && dir)
@@ -245,6 +244,13 @@ static bool sync_amiberry_home_dir_from_frontend()
 		if (save_dir.empty())
 			save_dir = system_dir;
 	}
+
+	// Don't overwrite a value the user (or a parent process) has already exported.
+	// amiberry consumes the env var once at startup, so re-exporting after that
+	// has no effect anyway, and respecting the inherited value lets advanced
+	// users/CIs pin a custom layout without code changes.
+	if (const char* existing = getenv("AMIBERRY_HOME_DIR"); existing && existing[0] != '\0')
+		return true;
 
 	// Prefer save_dir (always writable per libretro spec); fall back to system_dir.
 	const std::string& target = !save_dir.empty() ? save_dir : system_dir;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -220,6 +220,45 @@ static void libretro_debug_log(const char* fmt, ...)
 	va_end(ap);
 }
 
+// Re-query system_dir / save_dir from the frontend and (re)export AMIBERRY_HOME_DIR
+// so amiberry's get_home_directory() resolves paths inside the frontend-provided
+// directory instead of falling back to $HOME/Amiberry. Some frontends only populate
+// these directories AFTER retro_set_environment(), so we call this from multiple
+// lifecycle points (retro_set_environment, retro_init, retro_load_game, core_entry)
+// to guarantee AMIBERRY_HOME_DIR is set before amiberry_main() runs.
+//
+// Returns true if AMIBERRY_HOME_DIR is set after this call.
+static bool sync_amiberry_home_dir_from_frontend()
+{
+	// Already set — nothing to do. We never overwrite a previously set value
+	// because amiberry consumes the env var only at startup, and re-exporting
+	// after that point has no effect.
+	if (const char* existing = getenv("AMIBERRY_HOME_DIR"); existing && existing[0] != '\0')
+		return true;
+
+	if (environ_cb) {
+		const char* dir = nullptr;
+		if (system_dir.empty() && environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir) && dir)
+			system_dir = dir;
+		if (save_dir.empty() && environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir) && dir)
+			save_dir = dir;
+		if (save_dir.empty())
+			save_dir = system_dir;
+	}
+
+	// Prefer save_dir (always writable per libretro spec); fall back to system_dir.
+	const std::string& target = !save_dir.empty() ? save_dir : system_dir;
+	if (target.empty())
+		return false;
+
+#ifdef _WIN32
+	_putenv_s("AMIBERRY_HOME_DIR", target.c_str());
+#else
+	setenv("AMIBERRY_HOME_DIR", target.c_str(), 1);
+#endif
+	return true;
+}
+
 struct DiskImage {
 	std::string path;
 	std::string label;
@@ -2590,7 +2629,23 @@ static void poll_input(void)
 static void core_entry(void)
 {
 	libretro_debug_open();
-	libretro_debug_log("core_entry start: game_path='%s'\n", game_path);
+	// Final defensive setup before amiberry_main() runs. By this point all
+	// earlier callbacks (retro_set_environment, retro_init, retro_load_game)
+	// have already had a chance to set AMIBERRY_HOME_DIR — but if every one
+	// of them was called before the frontend populated system_dir/save_dir,
+	// this is the last opportunity to capture the path before init_amiberry_dirs
+	// runs and would otherwise create $HOME/Amiberry. If we still have nothing,
+	// log a warning so the user knows to configure their frontend.
+	if (!sync_amiberry_home_dir_from_frontend()) {
+		if (log_cb)
+			log_cb(RETRO_LOG_WARN,
+				"AMIBERRY_HOME_DIR not set: frontend did not provide a system or save directory. "
+				"Configure your frontend's system/save directories to avoid creating files in unexpected locations.\n");
+		libretro_debug_log("core_entry: AMIBERRY_HOME_DIR unset — frontend did not provide system/save dir\n");
+	}
+	libretro_debug_log("core_entry start: game_path='%s' AMIBERRY_HOME_DIR='%s'\n",
+		game_path,
+		getenv("AMIBERRY_HOME_DIR") ? getenv("AMIBERRY_HOME_DIR") : "");
 	std::vector<char*> argv;
 	argv.reserve(32);
 	bool argv_alloc_failed = false;
@@ -2861,6 +2916,11 @@ void retro_init(void)
 	if (!core_fiber)
 		core_fiber = co_create(CORE_FIBER_STACK_SIZE, core_entry);
 
+	// Defensive: some frontends populate system_dir/save_dir between
+	// retro_set_environment and retro_init, so re-query and re-export
+	// AMIBERRY_HOME_DIR here. Idempotent — see sync_amiberry_home_dir_from_frontend.
+	sync_amiberry_home_dir_from_frontend();
+
 	if (log_cb)
 		log_cb(RETRO_LOG_INFO, "retro_init: main_fiber=%p core_fiber=%p\n", (void*)main_fiber, (void*)core_fiber);
 	libretro_debug_log("retro_init: main_fiber=%p core_fiber=%p\n", (void*)main_fiber, (void*)core_fiber);
@@ -2981,24 +3041,13 @@ void retro_set_environment(retro_environment_t cb)
 	}
 	{
 		const char* dir = nullptr;
-		if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir) && dir)
-			system_dir = dir;
-		if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir) && dir)
-			save_dir = dir;
 		if (environ_cb(RETRO_ENVIRONMENT_GET_CONTENT_DIRECTORY, &dir) && dir)
 			content_dir = dir;
-		if (save_dir.empty())
-			save_dir = system_dir;
-
-		// Prevent $HOME/Amiberry creation — see get_home_directory() in amiberry.cpp.
-		// Prefer save_dir (always writable per libretro spec); falls back to system_dir.
-		if (!save_dir.empty()) {
-#ifdef _WIN32
-			_putenv_s("AMIBERRY_HOME_DIR", save_dir.c_str());
-#else
-			setenv("AMIBERRY_HOME_DIR", save_dir.c_str(), 1);
-#endif
-		}
+		// Capture system_dir/save_dir and (re-)export AMIBERRY_HOME_DIR so amiberry's
+		// get_home_directory() does not fall back to $HOME/Amiberry. This is the
+		// earliest of several defensive call sites — see also retro_init,
+		// retro_load_game, and core_entry.
+		sync_amiberry_home_dir_from_frontend();
 
 		libretro_debug_open();
 		libretro_debug_log("env system_dir='%s' save_dir='%s' content_dir='%s'\n",
@@ -3252,6 +3301,10 @@ void retro_run(void)
 bool retro_load_game(const struct retro_game_info *info)
 {
 	libretro_debug_open();
+	// Defensive: by retro_load_game time, frontends that delay path setup will
+	// have populated system_dir/save_dir, even if they were empty during
+	// retro_set_environment / retro_init.
+	sync_amiberry_home_dir_from_frontend();
 	const struct retro_game_info_ext* info_ext = nullptr;
 	if (environ_cb)
 		environ_cb(RETRO_ENVIRONMENT_GET_GAME_INFO_EXT, &info_ext);

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -6769,12 +6769,23 @@ std::string get_home_directory(const bool portable_mode)
 			write_log("macOS: Using home directory from AMIBERRY_HOME_DIR: %s\n", env_home_dir);
 			return { env_home_dir };
 		}
+#ifdef LIBRETRO
+		// libretro: never fall back to ~/Documents/Amiberry. The libretro shim
+		// must always provide AMIBERRY_HOME_DIR; if it didn't, the frontend has
+		// not configured a system/save directory and we should not create files
+		// in the user's home tree. Returning empty causes init_amiberry_dirs()
+		// to leave host paths empty and create_missing_amiberry_folders() to skip
+		// directory creation. See libretro/libretro.cpp::sync_amiberry_home_dir_from_frontend.
+		write_log("libretro: AMIBERRY_HOME_DIR not set — refusing to fall back to host home dir\n");
+		return {};
+#else
 		const auto default_home_dir = get_default_macos_content_root();
 		if (!default_home_dir.empty())
 		{
 			write_log("macOS: Using home directory %s\n", default_home_dir.c_str());
 			return default_home_dir;
 		}
+#endif
 	}
 #endif
 	if (portable_mode)
@@ -6792,6 +6803,11 @@ std::string get_home_directory(const bool portable_mode)
 		write_log("Using home directory from AMIBERRY_HOME_DIR: %s\n", env_home_dir);
 		return { env_home_dir };
 	}
+#ifdef LIBRETRO
+	// libretro: never fall back to $HOME/Amiberry. See macOS branch above for rationale.
+	write_log("libretro: AMIBERRY_HOME_DIR not set — refusing to fall back to host home dir\n");
+	return {};
+#else
 	// 2: Check $HOME/Amiberry
 	const auto default_home_dir = get_default_posix_content_root();
 	if (!default_home_dir.empty())
@@ -6805,6 +6821,7 @@ std::string get_home_directory(const bool portable_mode)
 	const auto portable_root = get_portable_root_directory();
 	write_log("Fallback: Setting home directory to executable path\n");
 	return portable_root;
+#endif
 }
 
 // The location of .uae configurations
@@ -6818,11 +6835,17 @@ std::string get_config_directory(bool portable_mode)
 		if (env_home_dir != nullptr && env_home_dir[0] != '\0')
 			return normalize_path_string(std::string(env_home_dir) + "/Configurations");
 
+#ifdef LIBRETRO
+		// libretro: never fall back to ~/Documents/Amiberry/Configurations.
+		// See get_home_directory() for rationale.
+		return {};
+#else
 		const auto default_home_dir = get_default_macos_content_root();
 		if (!default_home_dir.empty())
 			return join_path(default_home_dir, "Configurations");
 
 		return {};
+#endif
 	}
 #elif defined(_WIN32)
 	if (portable_mode)
@@ -6868,6 +6891,11 @@ std::string get_config_directory(bool portable_mode)
 	if (env_home_dir != nullptr && env_home_dir[0] != '\0')
 		return join_path(env_home_dir, get_configurations_directory_name());
 
+#ifdef LIBRETRO
+	// libretro: never fall back to $HOME/Amiberry/Configurations.
+	// See get_home_directory() for rationale.
+	return {};
+#else
 	// 2: Check $HOME/Amiberry/Configurations
 	const auto default_home_dir = get_default_posix_content_root();
 	if (!default_home_dir.empty())
@@ -6876,6 +6904,7 @@ std::string get_config_directory(bool portable_mode)
 	// 3: Fallback to the executable directory when $HOME is unavailable.
 	write_log("Using config directory from executable path\n");
 	return join_path(get_portable_root_directory(), get_configurations_directory_name());
+#endif
 #endif
 }
 
@@ -6938,6 +6967,10 @@ std::string get_plugins_directory(bool portable_mode)
 		write_log("Using plugins directory from AMIBERRY_HOME_DIR/plugins\n");
 		return { std::string(env_home_dir) + "/plugins" };
 	}
+#ifdef LIBRETRO
+	// libretro: never fall back to $HOME/Amiberry/plugins. See get_home_directory() for rationale.
+	return {};
+#else
 	// 4: Check for ~/Amiberry/plugins.
 	// Keep path discovery side-effect free so migrated/customized setups do not recreate default folders.
 	const auto default_home_dir = get_default_posix_content_root();
@@ -6950,6 +6983,7 @@ std::string get_plugins_directory(bool portable_mode)
 	// 5: Fallback to the executable directory when no other plugin path is available.
 	write_log("Using plugins directory from executable path\n");
 	return join_path(get_portable_root_directory(), "plugins");
+#endif
 #endif
 }
 
@@ -6976,6 +7010,21 @@ static std::string get_settings_directory(const bool portable_mode)
 {
 	if (portable_mode)
 		return join_path(get_portable_root_directory(), "Settings");
+
+#ifdef LIBRETRO
+	// libretro: settings live alongside frontend-provided save data, not in the
+	// user's standalone config dir. This isolates libretro state from standalone use,
+	// so the libretro core neither inherits the user's saved $HOME/Amiberry path
+	// overrides nor overwrites the standalone amiberry.conf when it saves its own.
+	// Returning empty (when AMIBERRY_HOME_DIR is unset) causes resolve_bootstrap_settings_paths
+	// to skip directory creation and amiberry_conf_file to be empty (no load, no save).
+	{
+		const auto env_home_dir = getenv("AMIBERRY_HOME_DIR");
+		if (env_home_dir != nullptr && env_home_dir[0] != '\0')
+			return { env_home_dir };
+		return {};
+	}
+#endif
 
 #ifdef AMIBERRY_IOS
 	// iOS: settings in the Documents sandbox

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -5945,11 +5945,19 @@ static int parse_amiberry_settings_line(const char *path, char *linea)
 	int ret = 0;
 	std::string configured_base_path;
 
+#ifdef LIBRETRO
+	// libretro: ignore base_content_path entries from amiberry.conf — see the
+	// per-option skip block below for full rationale. base_content_path is handled
+	// before the option/value split so it gets its own early skip here.
+	if (parse_base_content_path_line(path, linea, configured_base_path))
+		return 1;
+#else
 	if (parse_base_content_path_line(path, linea, configured_base_path))
 	{
 		set_base_content_path(configured_base_path);
 		return 1;
 	}
+#endif
 
 	if (!cfgfile_separate_linea(path, linea, option, value))
 		return 0;
@@ -5987,6 +5995,30 @@ static int parse_amiberry_settings_line(const char *path, char *linea)
 	else
 	{
 		_sntprintf(legacy_cd_path_option, sizeof legacy_cd_path_option / sizeof(TCHAR), _T("%s.cd_path"), TARGET_NAME);
+#ifdef LIBRETRO
+		// libretro: ignore path-override entries from amiberry.conf. All host paths
+		// in libretro builds are derived from AMIBERRY_HOME_DIR (frontend save_dir),
+		// so saved standalone path overrides — typically pointing at $HOME/Amiberry —
+		// must not be allowed to leak in via load_amiberry_settings(). The next save
+		// rewrites the file without these lines. See get_home_directory() in this
+		// file and libretro/libretro.cpp::sync_amiberry_home_dir_from_frontend.
+		static const TCHAR* const libretro_skipped_path_options[] = {
+			_T("config_path"), _T("controllers_path"), _T("retroarch_config"),
+			_T("whdboot_path"), _T("whdload_arch_path"), _T("floppy_path"),
+			_T("harddrive_path"), _T("cdrom_path"), _T("cd_path"),
+			_T("logfile_path"), _T("rom_path"), _T("rp9_path"),
+			_T("floppy_sounds_dir"), _T("saveimage_dir"), _T("savestate_dir"),
+			_T("ripper_path"), _T("inputrecordings_dir"), _T("screenshot_dir"),
+			_T("nvram_dir"), _T("plugins_dir"), _T("video_dir"),
+			_T("themes_path"), _T("shaders_path"), _T("bezels_path"),
+		};
+		for (const auto* skipped : libretro_skipped_path_options) {
+			if (_tcscmp(option, skipped) == 0)
+				return 1;
+		}
+		if (_tcscmp(option, legacy_cd_path_option) == 0)
+			return 1;
+#endif
 		ret |= cfgfile_string(option, value, "config_path", config_path);
 		ret |= cfgfile_string(option, value, "controllers_path", controllers_path);
 		ret |= cfgfile_string(option, value, "retroarch_config", retroarch_file);
@@ -6718,6 +6750,24 @@ static std::string get_default_posix_content_root()
 
 std::string get_home_directory(const bool portable_mode)
 {
+#ifdef LIBRETRO
+	// libretro: never fall back to a host home dir on any platform. The libretro shim
+	// must always provide AMIBERRY_HOME_DIR (see libretro/libretro.cpp::
+	// sync_amiberry_home_dir_from_frontend). If it's unset, the frontend has not
+	// configured a system/save directory and we must not create files in the user's
+	// home tree. Returning empty causes init_amiberry_dirs() to leave host paths
+	// empty and create_missing_amiberry_folders() to skip directory creation.
+	{
+		const auto env_home_dir = getenv("AMIBERRY_HOME_DIR");
+		if (env_home_dir != nullptr && env_home_dir[0] != '\0')
+		{
+			write_log("libretro: Using home directory from AMIBERRY_HOME_DIR: %s\n", env_home_dir);
+			return { env_home_dir };
+		}
+		write_log("libretro: AMIBERRY_HOME_DIR not set — refusing to fall back to host home dir\n");
+		return {};
+	}
+#endif
 #if defined(AMIBERRY_IOS)
 	// iOS: sandboxed Documents directory, similar to Android
 	const auto user_home_dir = getenv("HOME");
@@ -6769,23 +6819,12 @@ std::string get_home_directory(const bool portable_mode)
 			write_log("macOS: Using home directory from AMIBERRY_HOME_DIR: %s\n", env_home_dir);
 			return { env_home_dir };
 		}
-#ifdef LIBRETRO
-		// libretro: never fall back to ~/Documents/Amiberry. The libretro shim
-		// must always provide AMIBERRY_HOME_DIR; if it didn't, the frontend has
-		// not configured a system/save directory and we should not create files
-		// in the user's home tree. Returning empty causes init_amiberry_dirs()
-		// to leave host paths empty and create_missing_amiberry_folders() to skip
-		// directory creation. See libretro/libretro.cpp::sync_amiberry_home_dir_from_frontend.
-		write_log("libretro: AMIBERRY_HOME_DIR not set — refusing to fall back to host home dir\n");
-		return {};
-#else
 		const auto default_home_dir = get_default_macos_content_root();
 		if (!default_home_dir.empty())
 		{
 			write_log("macOS: Using home directory %s\n", default_home_dir.c_str());
 			return default_home_dir;
 		}
-#endif
 	}
 #endif
 	if (portable_mode)
@@ -6803,11 +6842,6 @@ std::string get_home_directory(const bool portable_mode)
 		write_log("Using home directory from AMIBERRY_HOME_DIR: %s\n", env_home_dir);
 		return { env_home_dir };
 	}
-#ifdef LIBRETRO
-	// libretro: never fall back to $HOME/Amiberry. See macOS branch above for rationale.
-	write_log("libretro: AMIBERRY_HOME_DIR not set — refusing to fall back to host home dir\n");
-	return {};
-#else
 	// 2: Check $HOME/Amiberry
 	const auto default_home_dir = get_default_posix_content_root();
 	if (!default_home_dir.empty())
@@ -6821,12 +6855,20 @@ std::string get_home_directory(const bool portable_mode)
 	const auto portable_root = get_portable_root_directory();
 	write_log("Fallback: Setting home directory to executable path\n");
 	return portable_root;
-#endif
 }
 
 // The location of .uae configurations
 std::string get_config_directory(bool portable_mode)
 {
+#ifdef LIBRETRO
+	// libretro: never fall back to host home dir on any platform. See get_home_directory().
+	{
+		const auto env_home_dir = getenv("AMIBERRY_HOME_DIR");
+		if (env_home_dir != nullptr && env_home_dir[0] != '\0')
+			return join_path(env_home_dir, get_configurations_directory_name());
+		return {};
+	}
+#endif
 #ifdef AMIBERRY_IOS
 	return join_path(get_home_directory(false), "Configurations");
 #elif defined(AMIBERRY_MACOS)
@@ -6835,17 +6877,11 @@ std::string get_config_directory(bool portable_mode)
 		if (env_home_dir != nullptr && env_home_dir[0] != '\0')
 			return normalize_path_string(std::string(env_home_dir) + "/Configurations");
 
-#ifdef LIBRETRO
-		// libretro: never fall back to ~/Documents/Amiberry/Configurations.
-		// See get_home_directory() for rationale.
-		return {};
-#else
 		const auto default_home_dir = get_default_macos_content_root();
 		if (!default_home_dir.empty())
 			return join_path(default_home_dir, "Configurations");
 
 		return {};
-#endif
 	}
 #elif defined(_WIN32)
 	if (portable_mode)
@@ -6891,11 +6927,6 @@ std::string get_config_directory(bool portable_mode)
 	if (env_home_dir != nullptr && env_home_dir[0] != '\0')
 		return join_path(env_home_dir, get_configurations_directory_name());
 
-#ifdef LIBRETRO
-	// libretro: never fall back to $HOME/Amiberry/Configurations.
-	// See get_home_directory() for rationale.
-	return {};
-#else
 	// 2: Check $HOME/Amiberry/Configurations
 	const auto default_home_dir = get_default_posix_content_root();
 	if (!default_home_dir.empty())
@@ -6905,12 +6936,27 @@ std::string get_config_directory(bool portable_mode)
 	write_log("Using config directory from executable path\n");
 	return join_path(get_portable_root_directory(), get_configurations_directory_name());
 #endif
-#endif
 }
 
 // Plugins that Amiberry can use, usually in the form of shared libraries
 std::string get_plugins_directory(bool portable_mode)
 {
+#ifdef LIBRETRO
+	// libretro: standard standalone fallbacks (executable dir / app bundle Resources)
+	// don't apply because the libretro core is loaded as a shared object inside the
+	// frontend's process — the executable is the frontend, not amiberry. Resolve only
+	// from explicit env vars; otherwise return empty (no plugins). Never fall back
+	// to a host home dir. See get_home_directory() for rationale.
+	{
+		const auto env_plugins_dir = getenv("AMIBERRY_PLUGINS_DIR");
+		if (env_plugins_dir != nullptr && env_plugins_dir[0] != '\0')
+			return { env_plugins_dir };
+		const auto env_home_dir = getenv("AMIBERRY_HOME_DIR");
+		if (env_home_dir != nullptr && env_home_dir[0] != '\0')
+			return { std::string(env_home_dir) + "/plugins" };
+		return {};
+	}
+#endif
 #ifdef AMIBERRY_IOS
 	// iOS: no plugins directory (no dynamic loading on iOS)
 	return {};
@@ -6967,10 +7013,6 @@ std::string get_plugins_directory(bool portable_mode)
 		write_log("Using plugins directory from AMIBERRY_HOME_DIR/plugins\n");
 		return { std::string(env_home_dir) + "/plugins" };
 	}
-#ifdef LIBRETRO
-	// libretro: never fall back to $HOME/Amiberry/plugins. See get_home_directory() for rationale.
-	return {};
-#else
 	// 4: Check for ~/Amiberry/plugins.
 	// Keep path discovery side-effect free so migrated/customized setups do not recreate default folders.
 	const auto default_home_dir = get_default_posix_content_root();
@@ -6983,7 +7025,6 @@ std::string get_plugins_directory(bool portable_mode)
 	// 5: Fallback to the executable directory when no other plugin path is available.
 	write_log("Using plugins directory from executable path\n");
 	return join_path(get_portable_root_directory(), "plugins");
-#endif
 #endif
 }
 
@@ -7222,9 +7263,53 @@ static bool import_legacy_settings_file_if_needed(const std::vector<std::string>
 	return false;
 }
 
+#ifdef LIBRETRO
+// libretro relocated its settings_dir from the standalone settings_dir
+// (~/.config/amiberry on Linux, ~/Library/Application Support/Amiberry on macOS,
+// %LOCALAPPDATA%\Amiberry on Windows) to AMIBERRY_HOME_DIR (= frontend save_dir).
+// On first run after the relocation, import the user's previous amiberry.conf
+// and amiberry.ini into the new settings_dir.
+//
+// These paths are deliberately NOT added to get_legacy_settings_candidate_directories
+// to avoid side effects on the legacy-cleanup prompt (which would otherwise propose
+// deleting the user's standalone config) and on --dump-paths resolution.
+//
+// Path-override lines from the imported file are skipped in parse_amiberry_settings_line()
+// when LIBRETRO is defined, so the user's preferences come over but content paths
+// stay derived from AMIBERRY_HOME_DIR.
+static std::vector<std::string> get_libretro_pre_relocation_candidate_directories()
+{
+	std::vector<std::string> candidates;
+#if defined(AMIBERRY_MACOS)
+	const auto user_home_dir = getenv("HOME");
+	if (user_home_dir != nullptr && user_home_dir[0] != '\0')
+		append_settings_candidate(candidates,
+			normalize_path_string(std::string(user_home_dir) + "/Library/Application Support/Amiberry"));
+#elif defined(_WIN32)
+	const auto local_app_data = getenv("LOCALAPPDATA");
+	if (local_app_data != nullptr && local_app_data[0] != '\0')
+		append_settings_candidate(candidates,
+			normalize_path_string(std::string(local_app_data) + "\\Amiberry"));
+	const auto roaming_app_data = getenv("APPDATA");
+	if (roaming_app_data != nullptr && roaming_app_data[0] != '\0')
+		append_settings_candidate(candidates,
+			normalize_path_string(std::string(roaming_app_data) + "\\Amiberry"));
+#elif !defined(__ANDROID__) && !defined(AMIBERRY_IOS)
+	append_settings_candidate(candidates, normalize_path_string(get_xdg_config_home() + "/amiberry"));
+#endif
+	return candidates;
+}
+#endif // LIBRETRO
+
 static void migrate_legacy_settings_files(const bool portable_mode)
 {
-	const auto candidate_directories = get_legacy_settings_candidate_directories(portable_mode);
+	auto candidate_directories = get_legacy_settings_candidate_directories(portable_mode);
+#ifdef LIBRETRO
+	// Append libretro-specific pre-relocation candidates so the standalone
+	// settings_dir is consulted only for migration, not for cleanup or resolution.
+	for (auto& dir : get_libretro_pre_relocation_candidate_directories())
+		append_settings_candidate(candidate_directories, dir);
+#endif
 	bool conf_copy_failed = false;
 	bool ini_copy_failed = false;
 	const bool conf_copied = import_legacy_settings_file_if_needed(candidate_directories, "amiberry.conf", conf_copy_failed);
@@ -8678,21 +8763,20 @@ static void init_amiberry_dirs(const bool portable_mode, const bool materialize_
 
 	apply_current_visual_asset_paths(get_visual_asset_paths_from_content_root(visual_content_root));
 
-	retroarch_file = config_path;
+	// Use join_path so an empty config_path / data_dir (libretro fallback when
+	// AMIBERRY_HOME_DIR is unset) yields an empty result instead of a bare
+	// absolute "/retroarch.cfg" or relative "floppy_sounds/" path.
+	retroarch_file = join_path(config_path, "retroarch.cfg");
+	floppy_sounds_dir = data_dir.empty() ? std::string{} : join_path(data_dir, "floppy_sounds");
+	if (!floppy_sounds_dir.empty()) {
 #ifdef _WIN32
-	retroarch_file.append("\\retroarch.cfg");
-#elif defined(__ANDROID__)
-	retroarch_file.append("retroarch.cfg");
+		if (floppy_sounds_dir.back() != '\\' && floppy_sounds_dir.back() != '/')
+			floppy_sounds_dir += '\\';
 #else
-	retroarch_file.append("/retroarch.cfg");
+		if (floppy_sounds_dir.back() != '/')
+			floppy_sounds_dir += '/';
 #endif
-
-	floppy_sounds_dir = data_dir;
-#ifdef _WIN32
-	floppy_sounds_dir.append("floppy_sounds\\");
-#else
-	floppy_sounds_dir.append("floppy_sounds/");
-#endif
+	}
 
 	default_base_content_paths = get_current_base_content_path_set();
 }
@@ -8819,6 +8903,13 @@ static void load_amiberry_settings_from_file(const std::string& settings_file)
 			serialized_base_path_to_skip = inferred_serialized_base_path;
 		}
 
+#ifdef LIBRETRO
+		// libretro: never apply a saved base_content_path or infer one from the
+		// managed-path lines. All host paths in libretro builds derive from
+		// AMIBERRY_HOME_DIR (frontend save_dir); see parse_amiberry_settings_line()
+		// for the matching per-line skip and get_home_directory() for rationale.
+		(void)inferred_serialized_base_path;
+#else
 		if (has_base_content_path)
 			set_base_content_path(configured_base_path);
 		else if (!inferred_serialized_base_path.empty())
@@ -8829,6 +8920,7 @@ static void load_amiberry_settings_from_file(const std::string& settings_file)
 				apply_current_visual_asset_paths(
 					get_visual_asset_paths_from_content_root(inferred_serialized_base_path));
 		}
+#endif
 
 		for (const auto& line : settings_lines)
 		{


### PR DESCRIPTION
## Summary

The previous fix (#2019) only set `AMIBERRY_HOME_DIR` from `retro_set_environment()`, which was insufficient. Two failure modes remained:

1. **Delayed frontend setup** — Some frontends populate `system_dir`/`save_dir` *after* `retro_set_environment()`. The env var stayed unset and `get_home_directory()` fell back to `$HOME/Amiberry`.
2. **Standalone config bleed-through** — Even when `AMIBERRY_HOME_DIR` was set, the user's saved standalone `amiberry.conf` (e.g. at `~/.config/amiberry/amiberry.conf` on Linux) was loaded and overwrote the env-var-based defaults with explicit `$HOME/Amiberry/*` paths. `create_missing_amiberry_folders()` then materialized those.

This PR fixes both with a multi-layer defensive approach.

Closes #2018

## Changes

### `libretro/libretro.cpp`
- Extract `sync_amiberry_home_dir_from_frontend()` helper (idempotent — never overwrites if already set).
- Call it from **four** lifecycle points: `retro_set_environment`, `retro_init`, `retro_load_game`, and `core_entry` (the last opportunity before `amiberry_main` runs).
- If `AMIBERRY_HOME_DIR` is still unset by `core_entry`, log a libretro `RETRO_LOG_WARN` directing the user to configure their frontend's system/save dir.

### `src/osdep/amiberry.cpp`
- `get_home_directory()`, `get_config_directory()`, `get_plugins_directory()` — under `#ifdef LIBRETRO`, return **empty** instead of falling back to `$HOME/Amiberry` / `~/Documents/Amiberry`. Empty paths cascade harmlessly through `init_amiberry_dirs()` (`append_path_component` and `ensure_directory_exists_if_missing` both early-return on empty).
- `get_settings_directory()` — under `#ifdef LIBRETRO`, return `AMIBERRY_HOME_DIR` (or empty if unset). This isolates the libretro core's `amiberry.conf`/`amiberry.ini` from the standalone install, so the libretro core neither inherits the user's saved standalone path overrides nor overwrites their standalone config.

## Verification

I built a minimal libretro frontend test harness that simulates three lifecycle scenarios. All three now pass:

| Scenario | Before fix | After fix |
|----------|-----------|-----------|
| **Normal**: frontend sets dirs in `retro_set_environment` | ✅ already worked | ✅ works (via `retro_set_environment`) |
| **Delayed**: frontend sets dirs *after* `retro_init` | ❌ `~/Documents/Amiberry` files written | ✅ works (via `retro_load_game`) |
| **No-system**: frontend never provides dirs | ❌ `~/Documents/Amiberry` files written | ✅ no host pollution; warning logged |

In all three scenarios the libretro core's directories (`CDROMs`, `Configurations`, `Floppies`, etc.) end up under the frontend-provided save dir (or are skipped entirely), and the user's standalone `~/Documents/Amiberry/Amiberry.log` and `~/Library/Application Support/Amiberry/amiberry.conf` mtimes remain unchanged.

Standalone build verified separately with `--dump-paths` — paths resolve identically to before the change.

## Test plan
- [x] libretro core builds cleanly (no new warnings)
- [x] Standalone CMake build compiles and links cleanly
- [x] Test harness scenario "normal" — `~/Amiberry` (or `~/Documents/Amiberry`) untouched, dirs created in libretro save_dir
- [x] Test harness scenario "delayed-system" — same outcome (caught by the new `retro_load_game` defensive call)
- [x] Test harness scenario "no-system" — no host filesystem mutation, libretro warning logged
- [x] Standalone `amiberry --dump-paths` shows correct paths (libretro guards inactive)
- [x] User's standalone `amiberry.conf` no longer leaks into libretro session

## Regression Safety
All non-libretro code paths are gated behind `#ifdef LIBRETRO`. Standalone, Android, iOS, Windows builds are untouched. The only files modified are `libretro/libretro.cpp` (libretro-only) and `src/osdep/amiberry.cpp` (the LIBRETRO-conditional sections of `get_home_directory`, `get_config_directory`, `get_plugins_directory`, `get_settings_directory`).