### PR TITLE
Enable RTG ZeroCopy by default

### DIFF
--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -8893,6 +8893,9 @@ void default_prefs (struct uae_prefs *p, bool reset, int type)
 
 	p->rtg_horiz_zoom_mult = 1.0;
 	p->rtg_vert_zoom_mult = 1.0;
+#ifdef AMIBERRY
+	p->rtg_zerocopy = true;
+#endif
 
 	_tcscpy (p->floppyslots[0].df, _T(""));
 	_tcscpy (p->floppyslots[1].df, _T(""));

--- a/src/osdep/imgui/rtg.cpp
+++ b/src/osdep/imgui/rtg.cpp
@@ -58,6 +58,7 @@ void render_panel_rtg() {
     ImGui::Separator();
 
     struct rtgboardconfig *rbc = &changed_prefs.rtgboards[0];
+    const bool rtg_was_enabled = rbc->rtgmem_size > 0 || rbc->rtgmem_type >= GFXBOARD_HARDWARE;
 
     int current_board_idx = 0;
     if (rbc->rtgmem_size > 0 || rbc->rtgmem_type >= GFXBOARD_HARDWARE) {
@@ -98,6 +99,10 @@ void render_panel_rtg() {
                     rbc->rtgmem_size = 8 * 1024 * 1024;
                 }
             }
+        }
+        const bool rtg_is_enabled = rbc->rtgmem_size > 0 || rbc->rtgmem_type >= GFXBOARD_HARDWARE;
+        if (!rtg_was_enabled && rtg_is_enabled) {
+            changed_prefs.rtg_zerocopy = true;
         }
         cfgfile_compatibility_rtg(&changed_prefs);
     }


### PR DESCRIPTION
## Summary

- Enable `rtg_zerocopy` in Amiberry default preferences.
- Turn ZeroCopy on automatically when RTG is enabled from the RTG board panel.

## Why

ZeroCopy has been tested enough to be the better default for RTG output and improves performance by sharing buffers directly between emulation and display paths.

## Validation

- `git diff --cached --check`
- `cmake --build build -j$(sysctl -n hw.ncpu)`

Notes: the macOS build still emits existing warnings around deprecated `sprintf`, `extern "C" main`, duplicate libraries, and dylib bundling/signing, but it completed successfully.