### PR TITLE
Fix buttons in Controller Map window

### DIFF
--- a/src/osdep/imgui/controller_map.cpp
+++ b/src/osdep/imgui/controller_map.cpp
@@ -813,10 +813,6 @@ bool ControllerMap_HandleEvent(const SDL_Event& event)
 			return true;
 		}
 		break;
-	case SDL_EVENT_MOUSE_BUTTON_DOWN:
-	case SDL_EVENT_FINGER_DOWN:
-		SetCurrentBinding(s_iCurrentBinding + 1);
-		return true;
 	default:
 		break;
 	}


### PR DESCRIPTION
Changes proposed in this pull request:
- Removed the general click/tap handler that was interfering with the button logic.

Before:
Clicking "Back" did not go back
Clicking "Skip" skipped two steps

After:
Clicking "Back" now goes back
Clicking "Skip" skips one step

@midwan
