### PR TITLE
Heal duplicate config paths and clean startup logs

### DIFF
--- a/src/calc.cpp
+++ b/src/calc.cpp
@@ -466,7 +466,7 @@ static TCHAR *stacktostr(struct calcstack *st)
 	static TCHAR out[256];
 	if (st->s)
 		return st->s;
-	_stprintf(out, _T("%f"), st->val);
+	_sntprintf(out, sizeof out / sizeof(TCHAR), _T("%f"), st->val);
 	return out;
 }
 #endif
@@ -803,4 +803,3 @@ bool iscalcformula (const TCHAR *formula)
 	}
 	return false;
 }
-

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -2537,17 +2537,17 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		if (!p->gfx_monitor[i].enabled)
 			continue;
 		TCHAR tmp[256];
-		_stprintf(tmp, _T("gfx_monitor%d_display"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_display"), i);
 		cfgfile_write(f, tmp, _T("%d"), p->gfx_monitor[i].gfx_display);
-		_stprintf(tmp, _T("gfx_monitor%d_fullscreen"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_fullscreen"), i);
 		cfgfile_write(f, tmp, _T("%d"), p->gfx_monitor[i].gfx_fullscreen);
-		_stprintf(tmp, _T("gfx_monitor%d_width_windowed"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_width_windowed"), i);
 		cfgfile_write(f, tmp, _T("%d"), p->gfx_monitor[i].gfx_size_win.width);
-		_stprintf(tmp, _T("gfx_monitor%d_height_windowed"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_height_windowed"), i);
 		cfgfile_write(f, tmp, _T("%d"), p->gfx_monitor[i].gfx_size_win.height);
-		_stprintf(tmp, _T("gfx_monitor%d_width_fullscreen"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_width_fullscreen"), i);
 		cfgfile_write(f, tmp, _T("%d"), p->gfx_monitor[i].gfx_size_fs.width);
-		_stprintf(tmp, _T("gfx_monitor%d_height_fullscreen"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_height_fullscreen"), i);
 		cfgfile_write(f, tmp, _T("%d"), p->gfx_monitor[i].gfx_size_fs.height);
 	}
 
@@ -4161,24 +4161,24 @@ static int cfgfile_parse_host (struct uae_prefs *p, TCHAR *option, TCHAR *value)
 
 	for (int i = 1; i < MAX_AMIGADISPLAYS; i++) {
 		TCHAR tmp[256];
-		_stprintf(tmp, _T("gfx_monitor%d_display"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_display"), i);
 		if (cfgfile_intval(option, value, tmp, &p->gfx_monitor[i].gfx_display, 1)) {
 			p->gfx_monitor[i].enabled = true;
 			return 1;
 		}
-		_stprintf(tmp, _T("gfx_monitor%d_fullscreen"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_fullscreen"), i);
 		if (cfgfile_intval(option, value, tmp, &p->gfx_monitor[i].gfx_fullscreen, 1))
 			return 1;
-		_stprintf(tmp, _T("gfx_monitor%d_width_windowed"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_width_windowed"), i);
 		if (cfgfile_intval(option, value, tmp, &p->gfx_monitor[i].gfx_size_win.width, 1))
 			return 1;
-		_stprintf(tmp, _T("gfx_monitor%d_height_windowed"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_height_windowed"), i);
 		if (cfgfile_intval(option, value, tmp, &p->gfx_monitor[i].gfx_size_win.height, 1))
 			return 1;
-		_stprintf(tmp, _T("gfx_monitor%d_width_fullscreen"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_width_fullscreen"), i);
 		if (cfgfile_intval(option, value, tmp, &p->gfx_monitor[i].gfx_size_fs.width, 1))
 			return 1;
-		_stprintf(tmp, _T("gfx_monitor%d_height_fullscreen"), i);
+		_sntprintf(tmp, sizeof tmp / sizeof(TCHAR), _T("gfx_monitor%d_height_fullscreen"), i);
 		if (cfgfile_intval(option, value, tmp, &p->gfx_monitor[i].gfx_size_fs.height, 1))
 			return 1;
 	}

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -789,6 +789,49 @@ static TCHAR *cfgfile_put_multipath (struct multipath *mp, const TCHAR *s)
 	return my_strdup (s);
 }
 
+#ifdef AMIBERRY
+static bool cfgfile_multipath_entry_matches(const TCHAR *path1, const TCHAR *path2)
+{
+	if (!path1[0] || !path2[0])
+		return false;
+
+	TCHAR tmp1[MAX_DPATH], tmp2[MAX_DPATH];
+	_tcsncpy(tmp1, path1, MAX_DPATH - 1);
+	tmp1[MAX_DPATH - 1] = 0;
+	_tcsncpy(tmp2, path2, MAX_DPATH - 1);
+	tmp2[MAX_DPATH - 1] = 0;
+
+	fix_trailing(tmp1);
+	fix_trailing(tmp2);
+
+#ifdef _WIN32
+	for (TCHAR *p = tmp1; *p; p++) {
+		if (*p == '\\')
+			*p = '/';
+	}
+	for (TCHAR *p = tmp2; *p; p++) {
+		if (*p == '\\')
+			*p = '/';
+	}
+#endif
+
+#if defined(_WIN32) || defined(__APPLE__)
+	return _tcsicmp(tmp1, tmp2) == 0;
+#else
+	return _tcscmp(tmp1, tmp2) == 0;
+#endif
+}
+
+static bool cfgfile_multipath_contains_entry(const struct multipath *mp, const TCHAR *path, int entries)
+{
+	for (int i = 0; i < entries; i++) {
+		if (cfgfile_multipath_entry_matches(mp->path[i], path))
+			return true;
+	}
+	return false;
+}
+#endif
+
 
 static TCHAR *cfgfile_subst_path_load (const TCHAR *path, struct multipath *mp, const TCHAR *file, bool dir)
 {
@@ -1169,6 +1212,16 @@ static void cfgfile_dwrite_path (struct zfile *f, struct multipath *mp, const TC
 	cfgfile_dwrite_str (f, option, s);
 	xfree (s);
 }
+
+#ifdef AMIBERRY
+static void cfgfile_write_multipath(struct zfile *f, const TCHAR *option, const struct multipath *mp)
+{
+	for (int i = 0; i < MAX_PATHS; i++) {
+		if (mp->path[i][0] && !cfgfile_multipath_contains_entry(mp, mp->path[i], i))
+			cfgfile_write_str(f, option, mp->path[i]);
+	}
+}
+#endif
 
 static void cfgfile_write_multichoice(struct zfile *f, const TCHAR *option, const TCHAR *table[], int value)
 {
@@ -2061,6 +2114,16 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		}
 	}
 
+#ifdef AMIBERRY
+	_sntprintf(tmp, sizeof tmp, _T("%s.rom_path"), TARGET_NAME);
+	cfgfile_write_multipath(f, tmp, &p->path_rom);
+	_sntprintf(tmp, sizeof tmp, _T("%s.floppy_path"), TARGET_NAME);
+	cfgfile_write_multipath(f, tmp, &p->path_floppy);
+	_sntprintf(tmp, sizeof tmp, _T("%s.hardfile_path"), TARGET_NAME);
+	cfgfile_write_multipath(f, tmp, &p->path_hardfile);
+	_sntprintf(tmp, sizeof tmp, _T("%s.cd_path"), TARGET_NAME);
+	cfgfile_write_multipath(f, tmp, &p->path_cd);
+#else
 	for (i = 0; i < MAX_PATHS; i++) {
 		if (p->path_rom.path[i][0]) {
 			_sntprintf (tmp, sizeof tmp, _T("%s.rom_path"), TARGET_NAME);
@@ -2085,6 +2148,7 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 			cfgfile_write_str (f, tmp, p->path_cd.path[i]);
 		}
 	}
+#endif
 
 	cfg_write (_T("; host-specific"), f);
 
@@ -3403,6 +3467,19 @@ static int cfgfile_multipath (const TCHAR *option, const TCHAR *value, const TCH
 	TCHAR tmploc[MAX_DPATH];
 	if (!cfgfile_string (option, value, name, tmploc, MAX_DPATH))
 		return 0;
+#ifdef AMIBERRY
+	const auto s = target_expand_environment (tmploc, nullptr, 0);
+	_tcsncpy (tmploc, s, MAX_DPATH - 1);
+	tmploc[MAX_DPATH - 1] = 0;
+	fix_trailing (tmploc);
+	xfree (s);
+	if (cfgfile_multipath_contains_entry(mp, tmploc, MAX_PATHS))
+		return 1;
+	for (int i = 0; i < MAX_PATHS; i++) {
+		if (mp->path[i][0] == 0 || (i == 0 && (!_tcscmp (mp->path[i], _T(".\\")) || !_tcscmp (mp->path[i], _T("./"))))) {
+			_tcsncpy (mp->path[i], tmploc, MAX_DPATH - 1);
+			mp->path[i][MAX_DPATH - 1] = 0;
+#else
 	for (int i = 0; i < MAX_PATHS; i++) {
 		if (mp->path[i][0] == 0 || (i == 0 && (!_tcscmp (mp->path[i], _T(".\\")) || !_tcscmp (mp->path[i], _T("./"))))) {
 			const auto s = target_expand_environment (tmploc, nullptr, 0);
@@ -3410,6 +3487,7 @@ static int cfgfile_multipath (const TCHAR *option, const TCHAR *value, const TCH
 			mp->path[i][MAX_DPATH - 1] = 0;
 			fix_trailing (mp->path[i]);
 			xfree (s);
+#endif
 			//target_multipath_modified(p);
 			return 1;
 		}

--- a/src/debugmem.cpp
+++ b/src/debugmem.cpp
@@ -3679,7 +3679,7 @@ int debugmem_get_symbol(uaecptr addr, TCHAR *out, int maxsize)
 						if (!first)
 							*p2++ = ',';
 						first = false;
-						_stprintf(p2, _T("%s:+%05X"), sv->name, sv->offset);
+						_sntprintf(p2, sizeof txt2 / sizeof(TCHAR) - (p2 - txt2), _T("%s:+%05X"), sv->name, sv->offset);
 						if (size <= _tcslen(txt2))
 							break;
 						size -= _tcslen(txt2);
@@ -3716,7 +3716,7 @@ int debugmem_get_sourceline(uaecptr addr, TCHAR *out, int maxsize)
 		for (int i = 0; i < codefilecnt; i++) {
 			struct debugcodefile *cf = codefiles[i];
 			if (cf && addr >= cf->start_pc && addr < cf->end_pc) {
-				_stprintf(out, _T("Source file: %s\n"), cf->name);
+				_sntprintf(out, maxsize, _T("Source file: %s\n"), cf->name);
 				return -1;
 			}
 		}

--- a/src/expansion.cpp
+++ b/src/expansion.cpp
@@ -3152,7 +3152,7 @@ static void expansion_parse_cards(struct uae_prefs *p, bool log)
 						}
 					}
 				}
-				_stprintf(label, _T("%s (%s)"), aci->cst->name, man);
+				_sntprintf(label, sizeof label / sizeof(TCHAR), _T("%s (%s)"), aci->cst->name, man);
 #endif
 				_tcscpy(label, aci->cst->name);
 			}

--- a/src/fpp_softfloat.cpp
+++ b/src/fpp_softfloat.cpp
@@ -107,7 +107,7 @@ static const TCHAR *fp_printx80(floatx80 *fx, int mode)
 	flag n, u, d;
 
 	if (mode < 0) {
-		_stprintf(fsout, _T("%04X-%08X-%08X"), fx->high, (uae_u32)(fx->low >> 32), (uae_u32)fx->low);
+		_sntprintf(fsout, sizeof fsout / sizeof(TCHAR), _T("%04X-%08X-%08X"), fx->high, (uae_u32)(fx->low >> 32), (uae_u32)fx->low);
 		return fsout;
 	}
 
@@ -116,17 +116,17 @@ static const TCHAR *fp_printx80(floatx80 *fx, int mode)
 	d = floatx80_is_denormal(*fx);
 	
 	if (floatx80_is_infinity(*fx)) {
-		_stprintf(fsout, _T("%c%s"), n ? '-' : '+', _T("inf"));
+		_sntprintf(fsout, sizeof fsout / sizeof(TCHAR), _T("%c%s"), n ? '-' : '+', _T("inf"));
 	} else if (floatx80_is_signaling_nan(*fx)) {
-		_stprintf(fsout, _T("%c%s"), n ? '-' : '+', _T("snan"));
+		_sntprintf(fsout, sizeof fsout / sizeof(TCHAR), _T("%c%s"), n ? '-' : '+', _T("snan"));
 	} else if (floatx80_is_nan(*fx)) {
-		_stprintf(fsout, _T("%c%s"), n ? '-' : '+', _T("nan"));
+		_sntprintf(fsout, sizeof fsout / sizeof(TCHAR), _T("%c%s"), n ? '-' : '+', _T("nan"));
 	} else {
 		int32_t len = 17;
 		int8_t save_exception_flags = fs.float_exception_flags;
 		fs.float_exception_flags = 0;
 		floatx80 x = floatx80_to_floatdecimal(*fx, &len, &fs);
-		_stprintf(fsout, _T("%c%01lld.%016llde%c%05u%s%s"), n ? '-' : '+',
+		_sntprintf(fsout, sizeof fsout / sizeof(TCHAR), _T("%c%01lld.%016llde%c%05u%s%s"), n ? '-' : '+',
 				x.low / LIT64(10000000000000000), x.low % LIT64(10000000000000000),
 				(x.high & 0x4000) ? '-' : '+', x.high & 0x3FFF, d ? _T("D") : u ? _T("U") : _T(""),
 				(fs.float_exception_flags & float_flag_inexact) ? _T("~") : _T(""));
@@ -833,4 +833,3 @@ void fp_init_softfloat(int fpu_model)
 	fpp_tst = fp_tst;
 	fpp_move = fp_move;
 }
-

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -3522,7 +3522,7 @@ static void mouseupdate (int pct, bool vsync)
 #if OUTPUTDEBUG
 			if (v1 || v2) {
 				TCHAR xx1[256];
-				_stprintf(xx1, _T("%p %d VX=%d VY=%d X=%d Y=%d DX=%d DY=%d VS=%d\n"),
+				_sntprintf(xx1, sizeof xx1 / sizeof(TCHAR), _T("%p %d VX=%d VY=%d X=%d Y=%d DX=%d DY=%d VS=%d\n"),
 					GetCurrentProcess(), timeframes, v1, v2, mouse_x[i], mouse_y[i], mouse_frame_x[i] - mouse_x[i], mouse_frame_y[i] - mouse_y[i], vsync);
 				OutputDebugString(xx1);
 			}
@@ -9987,7 +9987,7 @@ void setmousestate (int mouse, int axis, int data, int isabs)
 
 #if OUTPUTDEBUG
 	TCHAR xx1[256];
-	_stprintf(xx1, _T("%p %d M=%d A=%d D=%d IA=%d\n"), GetCurrentProcess(), timeframes, mouse, axis, data, isabs);
+	_sntprintf(xx1, sizeof xx1 / sizeof(TCHAR), _T("%p %d M=%d A=%d D=%d IA=%d\n"), GetCurrentProcess(), timeframes, mouse, axis, data, isabs);
 	OutputDebugString(xx1);
 #endif
 
@@ -10071,7 +10071,7 @@ void setmousestate (int mouse, int axis, int data, int isabs)
 #if OUTPUTDEBUG
 		if (id->eventid[ID_AXIS_OFFSET + axis][i]) {
 			TCHAR xx2[256];
-			_stprintf(xx2, _T("%p %d -> %d ID=%d\n"), GetCurrentProcess(), timeframes, v, id->eventid[ID_AXIS_OFFSET + axis][i]);
+			_sntprintf(xx2, sizeof xx2 / sizeof(TCHAR), _T("%p %d -> %d ID=%d\n"), GetCurrentProcess(), timeframes, v, id->eventid[ID_AXIS_OFFSET + axis][i]);
 			OutputDebugString(xx2);
 		}
 #endif

--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -3021,25 +3021,32 @@ STATIC_INLINE void create_popalls(void)
 #if defined(CPU_AARCH64)
         /* On ARM64, allocate popallspace + JIT cache as one contiguous block
          * to guarantee the cache is within B/BL branch range (+-128 MB). */
-        const uint32 cache_kb = currprefs.cachesize > 0 ? currprefs.cachesize : MAX_JIT_CACHE;
-        const size_t cache_bytes = (size_t)cache_kb * 1024;
-        const size_t combined_size = POPALLSPACE_SIZE + cache_bytes;
-        jit_log("ARM64: allocating popallspace+cache (cache=%u KB, total=%zu bytes)",
-            cache_kb, combined_size);
-        popallspace = alloc_code(combined_size);
-        if (popallspace) {
-            popall_combined_alloc_size = combined_size;
-            popall_combined_cache_start = popallspace + POPALLSPACE_SIZE;
-            popall_combined_cache_kb = cache_kb;
-            jit_log("ARM64: combined popallspace+cache allocation at %p (%u KB cache)",
-                popallspace, cache_kb);
+        if (currprefs.cachesize > 0) {
+            const uint32 cache_kb = currprefs.cachesize;
+            const size_t cache_bytes = (size_t)cache_kb * 1024;
+            const size_t combined_size = POPALLSPACE_SIZE + cache_bytes;
+            jit_log("ARM64: allocating popallspace+cache (cache=%u KB, total=%zu bytes)",
+                cache_kb, combined_size);
+            popallspace = alloc_code(combined_size);
+            if (popallspace) {
+                popall_combined_alloc_size = combined_size;
+                popall_combined_cache_start = popallspace + POPALLSPACE_SIZE;
+                popall_combined_cache_kb = cache_kb;
+                jit_log("ARM64: combined popallspace+cache allocation at %p (%u KB cache)",
+                    popallspace, cache_kb);
+            } else {
+                /* Fall back to popallspace-only allocation */
+                popall_combined_alloc_size = 0;
+                popall_combined_cache_start = NULL;
+                popall_combined_cache_kb = 0;
+                jit_log("ARM64: combined popallspace+cache allocation failed; retrying popallspace-only (%u bytes)",
+                    (unsigned)POPALLSPACE_SIZE);
+                popallspace = alloc_code(POPALLSPACE_SIZE);
+            }
         } else {
-            /* Fall back to popallspace-only allocation */
             popall_combined_alloc_size = 0;
             popall_combined_cache_start = NULL;
             popall_combined_cache_kb = 0;
-            jit_log("ARM64: combined popallspace+cache allocation failed; retrying popallspace-only (%u bytes)",
-                (unsigned)POPALLSPACE_SIZE);
             popallspace = alloc_code(POPALLSPACE_SIZE);
         }
         if (popallspace == NULL) {
@@ -3353,6 +3360,8 @@ void build_comp(void)
 		return;
 	}
 	alloc_cache();
+	if (currprefs.cachesize == 0)
+		return;
 	if (!compiled_code) {
 		disable_jit_runtime("failed to allocate ARM64 JIT code cache");
 		return;

--- a/src/osdep/ahi_v2.cpp
+++ b/src/osdep/ahi_v2.cpp
@@ -511,8 +511,9 @@ static int alError(const TCHAR* format, ...)
 	if (err == AL_NO_ERROR)
 		return 0;
 	va_start(parms, format);
-	_vsntprintf(buffer, sizeof buffer - 1, format, parms);
-	_stprintf(buffer + _tcslen(buffer), _T(": ERR=%x\n"), err);
+	_vsntprintf(buffer, sizeof buffer / sizeof(TCHAR), format, parms);
+	va_end(parms);
+	_sntprintf(buffer + _tcslen(buffer), sizeof buffer / sizeof(TCHAR) - _tcslen(buffer), _T(": ERR=%x\n"), err);
 	write_log(_T("%s"), buffer);
 	return err;
 }

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4062,7 +4062,12 @@ void fullpath(TCHAR* path, int size, bool userelative)
 	}
 	else if (path[0] != 0)
 	{
-		write_log("fullpath: realpath() failed for '%s' (errno=%d), using path as-is.\n", path, errno);
+		const auto path_len = _tcslen(path);
+		const bool pseudo_path = path[0] == ':';
+		const bool optional_geometry_file = errno == ENOENT && path_len >= 4
+			&& _tcsicmp(path + path_len - 4, _T(".geo")) == 0;
+		if (!pseudo_path && !optional_geometry_file)
+			write_log("fullpath: realpath() failed for '%s' (errno=%d), using path as-is.\n", path, errno);
 	}
 }
 
@@ -4194,6 +4199,21 @@ void target_quit()
 #endif
 }
 
+#ifdef AMIBERRY
+static void heal_unavailable_display_index(int& display, const char* label)
+{
+	if (display <= 0)
+		return;
+	if (target_get_display_name(display, false))
+		return;
+
+	const int previous_display = display;
+	display = 1;
+	if (previous_display != display)
+		write_log("Configured %s display %d is not available, using primary display\n", label, previous_display);
+}
+#endif
+
 void target_fixup_options(uae_prefs* p)
 {
 	if (p->automount_cddrives && !p->scsi)
@@ -4232,6 +4252,12 @@ void target_fixup_options(uae_prefs* p)
 	{
 		// Make sure that Auto-Center is disabled
 		p->gfx_xcenter = p->gfx_ycenter = 0;
+	}
+	heal_unavailable_display_index(p->gfx_apmode[APMODE_NATIVE].gfx_display, "native");
+	heal_unavailable_display_index(p->gfx_apmode[APMODE_RTG].gfx_display, "RTG");
+	for (int i = 1; i < MAX_AMIGADISPLAYS; i++) {
+		if (p->gfx_monitor[i].enabled)
+			heal_unavailable_display_index(p->gfx_monitor[i].gfx_display, "monitor");
 	}
 #ifdef WITH_THREADED_CPU
 	// JIT and CPU Thread can now work together.

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4344,7 +4344,7 @@ void target_default_options(uae_prefs* p, const int type)
 			p->gf[GF_RTG].gfx_filter = 1;
 		//WIN32GUI_LoadUIString(IDS_INPUT_CUSTOM, buf, sizeof buf / sizeof(TCHAR));
 		//for (int i = 0; i < GAMEPORT_INPUT_SETTINGS; i++)
-		//	_stprintf(p->input_config_name[i], buf, i + 1);
+		//	_sntprintf(p->input_config_name[i], sizeof p->input_config_name[i] / sizeof(TCHAR), buf, i + 1);
 		//p->aviout_xoffset = -1;
 		//p->aviout_yoffset = -1;
 	}

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4204,7 +4204,10 @@ static void heal_unavailable_display_index(int& display, const char* label)
 {
 	if (display <= 0)
 		return;
-	if (target_get_display_name(display, false))
+	int display_count = 0;
+	while (display_count < MAX_DISPLAYS && Displays[display_count].monitorname)
+		display_count++;
+	if (display_count == 0 || display <= display_count)
 		return;
 
 	const int previous_display = display;

--- a/src/osdep/amiberry_hardfile.cpp
+++ b/src/osdep/amiberry_hardfile.cpp
@@ -516,7 +516,7 @@ static void scan_harddrives_windows()
 		if (!(logical_drives & 1))
 			continue;
 		TCHAR vol_path[16];
-		_stprintf(vol_path, _T("\\\\.\\%c:"), letter);
+		_sntprintf(vol_path, sizeof vol_path / sizeof(TCHAR), _T("\\\\.\\%c:"), letter);
 		HANDLE hVol = CreateFile(vol_path, 0,
 			FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
 		if (hVol == INVALID_HANDLE_VALUE)
@@ -538,7 +538,7 @@ static void scan_harddrives_windows()
 
 	for (int drv = 0; drv < 32; drv++) {
 		TCHAR dev_path[64];
-		_stprintf(dev_path, _T("\\\\.\\PhysicalDrive%d"), drv);
+		_sntprintf(dev_path, sizeof dev_path / sizeof(TCHAR), _T("\\\\.\\PhysicalDrive%d"), drv);
 
 		// Probe with zero access first (just check existence)
 		HANDLE h = CreateFile(dev_path, 0,

--- a/src/osdep/amiberry_serial.cpp
+++ b/src/osdep/amiberry_serial.cpp
@@ -190,7 +190,7 @@ bool shmem_serial_create()
 	}
 
 	if (ftruncate(fd, sizeof(sermap_buffer) * 2) == -1) {
-		write_log("Failed to set size of shared memory");
+		write_log("Failed to set size of shared memory: %s\n", strerror(errno));
 		close(fd);
 		return false;
 	}

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -897,9 +897,9 @@ static int create_windows(struct AmigaMonitor* mon)
 	}
 	TCHAR wintitle[256];
 	if (mon->monitor_id > 0)
-		_stprintf(wintitle, _T("Amiberry [%d]"), mon->monitor_id + 1);
+		_sntprintf(wintitle, sizeof wintitle / sizeof(TCHAR), _T("Amiberry [%d]"), mon->monitor_id + 1);
 	else if (last_active_config[0])
-		_stprintf(wintitle, _T("Amiberry - [%s]"), last_active_config);
+		_sntprintf(wintitle, sizeof wintitle / sizeof(TCHAR), _T("Amiberry - [%s]"), last_active_config);
 	else
 		_tcscpy(wintitle, _T("Amiberry"));
 	mon->amiga_window = SDL_CreateWindow(wintitle,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -721,7 +721,7 @@ int enumserialports (void)
 	TCHAR devname[MAX_DPATH];
 	for (int i = 0; i < 32; i++) {
 		TCHAR comname[16];
-		_stprintf(comname, _T("COM%d"), i);
+		_sntprintf(comname, sizeof comname / sizeof(TCHAR), _T("COM%d"), i);
 		if (QueryDosDevice(comname, devname, sizeof(devname) / sizeof(TCHAR))) {
 			serial_ports.emplace_back(comname);
 			cnt++;


### PR DESCRIPTION
## Summary

- Deduplicate Amiberry multipath config entries when loading and saving `.uae` files
- Replace remaining unbounded `_stprintf` calls with bounded `_sntprintf`
- Reduce noisy startup logs for optional `.geo` files, pseudo paths, unavailable displays, and disabled ARM64 JIT cache allocation

## Details

Duplicate `amiberry.*_path` entries were preserved because defaults seed the multipath arrays and config loading appended each matching line. This now deduplicates Amiberry path entries while keeping the behavior behind `AMIBERRY` guards to reduce WinUAE merge friction.

The startup-log cleanup also preserves `gfx_display=0` as the existing primary/default display value and only heals explicit unavailable display indexes.

## Validation

- `git diff --check master...HEAD`
- `rg -n "_stprintf\(" src`
- `cmake --build cmake-build-debug -j8`

Runtime A4000 boot/log validation is left for manual testing.