### PR TITLE
Fix keyboard LED console probing

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -417,23 +417,121 @@ char kbd_flags;
 int led_console_fd = -1;
 
 #if defined(__linux__) && !defined(__ANDROID__) && !defined(LIBRETRO)
+static char led_console_name[128];
+static bool led_console_reported_io_error = false;
+
+static void remember_led_console_name(const int fd, const char* fallback)
+{
+	if (ttyname_r(fd, led_console_name, sizeof led_console_name) != 0 || led_console_name[0] == '\0') {
+		strncpy(led_console_name, fallback, sizeof led_console_name - 1);
+		led_console_name[sizeof led_console_name - 1] = '\0';
+	}
+}
+
+static void log_led_console_io_error(const char* op)
+{
+	if (led_console_reported_io_error)
+		return;
+
+	led_console_reported_io_error = true;
+	write_log(_T("Keyboard LEDs: %s failed on %s (errno=%d: %s), disabling keyboard LED updates\n"),
+		op, led_console_name[0] != '\0' ? led_console_name : "console TTY", errno, strerror(errno));
+}
+
+static bool probe_led_console(const int fd, const char* path, unsigned char* leds)
+{
+	if (ioctl(fd, KDGETLED, leds) < 0)
+		return false;
+
+	// Probe writes too: a readable console fd is not sufficient for activity LEDs.
+	if (ioctl(fd, KDSETLED, *leds) < 0)
+		return false;
+
+	remember_led_console_name(fd, path);
+	return true;
+}
+
+bool amiberry_led_console_get_leds(unsigned char* leds)
+{
+	if (led_console_fd < 0)
+		return false;
+	if (ioctl(led_console_fd, KDGETLED, leds) == 0)
+		return true;
+
+	log_led_console_io_error("KDGETLED");
+	close(led_console_fd);
+	led_console_fd = -1;
+	return false;
+}
+
+bool amiberry_led_console_set_leds(const unsigned char leds)
+{
+	if (led_console_fd < 0)
+		return false;
+	if (ioctl(led_console_fd, KDSETLED, leds) == 0)
+		return true;
+
+	log_led_console_io_error("KDSETLED");
+	close(led_console_fd);
+	led_console_fd = -1;
+	return false;
+}
+
+bool amiberry_led_console_get_flags(char* flags)
+{
+	if (led_console_fd < 0)
+		return false;
+	if (ioctl(led_console_fd, KDGKBLED, flags) == 0)
+		return true;
+
+	log_led_console_io_error("KDGKBLED");
+	close(led_console_fd);
+	led_console_fd = -1;
+	return false;
+}
+
 static void open_led_console(void)
 {
 	if (led_console_fd >= 0)
 		return;
 
-	static const char* const candidates[] = { "/dev/tty", "/dev/tty0", "/dev/console" };
+	char stdin_tty[128] = {};
+	const bool have_stdin_tty = ttyname_r(STDIN_FILENO, stdin_tty, sizeof stdin_tty) == 0 && stdin_tty[0] != '\0';
+	const char* const candidates[] = {
+		"/dev/tty0",
+		have_stdin_tty ? stdin_tty : nullptr,
+		"/dev/tty",
+		"/dev/console"
+	};
 	int last_errno = 0;
 	for (size_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); ++i) {
+		if (candidates[i] == nullptr)
+			continue;
+
+		bool seen = false;
+		for (size_t j = 0; j < i; ++j) {
+			if (candidates[j] != nullptr && strcmp(candidates[i], candidates[j]) == 0) {
+				seen = true;
+				break;
+			}
+		}
+		if (seen)
+			continue;
+
 		const int fd = open(candidates[i], O_RDWR | O_NOCTTY | O_CLOEXEC);
 		if (fd < 0) {
 			last_errno = errno;
 			continue;
 		}
 		unsigned char probe = 0;
-		if (ioctl(fd, KDGETLED, &probe) == 0) {
+		if (probe_led_console(fd, candidates[i], &probe)) {
 			led_console_fd = fd;
-			write_log(_T("Keyboard LEDs: using %s for KD ioctls\n"), candidates[i]);
+			kbd_led_status = probe;
+			led_console_reported_io_error = false;
+			if (strcmp(candidates[i], led_console_name) == 0)
+				write_log(_T("Keyboard LEDs: using %s for KD ioctls\n"), led_console_name);
+			else
+				write_log(_T("Keyboard LEDs: using %s (%s) for KD ioctls\n"), candidates[i], led_console_name);
 			return;
 		}
 		last_errno = errno;
@@ -451,6 +549,21 @@ static void close_led_console(void)
 	}
 }
 #else
+bool amiberry_led_console_get_leds(unsigned char* leds)
+{
+	(void)leds;
+	return false;
+}
+bool amiberry_led_console_set_leds(const unsigned char leds)
+{
+	(void)leds;
+	return false;
+}
+bool amiberry_led_console_get_flags(char* flags)
+{
+	(void)flags;
+	return false;
+}
 static inline void open_led_console(void) {}
 static inline void close_led_console(void) {}
 #endif

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -419,6 +419,7 @@ int led_console_fd = -1;
 #if defined(__linux__) && !defined(__ANDROID__) && !defined(LIBRETRO)
 static char led_console_name[128];
 static bool led_console_reported_io_error = false;
+static bool led_console_updates_disabled = false;
 
 static void remember_led_console_name(const int fd, const char* fallback)
 {
@@ -428,13 +429,14 @@ static void remember_led_console_name(const int fd, const char* fallback)
 	}
 }
 
-static void log_led_console_io_error(const char* op)
+static void disable_led_console_updates(const char* op)
 {
+	led_console_updates_disabled = true;
 	if (led_console_reported_io_error)
 		return;
 
 	led_console_reported_io_error = true;
-	write_log(_T("Keyboard LEDs: %s failed on %s (errno=%d: %s), disabling keyboard LED updates\n"),
+	write_log(_T("Keyboard LEDs: %s failed on %s (errno=%d: %s), disabling keyboard LED activity updates\n"),
 		op, led_console_name[0] != '\0' ? led_console_name : "console TTY", errno, strerror(errno));
 }
 
@@ -453,40 +455,34 @@ static bool probe_led_console(const int fd, const char* path, unsigned char* led
 
 bool amiberry_led_console_get_leds(unsigned char* leds)
 {
-	if (led_console_fd < 0)
+	if (led_console_fd < 0 || led_console_updates_disabled)
 		return false;
 	if (ioctl(led_console_fd, KDGETLED, leds) == 0)
 		return true;
 
-	log_led_console_io_error("KDGETLED");
-	close(led_console_fd);
-	led_console_fd = -1;
+	disable_led_console_updates("KDGETLED");
 	return false;
 }
 
 bool amiberry_led_console_set_leds(const unsigned char leds)
 {
-	if (led_console_fd < 0)
+	if (led_console_fd < 0 || led_console_updates_disabled)
 		return false;
 	if (ioctl(led_console_fd, KDSETLED, leds) == 0)
 		return true;
 
-	log_led_console_io_error("KDSETLED");
-	close(led_console_fd);
-	led_console_fd = -1;
+	disable_led_console_updates("KDSETLED");
 	return false;
 }
 
 bool amiberry_led_console_get_flags(char* flags)
 {
-	if (led_console_fd < 0)
+	if (led_console_fd < 0 || led_console_updates_disabled)
 		return false;
 	if (ioctl(led_console_fd, KDGKBLED, flags) == 0)
 		return true;
 
-	log_led_console_io_error("KDGKBLED");
-	close(led_console_fd);
-	led_console_fd = -1;
+	disable_led_console_updates("KDGKBLED");
 	return false;
 }
 
@@ -528,6 +524,7 @@ static void open_led_console(void)
 			led_console_fd = fd;
 			kbd_led_status = probe;
 			led_console_reported_io_error = false;
+			led_console_updates_disabled = false;
 			if (strcmp(candidates[i], led_console_name) == 0)
 				write_log(_T("Keyboard LEDs: using %s for KD ioctls\n"), led_console_name);
 			else

--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -57,9 +57,10 @@
 #endif
 #endif
 
-// Console fd for KDSETLED/KDGETLED, opened by open_led_console() in amiberry.cpp;
-// -1 when no usable console TTY is available — guard each ioctl with `>= 0`.
-extern int led_console_fd;
+#if defined(__linux__)
+extern bool amiberry_led_console_get_leds(unsigned char* leds);
+extern bool amiberry_led_console_set_leds(unsigned char leds);
+#endif
 
 int emulating = 0;
 bool config_loaded = false;
@@ -1039,7 +1040,7 @@ static int want_temp = 1; // Make this a negative number to disable Temperature 
 
 void gui_led(int led, int on, int brightness)
 {
-	unsigned char kbd_led_status;
+	unsigned char kbd_led_status = 0;
 
 	// Check current prefs/ update if changed
 	if (currprefs.kbd_led_num != changed_prefs.kbd_led_num) currprefs.kbd_led_num = changed_prefs.kbd_led_num;
@@ -1058,24 +1059,23 @@ void gui_led(int led, int on, int brightness)
 		}
 	}
 
-	if (led_console_fd >= 0)
-		ioctl(led_console_fd, KDGETLED, &kbd_led_status);
+	const bool have_keyboard_leds = amiberry_led_console_get_leds(&kbd_led_status);
 
 	// Handle floppy led status
 	if (led >= LED_DF0 && led <= LED_DF3)
 	{
-		if (currprefs.kbd_led_num == led)
+		if (have_keyboard_leds && currprefs.kbd_led_num == led)
 		{
 			if (on) kbd_led_status |= LED_NUM;
 			
 			else kbd_led_status &= ~LED_NUM;
 		}
-		if (currprefs.kbd_led_scr == led)
+		if (have_keyboard_leds && currprefs.kbd_led_scr == led)
 		{
 			if (on) kbd_led_status |= LED_SCR;
 			else kbd_led_status &= ~LED_SCR;
 		}
-		if (currprefs.kbd_led_cap == led)
+		if (have_keyboard_leds && currprefs.kbd_led_cap == led)
 		{
 			if (on) kbd_led_status |= LED_CAP;
 			else kbd_led_status &= ~LED_CAP;
@@ -1094,17 +1094,17 @@ void gui_led(int led, int on, int brightness)
 	// Handle power, hd/cd led status
 	if (led == LED_POWER || led == LED_HD || led == LED_CD)
 	{
-		if (currprefs.kbd_led_num == led)
+		if (have_keyboard_leds && currprefs.kbd_led_num == led)
 		{
 			if (on) kbd_led_status |= LED_NUM;
 			else kbd_led_status &= ~LED_NUM;
 		}
-		if (currprefs.kbd_led_scr == led)
+		if (have_keyboard_leds && currprefs.kbd_led_scr == led)
 		{
 			if (on) kbd_led_status |= LED_SCR;
 			else kbd_led_status &= ~LED_SCR;
 		}
-		if (currprefs.kbd_led_cap == led)
+		if (have_keyboard_leds && currprefs.kbd_led_cap == led)
 		{
 			if (on) kbd_led_status |= LED_CAP;
 			else kbd_led_status &= ~LED_CAP;
@@ -1126,8 +1126,8 @@ void gui_led(int led, int on, int brightness)
 #endif
 	}
 
-	if (led_console_fd >= 0)
-		ioctl(led_console_fd, KDSETLED, kbd_led_status);
+	if (have_keyboard_leds)
+		amiberry_led_console_set_leds(kbd_led_status);
 
 	// Temperature reading
 	if (static unsigned int temp_count = 0; temp_fd >= 0 && ++temp_count % 25 == 0) {

--- a/src/osdep/amiberry_platform_internal_host.h
+++ b/src/osdep/amiberry_platform_internal_host.h
@@ -63,11 +63,9 @@ static inline void osdep_platform_init_ui()
 static inline void osdep_platform_sync_keyboard_leds()
 {
 #if defined(__linux__)
-	if (led_console_fd < 0)
+	if (!amiberry_led_console_get_flags(&kbd_flags))
 		return;
-	if (ioctl(led_console_fd, KDGKBLED, &kbd_flags) < 0)
-		return;
-	if (ioctl(led_console_fd, KDGETLED, &kbd_led_status) < 0)
+	if (!amiberry_led_console_get_leds(&kbd_led_status))
 		return;
 	if (kbd_flags & 07 & LED_CAP)
 	{
@@ -79,7 +77,7 @@ static inline void osdep_platform_sync_keyboard_leds()
 		kbd_led_status &= ~LED_CAP;
 		inputdevice_do_keyboard(AK_CAPSLOCK, 0);
 	}
-	ioctl(led_console_fd, KDSETLED, kbd_led_status);
+	amiberry_led_console_set_leds(kbd_led_status);
 #else
 	int caps = SDL_GetModState();
 	caps = caps & SDL_KMOD_CAPS;


### PR DESCRIPTION
## Summary
- Probe Linux console LED fds with both `KDGETLED` and `KDSETLED` before accepting them
- Prefer the active VT entry point and log the resolved console path instead of only the opened alias
- Route runtime keyboard LED ioctls through checked helpers so failures are logged once and LED state is not updated from uninitialized data

## Root Cause
The earlier fix for #1988 stopped using stdin and opened a console fd explicitly, but it only validated the fd with `KDGETLED`. The latest screenshot shows Amiberry accepted `/dev/tty`, but that did not prove `KDSETLED` writes worked. Runtime `KDGETLED`/`KDSETLED` failures were also still silent.

This patch makes startup require a successful no-op `KDSETLED` probe and adds runtime error logging. It should either restore activity LEDs on the affected Pi console setup, or produce the missing diagnostic needed for the next step.

Refs #1988

## Validation
- `git diff --check`
- `cmake --build cmake-build-debug -j8`
- `docker run --rm --platform linux/amd64 -v /Users/midwan/Github/amiberry:/src:ro midwan/amiberry-debian-x86_64:trixie bash -lc 'cmake -S /src -B /tmp/build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DDISTRO_CODENAME=trixie && cmake --build /tmp/build -j$(nproc)'`

## Notes
Physical Raspberry Pi console/KMS validation is still needed. If LEDs still do not move after this patch and there is no new `KDSETLED` failure log, the next thing to check is whether `setleds -L +num < /dev/tty1` works in the same boot path, since `setleds -D` tests lock-state behavior rather than exactly the arbitrary LED override path used here.
