### PR TITLE
Fix macOS app bundle codesigning

### DIFF
--- a/cmake/macos/codesign_bundle.cmake
+++ b/cmake/macos/codesign_bundle.cmake
@@ -1,0 +1,104 @@
+if(NOT DEFINED APP_BUNDLE OR APP_BUNDLE STREQUAL "")
+    message(FATAL_ERROR "APP_BUNDLE is required")
+endif()
+
+if(NOT EXISTS "${APP_BUNDLE}/Contents")
+    message(FATAL_ERROR "APP_BUNDLE does not look like a macOS app bundle: ${APP_BUNDLE}")
+endif()
+
+if(NOT DEFINED CODESIGN_EXECUTABLE OR CODESIGN_EXECUTABLE STREQUAL "")
+    find_program(CODESIGN_EXECUTABLE codesign)
+    if(NOT CODESIGN_EXECUTABLE)
+        message(FATAL_ERROR "codesign executable not found")
+    endif()
+endif()
+
+if(NOT DEFINED AMIBERRY_CODESIGN_IDENTITY OR AMIBERRY_CODESIGN_IDENTITY STREQUAL "")
+    set(AMIBERRY_CODESIGN_IDENTITY "-")
+endif()
+
+set(_amiberry_codesign_base_args
+    --force
+    --sign "${AMIBERRY_CODESIGN_IDENTITY}"
+)
+
+if(DEFINED AMIBERRY_CODESIGN_OPTIONS AND NOT AMIBERRY_CODESIGN_OPTIONS STREQUAL "")
+    list(APPEND _amiberry_codesign_base_args --options "${AMIBERRY_CODESIGN_OPTIONS}")
+endif()
+
+function(_amiberry_codesign _path _description)
+    execute_process(
+        COMMAND "${CODESIGN_EXECUTABLE}" ${_amiberry_codesign_base_args} "${_path}"
+        RESULT_VARIABLE _amiberry_codesign_result
+        OUTPUT_VARIABLE _amiberry_codesign_stdout
+        ERROR_VARIABLE _amiberry_codesign_stderr
+    )
+
+    if(NOT _amiberry_codesign_result EQUAL 0)
+        message(FATAL_ERROR
+            "Failed to codesign ${_description} '${_path}':\n"
+            "${_amiberry_codesign_stdout}${_amiberry_codesign_stderr}"
+        )
+    endif()
+endfunction()
+
+set(_amiberry_nested_code)
+foreach(_amiberry_nested_dir IN ITEMS
+        "${APP_BUNDLE}/Contents/Frameworks"
+        "${APP_BUNDLE}/Contents/Resources/plugins")
+    if(EXISTS "${_amiberry_nested_dir}")
+        file(GLOB_RECURSE _amiberry_dir_code
+            LIST_DIRECTORIES false
+            "${_amiberry_nested_dir}/*.dylib"
+            "${_amiberry_nested_dir}/*.so"
+        )
+        list(APPEND _amiberry_nested_code ${_amiberry_dir_code})
+    endif()
+endforeach()
+
+if(_amiberry_nested_code)
+    list(REMOVE_DUPLICATES _amiberry_nested_code)
+    list(SORT _amiberry_nested_code)
+endif()
+
+foreach(_amiberry_code IN LISTS _amiberry_nested_code)
+    if(NOT IS_SYMLINK "${_amiberry_code}")
+        _amiberry_codesign("${_amiberry_code}" "nested code")
+    endif()
+endforeach()
+
+set(_amiberry_bundle_codesign_args ${_amiberry_codesign_base_args})
+if(DEFINED AMIBERRY_ENTITLEMENTS AND NOT AMIBERRY_ENTITLEMENTS STREQUAL "")
+    if(NOT EXISTS "${AMIBERRY_ENTITLEMENTS}")
+        message(FATAL_ERROR "AMIBERRY_ENTITLEMENTS does not exist: ${AMIBERRY_ENTITLEMENTS}")
+    endif()
+    list(APPEND _amiberry_bundle_codesign_args --entitlements "${AMIBERRY_ENTITLEMENTS}")
+endif()
+
+execute_process(
+    COMMAND "${CODESIGN_EXECUTABLE}" ${_amiberry_bundle_codesign_args} "${APP_BUNDLE}"
+    RESULT_VARIABLE _amiberry_bundle_codesign_result
+    OUTPUT_VARIABLE _amiberry_bundle_codesign_stdout
+    ERROR_VARIABLE _amiberry_bundle_codesign_stderr
+)
+
+if(NOT _amiberry_bundle_codesign_result EQUAL 0)
+    message(FATAL_ERROR
+        "Failed to codesign app bundle '${APP_BUNDLE}':\n"
+        "${_amiberry_bundle_codesign_stdout}${_amiberry_bundle_codesign_stderr}"
+    )
+endif()
+
+execute_process(
+    COMMAND "${CODESIGN_EXECUTABLE}" --verify --deep --strict "${APP_BUNDLE}"
+    RESULT_VARIABLE _amiberry_verify_result
+    OUTPUT_VARIABLE _amiberry_verify_stdout
+    ERROR_VARIABLE _amiberry_verify_stderr
+)
+
+if(NOT _amiberry_verify_result EQUAL 0)
+    message(FATAL_ERROR
+        "Failed to verify app bundle signature '${APP_BUNDLE}':\n"
+        "${_amiberry_verify_stdout}${_amiberry_verify_stderr}"
+    )
+endif()

--- a/cmake/macos/install.cmake
+++ b/cmake/macos/install.cmake
@@ -34,23 +34,51 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -DAPP_BINARY=$<TARGET_FILE:${PROJECT_NAME}> -P ${CMAKE_SOURCE_DIR}/cmake/macos/dedupe_frameworks_rpath.cmake)
 
-# Codesign all bundled code with the same team identity
-# This removes the need for com.apple.security.cs.disable-library-validation
-set(MACOS_CODESIGN_IDENTITY "" CACHE STRING "Code signing identity for macOS (e.g. 'Developer ID Application: Name (TEAMID)')")
-if(MACOS_CODESIGN_IDENTITY)
-    # Sign plugins
+# Codesign local/intermediate bundles after dylibbundler and install_name_tool
+# have finished mutating load commands. CI re-signs the final universal bundle
+# with the Developer ID identity before notarization.
+option(MACOS_CODESIGN_BUNDLE
+    "Codesign local/intermediate macOS app bundles after copying dependencies"
+    ON)
+string(CONCAT _amiberry_codesign_identity_help
+    "Code signing identity for local/intermediate macOS bundles "
+    "(empty for non-App Store ad-hoc, '-' for explicit ad-hoc, "
+    "or 'Developer ID Application: Name (TEAMID)')")
+set(MACOS_CODESIGN_IDENTITY "" CACHE STRING "${_amiberry_codesign_identity_help}")
+string(CONCAT _amiberry_codesign_options_help
+    "Additional codesign --options value for local/intermediate macOS bundles (for example: runtime,hard)")
+set(MACOS_CODESIGN_OPTIONS "" CACHE STRING "${_amiberry_codesign_options_help}")
+if(MACOS_CODESIGN_BUNDLE)
+    find_program(CODESIGN_EXECUTABLE codesign)
+    if(NOT CODESIGN_EXECUTABLE)
+        message(FATAL_ERROR
+            "codesign executable not found; "
+            "set MACOS_CODESIGN_BUNDLE=OFF to skip macOS bundle signing"
+        )
+    endif()
+
+    if(MACOS_APP_STORE AND MACOS_CODESIGN_IDENTITY STREQUAL "")
+        message(FATAL_ERROR
+            "MACOS_APP_STORE builds require MACOS_CODESIGN_IDENTITY; "
+            "ad-hoc signing must be requested explicitly with '-'"
+        )
+    endif()
+
+    set(_amiberry_codesign_identity "${MACOS_CODESIGN_IDENTITY}")
+    if(_amiberry_codesign_identity STREQUAL "")
+        set(_amiberry_codesign_identity "-")
+    endif()
+
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND codesign --force --sign "${MACOS_CODESIGN_IDENTITY}"
-            $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/plugins/$<TARGET_FILE_NAME:capsimage>
-        COMMENT "Codesigning capsimage plugin")
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND codesign --force --sign "${MACOS_CODESIGN_IDENTITY}"
-            $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/plugins/$<TARGET_FILE_NAME:floppybridge>
-        COMMENT "Codesigning floppybridge plugin")
-    # Sign all bundled frameworks
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND bash -c "find '$<TARGET_FILE_DIR:${PROJECT_NAME}>/../Frameworks/' -name '*.dylib' -exec codesign --force --sign '${MACOS_CODESIGN_IDENTITY}' {} \\;"
-        COMMENT "Codesigning bundled frameworks")
+        COMMAND "${CMAKE_COMMAND}"
+            "-DAPP_BUNDLE=$<TARGET_BUNDLE_DIR:${PROJECT_NAME}>"
+            "-DCODESIGN_EXECUTABLE=${CODESIGN_EXECUTABLE}"
+            "-DAMIBERRY_CODESIGN_IDENTITY=${_amiberry_codesign_identity}"
+            "-DAMIBERRY_CODESIGN_OPTIONS=${MACOS_CODESIGN_OPTIONS}"
+            "-DAMIBERRY_ENTITLEMENTS=${AMIBERRY_ENTITLEMENTS}"
+            -P "${CMAKE_SOURCE_DIR}/cmake/macos/codesign_bundle.cmake"
+        COMMENT "Codesigning Amiberry app bundle"
+        VERBATIM)
 endif()
 
 if (NOT "${CMAKE_GENERATOR}" MATCHES "Xcode")


### PR DESCRIPTION
Supersedes #2039.

## Summary

- Replace the partial macOS post-build codesigning commands with a dedicated CMake script.
- Sign nested bundle code first, then sign and verify the app bundle after `dylibbundler` and `install_name_tool` finish mutating load commands.
- Default non-App Store local/intermediate bundles to ad-hoc signing when no identity is configured.
- Require an explicit `MACOS_CODESIGN_IDENTITY` for `MACOS_APP_STORE=ON` builds, while still allowing `-` when ad-hoc signing is requested deliberately.
- Keep CI final signing behavior intact: the universal macOS bundle is still re-signed with the Developer ID identity after `lipo` and before notarization.

## Validation

- `git diff --check`
- `cmake -DAPP_BUNDLE=/tmp/amiberry-codesign-test/Amiberry.app -DCODESIGN_EXECUTABLE=/usr/bin/true -DAMIBERRY_ENTITLEMENTS=/home/midwan/CLionProjects/amiberry/packaging/macos/Amiberry.entitlements -P cmake/macos/codesign_bundle.cmake`
- `cmake -DAPP_BUNDLE=/tmp/amiberry-codesign-test/Amiberry.app -DCODESIGN_EXECUTABLE=/usr/bin/true '-DAMIBERRY_CODESIGN_IDENTITY=Developer ID Application: Example (TEAMID)' -DAMIBERRY_CODESIGN_OPTIONS=runtime,hard -DAMIBERRY_ENTITLEMENTS=/home/midwan/CLionProjects/amiberry/packaging/macos/Amiberry.entitlements -P cmake/macos/codesign_bundle.cmake`
- `cmake -B /tmp/amiberry-ci-check -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/amiberry-ci-check -j$(nproc)`
