### PR TITLE
Fix ARM64 JIT DIVU noflags flag preservation

### DIFF
--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -3335,8 +3335,10 @@ void build_comp(void)
         }
         prop[cft_map(opcode)].set_flags = table68k[opcode].flagdead;
         prop[cft_map(opcode)].use_flags = table68k[opcode].flaglive;
-        if (table68k[opcode].mnemo == i_DIVU)
+        if (table68k[opcode].mnemo == i_DIVU) {
             prop[cft_map(opcode)].use_flags |= FLAG_CZNV;
+            nfcompfunctbl[cft_map(opcode)] = compfunctbl[cft_map(opcode)];
+        }
         /* Unconditional jumps don't evaluate condition codes, so they
          * don't actually use any flags themselves */
         if (prop[cft_map(opcode)].cflow & fl_const_jump)


### PR DESCRIPTION
## Summary
- Address the post-merge review finding from #2054 for DIVU no-flags compilation.
- Keep DIVU incoming CCR marked live and force the ARM JIT no-flags compile table to use the full-flags DIVU handler.
- This preserves the existing `save_flags()` path even when normal DIVU result flags are dead, covering exception paths such as divide-by-zero.

## Validation
- `cmake --build cmake-build-debug -j8`
- Focused ARM64 JIT cputester run with `cachesize=16384` and log-confirmed `JIT=CPU/FPU=16384`:
  - ASL.B: `All tests complete (total 5120).`
  - ASL.W: `All tests complete (total 5120).`
  - ASL.L: `All tests complete (total 5120).`
  - BFINS: `All tests complete (total 5342).`
  - MULL.L: `All tests complete (total 5794).`
  - DIVL.L: `All tests complete (total 5058).`
  - DIVU.W: `All tests complete (total 10983).`
  - ASR.B sanity: `All tests complete (total 5120).`
  - DIVS.W sanity: `All tests complete (total 11057).`
- `git diff --check`
