### PR TITLE
Fix uaenet vsync wakeups

### DIFF
--- a/src/osdep/amiberry_uaenet.cpp
+++ b/src/osdep/amiberry_uaenet.cpp
@@ -146,10 +146,11 @@ static void uaenet_queue_one(struct uaenet_data *ud, const uae_u8 *data, int len
     if (!ud || len <= 0 || len > MAX_FRAME_LEN)
         return;
 
-    if (ud->packetsinbuffer > 50)
-        return;
-
     uae_sem_wait(&ud->queue_sem);
+    if (ud->packetsinbuffer > 50) {
+        uae_sem_post(&ud->queue_sem);
+        return;
+    }
 
     q = xcalloc(struct uaenet_queue, 1);
     q->data = xmalloc(uae_u8, len);
@@ -285,7 +286,7 @@ static int uaenet_checkpacket(struct uaenet_data *ud)
 {
     struct uaenet_queue *q;
 
-    if (!ud || !ud->first)
+    if (!ud)
         return 0;
 
     uae_sem_wait(&ud->queue_sem);

--- a/src/sana2.cpp
+++ b/src/sana2.cpp
@@ -1794,21 +1794,36 @@ static uae_u32 REGPARAM2 uaenet_int_handler(TrapContext *ctx)
 	}
 }
 
+static bool uaenet_vsync_has_work(struct s2devstruct *dev)
+{
+	if (dev->readqueue)
+		return true;
+
+	for (struct asyncreq *ar = dev->ar; ar; ar = ar->next) {
+		if (!ar->ready && get_word_host(ar->request + 28) == CMD_FLUSH)
+			return true;
+	}
+
+	return false;
+}
+
 static void uaenet_vsync(void)
 {
 	if (!irq_init)
 		return;
+	for (int i = 0; i < MAX_TOTAL_NET_DEVICES; i++) {
+		struct s2devstruct *dev = &devst[i];
+		if (dev->td && dev->sysdata)
+			ethernet_receive_poll(dev->td, dev->sysdata);
+	}
 	if (uae_sem_trywait(&async_sem))
 		return;
 	bool pending = false;
 	for (int i = 0; i < MAX_TOTAL_NET_DEVICES; i++) {
 		struct s2devstruct *dev = &devst[i];
-		if (dev->online) {
-			if(dev->readqueue)
-				pending = true;
-		}
-		if (dev->ar) {
+		if (uaenet_vsync_has_work(dev)) {
 			pending = true;
+			break;
 		}
 	}
 	if (uaenet_int_late || pending)

--- a/src/sana2.cpp
+++ b/src/sana2.cpp
@@ -1800,8 +1800,11 @@ static bool uaenet_vsync_has_work(struct s2devstruct *dev)
 		return true;
 
 	for (struct asyncreq *ar = dev->ar; ar; ar = ar->next) {
-		if (!ar->ready && get_word_host(ar->request + 28) == CMD_FLUSH)
-			return true;
+		if (!ar->ready) {
+			const uae_u32 command = get_word_host(ar->request + 28);
+			if (command == CMD_FLUSH || command == S2_ONLINE)
+				return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
## Summary

- Avoid waking the uaenet worker on every vsync just because long-lived SANA-II async requests exist.
- Poll queued pcap/TAP receive packets from the emulation thread before checking SANA-II pending work.
- Keep incoming backend queue state checks under `queue_sem`.

## Root Cause

`uaenet_vsync()` treated any `dev->ar` entry as pending work. Normal async requests such as `CMD_READ` and event waits can remain queued indefinitely, so uaenet was signaling the Amiga worker every frame. That worker invokes `uaenet_int_handler` through an extended trap, which creates a short-lived host thread for each wakeup.

Fixes #2060.

## Verification

- `git diff --check` exits 0; line-ending warnings only.
- `cmake --build out\build\windows-debug --target amiberry --parallel 12` exits 0. The build emits the existing vcpkg applocal warning about missing `dumpbin`/`objdump`.