### PR TITLE
Harden filesystem inode recycling

### DIFF
--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -2539,6 +2539,8 @@ static void recycle_aino (Unit *unit, a_inode *new_aino)
 		|| new_aino->elock || new_aino == &unit->rootnode)
 		/* Still in use */
 		return;
+	if (new_aino->next != 0)
+		return;
 
 	TRACE3((_T("Recycling; cache size %u, total_locked %d\n"),
 		unit->aino_cache_size, unit->total_locked_ainos));
@@ -2564,6 +2566,21 @@ static void recycle_aino (Unit *unit, a_inode *new_aino)
 	aino_test (new_aino->prev);
 
 	unit->aino_cache_size++;
+}
+
+static bool release_aino_lock(a_inode *aino, const TCHAR *action)
+{
+	if (aino->elock) {
+		aino->elock = 0;
+		return true;
+	}
+	if (aino->shlock > 0) {
+		aino->shlock--;
+		return true;
+	}
+	write_log(_T("FILESYS: %s attempted to release unlocked a_inode %08x '%s'\n"),
+		action, aino->uniq, aino->nname ? aino->nname : _T("<unnamed>"));
+	return false;
 }
 
 void filesys_flush_cache (void)
@@ -4134,10 +4151,11 @@ static void action_free_lock(TrapContext *ctx, Unit *unit, dpacket *packet)
 		PUT_PCK_RES2 (packet, ERROR_OBJECT_NOT_AROUND);
 		return;
 	}
-	if (a->elock)
-		a->elock = 0;
-	else
-		a->shlock--;
+	if (!release_aino_lock(a, _T("ACTION_FREE_LOCK"))) {
+		PUT_PCK_RES1 (packet, DOS_FALSE);
+		PUT_PCK_RES2 (packet, ERROR_INVALID_LOCK);
+		return;
+	}
 	recycle_aino (unit, a);
 	free_lock(ctx, unit, lock);
 
@@ -4195,10 +4213,24 @@ static void action_lock_from_fh(TrapContext *ctx, Unit *unit, dpacket *packet)
 
 static void free_exkey (Unit *unit, a_inode *aino)
 {
+	if (!aino)
+		return;
+	if (aino->exnext_count == 0) {
+		write_log(_T("FILESYS: attempted to release inactive ExNext a_inode %08x '%s'\n"),
+			aino->uniq, aino->nname ? aino->nname : _T("<unnamed>"));
+		return;
+	}
 	if (--aino->exnext_count == 0) {
 		TRACE ((_T("Freeing ExKey and reducing total_locked from %d by %d\n"),
 			unit->total_locked_ainos, aino->locked_children));
-		unit->total_locked_ainos -= aino->locked_children;
+		if (unit->total_locked_ainos >= aino->locked_children) {
+			unit->total_locked_ainos -= aino->locked_children;
+		} else {
+			write_log(_T("FILESYS: ExNext locked child count underflow for a_inode %08x '%s' (%u < %u)\n"),
+				aino->uniq, aino->nname ? aino->nname : _T("<unnamed>"),
+				unit->total_locked_ainos, aino->locked_children);
+			unit->total_locked_ainos = 0;
+		}
 		aino->locked_children = 0;
 	}
 }
@@ -5273,7 +5305,7 @@ static void do_find(TrapContext *ctx, Unit *unit, dpacket *packet, int mode, int
 		return;
 	} else {
 		/* Object does not exist. aino points to containing directory. */
-		aino = create_child_aino(unit, aino, my_strdup (bstr_cut(ctx, unit, name)), 0);
+		aino = create_child_aino(unit, aino, bstr_cut(ctx, unit, name), 0);
 		if (aino == 0) {
 			PUT_PCK_RES1 (packet, DOS_FALSE);
 			PUT_PCK_RES2 (packet, ERROR_DISK_IS_FULL); /* best we can do */
@@ -5442,11 +5474,8 @@ static void	action_end(TrapContext *ctx, Unit *unit, dpacket *packet)
 			notify_check(ctx, unit, k->aino);
 			updatedirtime (k->aino, 1);
 		}
-		if (k->aino->elock)
-			k->aino->elock = 0;
-		else
-			k->aino->shlock--;
-		recycle_aino (unit, k->aino);
+		if (release_aino_lock(k->aino, _T("ACTION_END")))
+			recycle_aino (unit, k->aino);
 		free_key (unit, k);
 	}
 	PUT_PCK_RES1 (packet, DOS_TRUE);
@@ -5985,7 +6014,7 @@ static void	action_create_dir(TrapContext *ctx, Unit *unit, dpacket *packet)
 		return;
 	}
 	/* Object does not exist. aino points to containing directory. */
-	aino = create_child_aino(unit, aino, my_strdup (bstr_cut(ctx, unit, name)), 1);
+	aino = create_child_aino(unit, aino, bstr_cut(ctx, unit, name), 1);
 	if (aino == 0) {
 		PUT_PCK_RES1 (packet, DOS_FALSE);
 		PUT_PCK_RES2 (packet, ERROR_DISK_IS_FULL); /* best we can do */
@@ -5993,8 +6022,10 @@ static void	action_create_dir(TrapContext *ctx, Unit *unit, dpacket *packet)
 	}
 
 	if (my_mkdir (aino->nname) == -1) {
+		const int err = dos_errno ();
+		delete_aino (unit, aino);
 		PUT_PCK_RES1 (packet, DOS_FALSE);
-		PUT_PCK_RES2 (packet, dos_errno ());
+		PUT_PCK_RES2 (packet, err);
 		return;
 	}
 	aino->shlock = 1;


### PR DESCRIPTION
## Summary

Fixes #2048 (IBrowse disk cache crash).

Harden filesystem `a_inode` lifetime handling around lock release, recycle-cache insertion, directory creation failure, and `ExNext` cleanup.

The reported IBrowse disk-cache crash aborts in `create_child_aino()` while glibc is servicing a fresh allocation, which points to earlier heap metadata damage rather than the allocation itself. The likely failure class is stale or duplicate filesystem lock/end packets driving `shlock` below zero, allowing an already-recycled inode to be inserted into the recycle ring again and later freed twice by cache flushing.

## Changes

- Make `recycle_aino()` idempotent when an inode is already linked into the recycle list.
- Add guarded lock-release handling for `ACTION_FREE_LOCK` and `ACTION_END` so unlocked inodes cannot underflow `shlock`.
- Guard `ExNext` release accounting against inactive or underflowing enumeration state.
- Clean up a transient `a_inode` if `ACTION_CREATE_DIR` fails after the inode was created but before the host directory exists.
- Remove redundant `my_strdup(bstr_cut(...))` at create call sites because `create_child_aino()` already duplicates the name.
