### PR TITLE
Fix TCP serial status handling

### DIFF
--- a/src/osdep/amiberry_serial.cpp
+++ b/src/osdep/amiberry_serial.cpp
@@ -1611,15 +1611,16 @@ static void serial_status_debug(const TCHAR* s)
 uae_u8 serial_readstatus(uae_u8 v, uae_u8 dir)
 {
 #ifdef USE_LIBSERIALPORT
-	sp_signal signal;
+	int signal = 0;
 	uae_u8 serbits = oldserbits;
 
 	if (serloop_enabled) {
 		if (serstatus & 0x80) { // DTR -> DSR + CD
-			signal = SP_SIG_DSR;
+			signal |= SP_SIG_DSR;
+			signal |= SP_SIG_DCD;
 		}
 		if (serstatus & 0x10) { // RTS -> CTS
-			signal = SP_SIG_CTS;
+			signal |= SP_SIG_CTS;
 		}
 #ifdef RETROPLATFORM
 	} else if (rp_ismodem()) {
@@ -1641,20 +1642,30 @@ uae_u8 serial_readstatus(uae_u8 v, uae_u8 dir)
 #ifdef SERIAL_MAP
 	} else if (sermap_enabled) {
 		if (sermap_flags & 1) {
-			signal = SP_SIG_DSR;
+			signal |= SP_SIG_DSR;
 		}
 		if (sermap_flags & 2) {
-			signal = SP_SIG_DCD;
+			signal |= SP_SIG_DCD;
 		}
 		if (sermap_flags & 4) {
-			signal = SP_SIG_CTS;
+			signal |= SP_SIG_CTS;
 		}
 #endif
+	} else if (tcpserial) {
+		if (tcp_is_connected()) {
+			signal |= SP_SIG_DSR;
+			signal |= SP_SIG_DCD;
+			signal |= SP_SIG_CTS;
+		}
 	} else if (currprefs.use_serial) {
 #ifdef SERIAL_PORT
 		/* Read the current config from the port into that configuration. */
-		if (port != nullptr)
-			check(sp_get_signals(port, &signal));
+		if (port != nullptr) {
+			sp_signal port_signal = static_cast<sp_signal>(0);
+			if (check(sp_get_signals(port, &port_signal)) == SP_OK) {
+				signal = port_signal;
+			}
+		}
 #endif
 	}
 	else {


### PR DESCRIPTION
## Summary
- initialize the serial status signal mask before reading host modem-line state
- preserve multiple virtual status bits for loopback/shared serial instead of overwriting earlier bits (`=` → `|=`)
- report DSR/CD/CTS active while a TCP serial peer is connected, so `serial_status` does not make the virtual TCP link look unavailable to the Amiga side

## Scope
This is a correctness fix for libserialport modem-status handling on TCP/non-physical serial paths. It only affects the modem-status lines the Amiga reads, and is only observable when the RTS/CTS/DTR/DTE/CD handshaking option is enabled (with it off, those lines already read as asserted). The byte transport path is unchanged.

> Note: this does **not** fix #2052. Investigation showed that report is a CR/LF line-ending mismatch (Unix clients send LF, the AmigaOS console submits on CR), not a status or transport problem — the byte transport works correctly. That is handled separately in #2065.

## WinUAE comparison
WinUAE master `268eb083` initializes an integer status accumulator and ORs virtual modem-line bits. Its TCP backend still returns no modem status when there is no COM handle, so the connected-TCP status behavior is not resolved upstream and appears to be the same missing behavior there.

## Verification
- `wsl -e bash -lc "cd /mnt/d/Github/amiberry && cmake --build build --parallel"` (`USE_LIBSERIALPORT=ON`)
- `cmake --build out/build/windows-debug --parallel` (exit 0; vcpkg applocal warned that `dumpbin`, `llvm-objdump`, and `objdump` were unavailable for DLL dependency copying)
