### PR TITLE
Fix one-way TCP serial input (CR/LF): map lone LF to CR when Convert CR/LF is enabled

### DIFF
--- a/src/osdep/amiberry_serial.cpp
+++ b/src/osdep/amiberry_serial.cpp
@@ -822,6 +822,16 @@ static void checkreceive_serial ()
 				}
 			}
 			serial_recv_previous = recdata;
+			if (currprefs.serial_crlf && recdata == 10) {
+				// Lone LF (the CR+LF case is stripped above): Unix clients
+				// (nc, telnet, socat) terminate lines with LF, but AmigaOS
+				// line handlers (AUX:/console, shell) only submit a line on
+				// CR. Map the LF to CR so typed input is acted upon. Opt-in
+				// via the Convert CR/LF option. See issue #2052.
+				// serial_recv_previous keeps the original LF so a run of LFs
+				// each maps to CR instead of being mistaken for a CR+LF pair.
+				recdata = 13;
+			}
 			serdatr = recdata;
 			serdatr |= 0x0100;
 			if (break_in_serdatr < -1) {


### PR DESCRIPTION
## Summary
Resolves the "TCP serialport is one-way" report (#2052). The input direction was never actually broken at the transport level — every typed byte is received correctly and reaches `serial.device`. The real cause is a line-ending mismatch:

- AmigaOS line handlers (`AUX:`/console and the shell) submit a command line only on **CR** (`0x0D`).
- Unix clients (`nc`, `telnet`, `socat`) send a bare **LF** (`0x0A`) on Enter.

So typed lines were received but never submitted, which made the link look one-way.

## Change
When the existing **Convert CR/LF** (`serial_crlf`) option is enabled, a lone incoming LF (one that is not already part of a CR+LF pair, which is still stripped) is mapped to CR in `checkreceive_serial`. This stays opt-in, so raw/binary use of the link (e.g. the remote-debugging use case in #2052, which already worked) is unaffected.

## How it was diagnosed
Instrumenting the RX path showed every typed byte read off the socket, delivered to `SERDATR` with correct framing, and read back by the guest (RBF interrupt enabled) — i.e. the transport works. Sending a literal CR (`Ctrl-V Ctrl-M`) made the shell execute the command and reply, confirming the CR/LF root cause.

## User-facing note
Enable **Convert CR/LF** in the serial options for line-based clients such as `nc`. Leave it off for raw/binary protocols.

Fixes #2052
