### PR TITLE
Fix ARM JIT branch target PC state

### DIFF
--- a/src/jit/arm/codegen_arm.cpp
+++ b/src/jit/arm/codegen_arm.cpp
@@ -234,11 +234,26 @@ LOWFUNC(WRITE,READ,1,compemu_raw_cmp_pc,(IMPTR s))
 }
 LENDFUNC(WRITE,READ,1,compemu_raw_cmp_pc,(IMPTR s))
 
+STATIC_INLINE void compemu_raw_store_pc_state_from_work1(void)
+{
+  uintptr idx = (uintptr)&regs.pc_p - (uintptr)&regs;
+  STR_rRI(REG_WORK1, R_REGSTRUCT, idx);
+  idx = (uintptr)&regs.pc_oldp - (uintptr)&regs;
+  STR_rRI(REG_WORK1, R_REGSTRUCT, idx);
+
+#ifdef NATMEM_OFFSET
+  SUB_rrr(REG_WORK2, REG_WORK1, R_MEMSTART);
+  idx = (uintptr)&regs.pc - (uintptr)&regs;
+  STR_rRI(REG_WORK2, R_REGSTRUCT, idx);
+  idx = (uintptr)&regs.instruction_pc - (uintptr)&regs;
+  STR_rRI(REG_WORK2, R_REGSTRUCT, idx);
+#endif
+}
+
 LOWFUNC(NONE,WRITE,1,compemu_raw_set_pc_i,(IMPTR s))
 {
-  LOAD_U32(REG_WORK2, s);
-  uintptr idx = (uintptr) &(regs.pc_p) - (uintptr) &regs;
-  STR_rRI(REG_WORK2, R_REGSTRUCT, idx);
+  LOAD_U32(REG_WORK1, s);
+  compemu_raw_store_pc_state_from_work1();
 }
 LENDFUNC(NONE,WRITE,1,compemu_raw_set_pc_i,(IMPTR s))
 

--- a/src/jit/arm/codegen_arm64.cpp
+++ b/src/jit/arm/codegen_arm64.cpp
@@ -241,11 +241,26 @@ LOWFUNC(WRITE,READ,1,compemu_raw_cmp_pc,(IMPTR s))
 }
 LENDFUNC(WRITE,READ,1,compemu_raw_cmp_pc,(IMPTR s))
 
+STATIC_INLINE void compemu_raw_store_pc_state_from_work1(void)
+{
+	uintptr idx = (uintptr)&regs.pc_p - (uintptr)&regs;
+	STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
+	idx = (uintptr)&regs.pc_oldp - (uintptr)&regs;
+	STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
+
+#ifdef NATMEM_OFFSET
+	SUB_xxx(REG_WORK2, REG_WORK1, R_MEMSTART);
+	idx = (uintptr)&regs.pc - (uintptr)&regs;
+	STR_wXi(REG_WORK2, R_REGSTRUCT, idx);
+	idx = (uintptr)&regs.instruction_pc - (uintptr)&regs;
+	STR_wXi(REG_WORK2, R_REGSTRUCT, idx);
+#endif
+}
+
 LOWFUNC(NONE,WRITE,1,compemu_raw_set_pc_i,(IMPTR s))
 {
 	LOAD_U64(REG_WORK1, s);
-	uintptr idx = (uintptr) &(regs.pc_p) - (uintptr) &regs;
-	STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
+	compemu_raw_store_pc_state_from_work1();
 }
 LENDFUNC(NONE,WRITE,1,compemu_raw_set_pc_i,(IMPTR s))
 

--- a/src/jit/arm/compemu_arm.cpp
+++ b/src/jit/arm/compemu_arm.cpp
@@ -11355,6 +11355,11 @@ uae_u32 REGPARAM2 op_4808_0_comp_ff(uae_u32 opcode) {
 	uae_s32 srcreg = (opcode & 7);
 	uae_u32 m68k_pc_offset_thisinst = m68k_pc_offset;
 	m68k_pc_offset += 2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	int dodgy = 0;
 	if (srcreg == 7) dodgy = 1;
 	int src = dodgy ? alloc_scratch() : srcreg + 8;
@@ -13964,6 +13969,11 @@ uae_u32 REGPARAM2 op_4e50_0_comp_ff(uae_u32 opcode) {
 	uae_s32 srcreg = (opcode & 7);
 	uae_u32 m68k_pc_offset_thisinst = m68k_pc_offset;
 	m68k_pc_offset += 2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	int dodgy = 0;
 	if (srcreg == 7) dodgy = 1;
 	int src = dodgy ? alloc_scratch() : srcreg + 8;
@@ -38554,6 +38564,11 @@ uae_u32 REGPARAM2 op_4808_0_comp_nf(uae_u32 opcode) {
 	uae_s32 srcreg = (opcode & 7);
 	uae_u32 m68k_pc_offset_thisinst = m68k_pc_offset;
 	m68k_pc_offset += 2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	int dodgy = 0;
 	if (srcreg == 7) dodgy = 1;
 	int src = dodgy ? alloc_scratch() : srcreg + 8;
@@ -41066,6 +41081,11 @@ uae_u32 REGPARAM2 op_4e50_0_comp_nf(uae_u32 opcode) {
 	uae_s32 srcreg = (opcode & 7);
 	uae_u32 m68k_pc_offset_thisinst = m68k_pc_offset;
 	m68k_pc_offset += 2;
+	if (srcreg == 7) {
+		m68k_pc_offset = m68k_pc_offset_thisinst;
+		FAIL(1);
+		return 0;
+	}
 	int dodgy = 0;
 	if (srcreg == 7) dodgy = 1;
 	int src = dodgy ? alloc_scratch() : srcreg + 8;

--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -3110,32 +3110,19 @@ STATIC_INLINE void create_popalls(void)
 
     /* now the exit points */
     popall_execute_normal_setpc = get_target();
-    uintptr idx = (uintptr) & (regs.pc_p) - (uintptr)&regs;
-#if defined(CPU_AARCH64)
-    STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
-#else
-    STR_rRI(REG_WORK1, R_REGSTRUCT, idx);
-#endif
+    compemu_raw_store_pc_state_from_work1();
     popall_execute_normal = get_target();
     raw_pop_preserved_regs();
     compemu_raw_jmp((uintptr)execute_normal);
 
     popall_check_checksum_setpc = get_target();
-#if defined(CPU_AARCH64)
-    STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
-#else
-    STR_rRI(REG_WORK1, R_REGSTRUCT, idx);
-#endif
+    compemu_raw_store_pc_state_from_work1();
     popall_check_checksum = get_target();
     raw_pop_preserved_regs();
     compemu_raw_jmp((uintptr)check_checksum);
 
     popall_exec_nostats_setpc = get_target();
-#if defined(CPU_AARCH64)
-    STR_xXi(REG_WORK1, R_REGSTRUCT, idx);
-#else
-    STR_rRI(REG_WORK1, R_REGSTRUCT, idx);
-#endif
+    compemu_raw_store_pc_state_from_work1();
     raw_pop_preserved_regs();
     compemu_raw_jmp((uintptr)exec_nostats);
 

--- a/src/jit/arm/gencomp_arm.c
+++ b/src/jit/arm/gencomp_arm.c
@@ -4244,6 +4244,11 @@ gen_opcode(unsigned long int opcode) {
 		break;
 
 	case i_LINK:
+		comprintf("\tif (srcreg == 7) {\n"
+				"\t\tm68k_pc_offset = m68k_pc_offset_thisinst;\n"
+				"\t\tFAIL(1);\n"
+				"\t\treturn 0;\n"
+				"\t}\n");
 		genamode(curi->smode, "srcreg", sz_long, "src", 1, 0);
 		genamode(curi->dmode, "dstreg", curi->size, "offs", 1, 0);
 		comprintf("\tsub_l_ri(15,4);\n"


### PR DESCRIPTION
## Summary
- Keep the ARM/ARM64 JIT direct PC tuple coherent when set-PC paths jump from compiled code back to fallback/interpreter code: `regs.pc_p`, `regs.pc_oldp`, `regs.pc`, and `regs.instruction_pc` are updated together.
- Use the same PC-state emitter for the branch-to-block set-PC popall stubs, deriving the M68K PC from `pc_p - natmem_offset`.
- Force ARM JIT `LINK.W/L` with `An == A7` through interpreter fallback, matching Toni's suggested handling for this CPU-detection edge case.

## Validation
- `git diff --check HEAD~2..HEAD`
- `cmake --build out/build/macos-release --target Amiberry --parallel`
- Booted `cputester.uae` with a temporary `S/Startup-Sequence`; host log confirmed `CPU=68020, FPU=68881, JIT=CPU/FPU=16384`.
- `cputest basic/bcc.b`: `All tests complete (total 1551360).`
- `cputest basic/bcc.w`: `All tests complete (total 126976).`
- `cputest basic/bsr.b`: `All tests complete (total 35552).`
- `cputest basic/link.w`: `All tests complete (total 6912).`
- `cputest basic/link.l`: `All tests complete (total 36864).`
