### PR TITLE
Fix MCP can use the keyboard

### DIFF
--- a/src/osdep/amiberry_dbus.cpp
+++ b/src/osdep/amiberry_dbus.cpp
@@ -486,7 +486,7 @@ static void HandleSendKey(DBusMessage* msg)
 	if (err.is_set()) {
 		status = false;
 	} else {
-		inputdevice_add_inputcode(keycode, state, nullptr);
+		inputdevice_do_keyboard(keycode, state);
 	}
 	SendReply(msg, status);
 }

--- a/src/osdep/amiberry_ipc_socket.cpp
+++ b/src/osdep/amiberry_ipc_socket.cpp
@@ -459,7 +459,7 @@ static std::string HandleSendKey(const std::vector<std::string>& args)
 		return make_response(false, {"Invalid keycode or state"});
 	}
 
-	inputdevice_add_inputcode(keycode, state, nullptr);
+	inputdevice_do_keyboard(keycode, state);
 
 	return make_response(true);
 }


### PR DESCRIPTION
Fixes MCP can not use the keyboard.

Changes proposed in this pull request:
- use inputdevice_do_keyboard instead of inputdevice_add_inputcode in IPC Socket and DBUS
 
@midwan
