### PR TITLE
Improve libretro path handling

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <math.h>
 #include <ctype.h>
+#include <errno.h>
 #ifdef _WIN32
 #include <io.h>
 #include <direct.h>
@@ -90,6 +91,7 @@ static int last_sensitivity = -1;
 static bool last_input_log_file = false;
 static FILE* input_log_file = nullptr;
 static bool fastforward_forced = false;
+static bool minimum_audio_latency_requested = false;
 static bool libretro_analog_enabled = true;
 static bool last_analog_enabled = true;
 static int last_vsync_setting = -1;
@@ -220,6 +222,17 @@ static void libretro_debug_log(const char* fmt, ...)
 	va_end(ap);
 }
 
+static void set_env_path(const char* name, const std::string& value)
+{
+	if (!name || !*name || value.empty())
+		return;
+#ifdef _WIN32
+	_putenv_s(name, value.c_str());
+#else
+	setenv(name, value.c_str(), 1);
+#endif
+}
+
 // Re-query system_dir / save_dir from the frontend and (re)export AMIBERRY_HOME_DIR
 // so amiberry's get_home_directory() resolves paths inside the frontend-provided
 // directory instead of falling back to $HOME/Amiberry. Some frontends only populate
@@ -251,6 +264,10 @@ static bool sync_amiberry_home_dir_from_frontend()
 		if (save_dir.empty())
 			save_dir = system_dir;
 	}
+
+	set_env_path("AMIBERRY_LIBRETRO_SYSTEM_DIR", system_dir);
+	set_env_path("AMIBERRY_LIBRETRO_SAVE_DIR", save_dir);
+	set_env_path("AMIBERRY_LIBRETRO_CONTENT_DIR", content_dir);
 
 	// Don't overwrite a value the user (or a parent process) has already exported.
 	// amiberry consumes the env var once at startup, so re-exporting after that
@@ -1113,6 +1130,44 @@ static std::string path_join(const std::string& dir, const std::string& file)
 	return dir + "/" + file;
 }
 
+static bool dir_exists(const std::string& path);
+
+static bool ensure_host_directory(const std::string& path)
+{
+	if (path.empty())
+		return false;
+	if (dir_exists(path))
+		return true;
+
+#ifdef _WIN32
+	const int result = _mkdir(path.c_str());
+#else
+	const int result = mkdir(path.c_str(), 0755);
+#endif
+	if (result == 0 || dir_exists(path))
+		return true;
+
+	if (log_cb)
+		log_cb(RETRO_LOG_WARN, "Failed to create directory %s: %s\n", path.c_str(), strerror(errno));
+	return false;
+}
+
+static void ensure_whdload_save_dirs(const std::string& save_root)
+{
+	if (save_root.empty())
+		return;
+
+	ensure_host_directory(save_root);
+	static const char* subdirectories[] = {
+		"Autoboots",
+		"Debugs",
+		"Kickstarts",
+		"Savegames",
+	};
+	for (const auto* subdirectory : subdirectories)
+		ensure_host_directory(path_join(save_root, subdirectory));
+}
+
 static std::string to_lower_copy(std::string value)
 {
 	std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return static_cast<char>(tolower(c)); });
@@ -1205,36 +1260,22 @@ static bool vfs_read_all(const char* path, std::vector<uint8_t>& out)
 
 static void setup_whdload_paths()
 {
+	const char* whdboot_assets_dir = nullptr;
 	if (!system_dir.empty())
-		set_whdbootpath(system_dir);
+		whdboot_assets_dir = system_dir.c_str();
 	else if (!save_dir.empty())
-		set_whdbootpath(save_dir);
+		whdboot_assets_dir = save_dir.c_str();
 	else if (!content_dir.empty())
-		set_whdbootpath(content_dir);
-
-	const char* whdboot_env = nullptr;
-	if (!system_dir.empty())
-		whdboot_env = system_dir.c_str();
-	else if (!save_dir.empty())
-		whdboot_env = save_dir.c_str();
-	else if (!content_dir.empty())
-		whdboot_env = content_dir.c_str();
-	if (whdboot_env && *whdboot_env) {
-#ifdef _WIN32
-		_putenv_s("AMIBERRY_WHDBOOT_PATH", whdboot_env);
-#else
-		setenv("AMIBERRY_WHDBOOT_PATH", whdboot_env, 1);
-#endif
+		whdboot_assets_dir = content_dir.c_str();
+	if (whdboot_assets_dir && *whdboot_assets_dir) {
+		set_env_path("AMIBERRY_WHDBOOT_PATH", whdboot_assets_dir);
+		set_env_path("AMIBERRY_WHDBOOT_ASSETS_DIR", whdboot_assets_dir);
 	}
 
 	if (!save_dir.empty()) {
-#ifdef _WIN32
-		_putenv_s("WHDBOOT_SAVE_DATA", save_dir.c_str());
-		_putenv_s("AMIBERRY_WHDBOOT_SAVE_DATA", save_dir.c_str());
-#else
-		setenv("WHDBOOT_SAVE_DATA", save_dir.c_str(), 1);
-		setenv("AMIBERRY_WHDBOOT_SAVE_DATA", save_dir.c_str(), 1);
-#endif
+		ensure_whdload_save_dirs(save_dir);
+		set_env_path("WHDBOOT_SAVE_DATA", save_dir);
+		set_env_path("AMIBERRY_WHDBOOT_SAVE_DATA", save_dir);
 	}
 }
 
@@ -2502,10 +2543,13 @@ static void keyboard_cb(bool down, unsigned keycode, uint32_t character, uint16_
 
 static void poll_input(void)
 {
-	if (!input_poll_cb || !input_state_cb)
+	if (!input_poll_cb)
 		return;
 
 	input_poll_cb();
+	if (!input_state_cb)
+		return;
+
 	const bool analog_enabled = libretro_analog_enabled;
 	const bool clear_analog = !analog_enabled && last_analog_enabled;
 
@@ -2790,24 +2834,23 @@ static void core_entry(void)
 	safe_strdup("-G"); // No GUI
 
 	std::string rom_path_value;
-	if (!system_dir.empty()) {
+	if (!system_dir.empty() || !save_dir.empty()) {
+		const auto use_kick_dir_if_present = [&](const std::string& kick_dir) {
+			if (rom_path_value.empty() && dir_exists(kick_dir))
+				rom_path_value = kick_dir;
+		};
 		if (!save_dir.empty()) {
-			const std::string kick_dir = path_join(save_dir, "Kickstarts");
-			if (dir_exists(kick_dir))
-				rom_path_value = kick_dir;
+			use_kick_dir_if_present(path_join(save_dir, "Kickstarts"));
+			use_kick_dir_if_present(path_join(path_join(save_dir, "whdboot"), "save-data/Kickstarts"));
 		}
-		if (rom_path_value.empty()) {
-			const std::string kick_dir = path_join(system_dir, "Kickstarts");
-			if (dir_exists(kick_dir))
-				rom_path_value = kick_dir;
-		}
-		if (rom_path_value.empty()) {
-			const std::string kick_dir = path_join(system_dir, "save-data/Kickstarts");
-			if (dir_exists(kick_dir))
-				rom_path_value = kick_dir;
+		if (!system_dir.empty()) {
+			use_kick_dir_if_present(path_join(system_dir, "Kickstarts"));
+			use_kick_dir_if_present(path_join(path_join(system_dir, "whdboot"), "save-data/Kickstarts"));
+			use_kick_dir_if_present(path_join(path_join(path_join(system_dir, "amiberry"), "whdboot"), "save-data/Kickstarts"));
+			use_kick_dir_if_present(path_join(system_dir, "save-data/Kickstarts"));
 		}
 		if (rom_path_value.empty())
-			rom_path_value = system_dir;
+			rom_path_value = !system_dir.empty() ? system_dir : save_dir;
 		const std::string rom_path = "rom_path=" + rom_path_value;
 		push_s_option(rom_path);
 	}
@@ -2885,9 +2928,7 @@ static void core_entry(void)
 			push_s_option(std::string("hardfile2=rw,DH0:") + std::string(game_path) + ",0,0,0,512,0");
 			if (!save_dir.empty()) {
 				const std::string saves_path = save_dir + "/WHDSaves";
-				struct stat saves_st{};
-				if (stat(saves_path.c_str(), &saves_st) != 0)
-					mkdir(saves_path.c_str(), 0755);
+				ensure_host_directory(saves_path);
 				push_s_option("filesystem2=rw,DH1:WHDSaves:" + saves_path + ",0");
 				if (log_cb)
 					log_cb(RETRO_LOG_INFO, "HDF saves dir: %s\n", saves_path.c_str());
@@ -2922,13 +2963,75 @@ static void core_entry(void)
 	libretro_yield();
 }
 
-void retro_init(void)
+static bool ensure_core_fiber()
 {
 	if (!main_fiber)
 		main_fiber = co_active();
-	
-	if (!core_fiber)
+
+	if (!core_fiber) {
 		core_fiber = co_create(CORE_FIBER_STACK_SIZE, core_entry);
+		core_shutdown_complete = false;
+	}
+
+	return core_fiber != nullptr;
+}
+
+static void shutdown_core_fiber()
+{
+	if (!core_fiber)
+		return;
+
+	// Pump the core fiber so it can process uae_quit() and run the
+	// device cleanup chain (joins threads like akiko_thread).
+	// Each co_switch runs roughly one emulated frame.
+	if (core_started && !core_shutdown_complete) {
+		uae_quit();
+		for (int i = 0; i < 200 && !core_shutdown_complete; i++)
+			co_switch(core_fiber);
+
+		if (!core_shutdown_complete && log_cb)
+			log_cb(RETRO_LOG_WARN, "Core did not complete shutdown after 200 frames.\n");
+	}
+}
+
+static void delete_core_fiber()
+{
+	if (!core_fiber)
+		return;
+
+	co_delete(core_fiber);
+	core_fiber = NULL;
+}
+
+static void reset_core_runtime_state()
+{
+	if (fastforward_forced) {
+		warpmode(0);
+		fastforward_forced = false;
+	}
+	set_fastforward_override(false);
+	core_started = false;
+	core_shutdown_complete = false;
+	memory_map_set = false;
+	ff_override_active = false;
+	last_refresh_rate = -1.0f;
+	last_geometry_width = -1;
+	last_geometry_height = -1;
+}
+
+static void apply_minimum_audio_latency()
+{
+	if (minimum_audio_latency_requested || !environ_cb)
+		return;
+
+	unsigned audio_latency = 64;
+	environ_cb(RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY, &audio_latency);
+	minimum_audio_latency_requested = true;
+}
+
+void retro_init(void)
+{
+	ensure_core_fiber();
 
 	// Defensive: some frontends populate system_dir/save_dir between
 	// retro_set_environment and retro_init, so re-query and re-export
@@ -2939,37 +3042,19 @@ void retro_init(void)
 		log_cb(RETRO_LOG_INFO, "retro_init: main_fiber=%p core_fiber=%p\n", (void*)main_fiber, (void*)core_fiber);
 	libretro_debug_log("retro_init: main_fiber=%p core_fiber=%p\n", (void*)main_fiber, (void*)core_fiber);
 
-	core_started = false;
-	memory_map_set = false;
-	ff_override_active = false;
-	last_geometry_width = -1;
-	last_geometry_height = -1;
+	reset_core_runtime_state();
+	minimum_audio_latency_requested = false;
 }
 
 void retro_deinit(void)
 {
-	if (core_fiber)
-	{
-		// Pump the core fiber so it can process uae_quit() and run the
-		// device cleanup chain (joins threads like akiko_thread).
-		// Each co_switch runs roughly one emulated frame.
-		if (core_started && !core_shutdown_complete) {
-			uae_quit();
-			for (int i = 0; i < 200 && !core_shutdown_complete; i++)
-				co_switch(core_fiber);
-		}
-		co_delete(core_fiber);
-		core_fiber = NULL;
-	}
+	shutdown_core_fiber();
+	delete_core_fiber();
 	libretro_debug_close();
 	update_input_log_file(false);
 	last_input_log_file = false;
-	fastforward_forced = false;
-	last_refresh_rate = -1.0f;
-	core_started = false;
-	core_shutdown_complete = false;
-	memory_map_set = false;
-	ff_override_active = false;
+	reset_core_runtime_state();
+	minimum_audio_latency_requested = false;
 	content_is_cd = false;
 	cheat_entries.clear();
 }
@@ -2995,7 +3080,7 @@ void retro_get_system_info(struct retro_system_info *info)
 	/* info->valid_extensions = "adf|uae|ipf|zip|lha|hdf|rp9"; */
 	info->valid_extensions = "adf|adz|dms|fdi|raw|ipf|hdf|hdz|lha|lzh|zip|7z|uae|rp9|m3u|m3u8|iso|cue|ccd|nrg|mds|chd";
 	info->need_fullpath    = true;
-	info->block_extract    = false;
+	info->block_extract    = true;
 }
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
@@ -3117,10 +3202,6 @@ void retro_set_environment(retro_environment_t cb)
 
 	if (!environ_cb(RETRO_ENVIRONMENT_GET_PERF_INTERFACE, &perf_cb))
 		memset(&perf_cb, 0, sizeof(perf_cb));
-	{
-		unsigned audio_latency = 64;
-		environ_cb(RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY, &audio_latency);
-	}
 	{
 		struct retro_audio_buffer_status_callback audio_buf_cb = { audio_buffer_status_cb };
 		if (!environ_cb(RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK, &audio_buf_cb))
@@ -3255,9 +3336,15 @@ void retro_reset(void)
 
 void retro_run(void)
 {
+	apply_minimum_audio_latency();
+
+	if (!ensure_core_fiber())
+		return;
+
 	if (!core_started) {
 		if (log_cb)
 			log_cb(RETRO_LOG_INFO, "retro_run: starting core, core_fiber=%p\n", (void*)core_fiber);
+		poll_input();
 		co_switch(core_fiber);
 		core_started = true;
 		update_memory_map();
@@ -3314,6 +3401,12 @@ void retro_run(void)
 
 bool retro_load_game(const struct retro_game_info *info)
 {
+	if (core_started || core_shutdown_complete) {
+		shutdown_core_fiber();
+		delete_core_fiber();
+	}
+	ensure_core_fiber();
+	reset_core_runtime_state();
 	libretro_debug_open();
 	// Defensive: by retro_load_game time, frontends that delay path setup will
 	// have populated system_dir/save_dir, even if they were empty during
@@ -3512,7 +3605,9 @@ bool retro_load_game(const struct retro_game_info *info)
 
 void retro_unload_game(void)
 {
-	uae_quit();
+	shutdown_core_fiber();
+	delete_core_fiber();
+	reset_core_runtime_state();
 	cheat_entries.clear();
 	if (!whdload_temp_path.empty()) {
 		if (vfs_available && vfs_iface.remove)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1428,6 +1428,7 @@ static void parse_cmdline (int argc, TCHAR **argv)
 				|| _tcscmp(txt2.c_str(), ".dms") == 0
 				|| _tcscmp(txt2.c_str(), ".ipf") == 0
 				|| _tcscmp(txt2.c_str(), ".zip") == 0
+				|| _tcscmp(txt2.c_str(), ".7z") == 0
 				)
 			{
 				write_log("Floppy... %s\n", txt);

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -9088,10 +9088,42 @@ static std::string get_macos_app_resources_directory()
 }
 #endif
 
+#ifdef LIBRETRO
+static void append_libretro_whdboot_seed_root_candidates(std::vector<std::string>& candidates,
+	const char* env_name)
+{
+	const auto* root = std::getenv(env_name);
+	if (root == nullptr || root[0] == '\0')
+		return;
+
+	const std::string root_path = root;
+	append_unique_path_candidate(candidates, join_path(root_path, "whdboot"));
+	append_unique_path_candidate(candidates, join_path(join_path(root_path, "amiberry"), "whdboot"));
+	append_unique_path_candidate(candidates, join_path(join_path(root_path, "Amiberry"), "whdboot"));
+	append_unique_path_candidate(candidates, root_path);
+}
+
+static void append_libretro_whdboot_seed_source_candidates(std::vector<std::string>& candidates,
+	const std::string& subdirectory)
+{
+	if (subdirectory != "whdboot")
+		return;
+
+	append_libretro_whdboot_seed_root_candidates(candidates, "AMIBERRY_WHDBOOT_ASSETS_DIR");
+	append_libretro_whdboot_seed_root_candidates(candidates, "AMIBERRY_WHDBOOT_PATH");
+	append_libretro_whdboot_seed_root_candidates(candidates, "AMIBERRY_LIBRETRO_SYSTEM_DIR");
+	append_libretro_whdboot_seed_root_candidates(candidates, "AMIBERRY_LIBRETRO_SAVE_DIR");
+	append_libretro_whdboot_seed_root_candidates(candidates, "AMIBERRY_LIBRETRO_CONTENT_DIR");
+}
+#endif
+
 static std::vector<std::string> get_seed_source_candidates(const std::string& subdirectory,
 	const bool include_usr_local_share)
 {
 	std::vector<std::string> candidates;
+#ifdef LIBRETRO
+	append_libretro_whdboot_seed_source_candidates(candidates, subdirectory);
+#endif
 #ifdef AMIBERRY_IOS
 	const auto app_bundle_dir = get_ios_app_bundle_directory();
 	if (!app_bundle_dir.empty())
@@ -9114,6 +9146,8 @@ static std::vector<std::string> get_seed_source_candidates(const std::string& su
 static bool copy_missing_directory_contents_if_exists(const std::string& source_dir, const std::string& destination_dir)
 {
 	if (source_dir.empty() || destination_dir.empty() || !my_existsdir(source_dir.c_str()))
+		return false;
+	if (path_strings_match(source_dir, destination_dir))
 		return false;
 
 	ensure_directory_exists(destination_dir);
@@ -9376,22 +9410,22 @@ whdboot_download_result download_whdboot_assets(
 	return result;
 }
 
-static bool whdboot_seed_files_missing()
+static bool whdboot_seed_files_missing_at(const std::string& root_path)
 {
-	if (!file_exists(join_path(whdboot_path, "WHDLoad")))
+	if (!file_exists(join_path(root_path, "WHDLoad")))
 		return true;
-	if (!file_exists(join_path(whdboot_path, "JST")))
+	if (!file_exists(join_path(root_path, "JST")))
 		return true;
-	if (!file_exists(join_path(whdboot_path, "AmiQuit")))
+	if (!file_exists(join_path(root_path, "AmiQuit")))
 		return true;
 
-	const auto boot_data_zip = join_path(whdboot_path, "boot-data.zip");
-	const auto boot_data_dir = join_path(whdboot_path, "boot-data");
+	const auto boot_data_zip = join_path(root_path, "boot-data.zip");
+	const auto boot_data_dir = join_path(root_path, "boot-data");
 	if (!file_exists(boot_data_zip) && !my_existsdir(boot_data_dir.c_str()))
 		return true;
 
-	const auto json_destination = join_path(whdboot_path, "game-data/whdload_db.json");
-	const auto xml_destination = join_path(whdboot_path, "game-data/whdload_db.xml");
+	const auto json_destination = join_path(root_path, "game-data/whdload_db.json");
+	const auto xml_destination = join_path(root_path, "game-data/whdload_db.xml");
 	if (!file_exists(json_destination) && !file_exists(xml_destination))
 		return true;
 
@@ -9404,7 +9438,7 @@ static bool whdboot_seed_files_missing()
 	};
 	for (const auto* filename : required_rtb_files)
 	{
-		const auto destination = join_path(whdboot_path, std::string("save-data/Kickstarts/") + filename);
+		const auto destination = join_path(root_path, std::string("save-data/Kickstarts/") + filename);
 		if (!file_exists(destination))
 			return true;
 	}
@@ -9412,13 +9446,39 @@ static bool whdboot_seed_files_missing()
 	return false;
 }
 
+static bool whdboot_seed_files_missing()
+{
+	return whdboot_seed_files_missing_at(whdboot_path);
+}
+
+#ifdef LIBRETRO
+static bool seed_whdboot_files_from_candidates(const std::vector<std::string>& source_candidates)
+{
+	for (const auto& candidate : source_candidates)
+	{
+		if (path_strings_match(candidate, whdboot_path))
+			continue;
+		if (whdboot_seed_files_missing_at(candidate))
+			continue;
+		if (copy_missing_directory_contents_if_exists(candidate, whdboot_path))
+			return true;
+	}
+
+	return false;
+}
+#endif
+
 static void seed_default_whdboot_files_if_needed()
 {
 	if (!whdboot_seed_files_missing())
 		return;
 
 	const auto source_candidates = get_seed_source_candidates("whdboot", true);
+#ifdef LIBRETRO
+	if (!seed_whdboot_files_from_candidates(source_candidates))
+#else
 	if (!seed_missing_directory_contents_from_candidates(whdboot_path, source_candidates))
+#endif
 	{
 		write_log("No WHDLoad boot files found in bundled or system data locations\n");
 		write_log("Skipping automatic download during startup. Use the Paths panel or --download-whdboot to fetch them explicitly.\n");
@@ -9496,7 +9556,9 @@ static void init_amiberry_dirs(const bool portable_mode, const bool materialize_
 	plugins_dir = get_plugins_directory(portable_mode);
 	const auto visual_content_root = home_dir;
 
-#ifdef __MACH__
+#ifdef LIBRETRO
+	if constexpr (true)
+#elif defined(__MACH__)
 	if constexpr (true)
 #elif defined(__ANDROID__)
     if constexpr (true)
@@ -9506,7 +9568,8 @@ static void init_amiberry_dirs(const bool portable_mode, const bool materialize_
 	if (portable_mode)
 #endif
 	{
-		// These paths are relative to the XDG_DATA_HOME directory
+		// These paths are rooted in home_dir. In libretro builds this is the
+		// frontend-provided system/save directory, not Amiberry's standalone XDG tree.
 		controllers_path = whdboot_path = saveimage_dir = savestate_dir =
 		ripper_path = input_dir = screenshot_dir = nvram_dir = video_dir =
 		home_dir;

--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -1892,7 +1892,7 @@ static void handle_drop_file_event(const SDL_Event& event)
 		uae_restart(&currprefs, -1, dropped_file);
 		gui_running = false;
 	}
-	else if (strcasecmp(ext.c_str(), ".adf") == 0 || strcasecmp(ext.c_str(), ".adz") == 0 || strcasecmp(ext.c_str(), ".dms") == 0 || strcasecmp(ext.c_str(), ".ipf") == 0 || strcasecmp(ext.c_str(), ".zip") == 0)
+	else if (strcasecmp(ext.c_str(), ".adf") == 0 || strcasecmp(ext.c_str(), ".adz") == 0 || strcasecmp(ext.c_str(), ".dms") == 0 || strcasecmp(ext.c_str(), ".ipf") == 0 || strcasecmp(ext.c_str(), ".zip") == 0 || strcasecmp(ext.c_str(), ".7z") == 0)
 	{
 		// Insert floppy image
 		disk_insert(0, dropped_file);

--- a/tools/check_libretro_contract.py
+++ b/tools/check_libretro_contract.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Check libretro API contract details that are easy to regress by refactor."""
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "libretro" / "libretro.cpp"
+AMIBERRY_SOURCE = ROOT / "src" / "osdep" / "amiberry.cpp"
+
+
+def extract_body(text, signature):
+	start = text.find(signature)
+	if start == -1:
+		raise AssertionError(f"missing {signature}")
+	brace = text.find("{", start)
+	if brace == -1:
+		raise AssertionError(f"missing body for {signature}")
+	depth = 0
+	for pos in range(brace, len(text)):
+		if text[pos] == "{":
+			depth += 1
+		elif text[pos] == "}":
+			depth -= 1
+			if depth == 0:
+				return text[brace + 1:pos]
+	raise AssertionError(f"unterminated body for {signature}")
+
+
+def extract_if_body(text, condition):
+	start = text.find(condition)
+	if start == -1:
+		raise AssertionError(f"missing {condition}")
+	brace = text.find("{", start)
+	if brace == -1:
+		raise AssertionError(f"missing body for {condition}")
+	depth = 0
+	for pos in range(brace, len(text)):
+		if text[pos] == "{":
+			depth += 1
+		elif text[pos] == "}":
+			depth -= 1
+			if depth == 0:
+				return text[brace + 1:pos]
+	raise AssertionError(f"unterminated body for {condition}")
+
+
+def require(condition, message, failures):
+	if not condition:
+		failures.append(message)
+
+
+def main():
+	text = SOURCE.read_text(encoding="utf-8")
+	amiberry_text = AMIBERRY_SOURCE.read_text(encoding="utf-8")
+	failures = []
+
+	set_environment = extract_body(text, "void retro_set_environment(retro_environment_t cb)")
+	retro_run = extract_body(text, "void retro_run(void)")
+	startup = extract_if_body(retro_run, "if (!core_started)")
+	retro_deinit = extract_body(text, "void retro_deinit(void)")
+	retro_unload_game = extract_body(text, "void retro_unload_game(void)")
+	retro_get_system_info = extract_body(text, "void retro_get_system_info(struct retro_system_info *info)")
+	setup_whdload_paths = extract_body(text, "static void setup_whdload_paths()")
+	get_seed_source_candidates = extract_body(
+		amiberry_text,
+		"static std::vector<std::string> get_seed_source_candidates(const std::string& subdirectory,\n\tconst bool include_usr_local_share)",
+	)
+	libretro_whdboot_seed_candidates = extract_body(
+		amiberry_text,
+		"static void append_libretro_whdboot_seed_source_candidates(std::vector<std::string>& candidates,\n\tconst std::string& subdirectory)",
+	)
+	copy_seed_dir = extract_body(
+		amiberry_text,
+		"static bool copy_missing_directory_contents_if_exists(const std::string& source_dir, const std::string& destination_dir)",
+	)
+
+	require(
+		"RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY" not in set_environment,
+		"minimum audio latency must not be set from retro_set_environment()",
+		failures,
+	)
+	require(
+		"apply_minimum_audio_latency();" in retro_run,
+		"retro_run() must apply minimum audio latency from the allowed callback",
+		failures,
+	)
+	poll_pos = startup.find("poll_input();")
+	switch_pos = startup.find("co_switch(core_fiber)")
+	require(
+		poll_pos != -1 and switch_pos != -1 and poll_pos < switch_pos,
+		"the first retro_run() path must poll input before switching to the core fiber",
+		failures,
+	)
+	require(
+		"shutdown_core_fiber();" in retro_deinit,
+		"retro_deinit() must use the shared core shutdown helper",
+		failures,
+	)
+	require(
+		"shutdown_core_fiber();" in retro_unload_game,
+		"retro_unload_game() must pump core shutdown, not just request uae_quit()",
+		failures,
+	)
+	require(
+		"info->block_extract    = true;" in retro_get_system_info,
+		"retro_get_system_info() must block frontend archive extraction for Amiberry-managed archive formats",
+		failures,
+	)
+	require(
+		"ensure_whdload_save_dirs(save_dir);" in setup_whdload_paths,
+		"setup_whdload_paths() must create the WHDLoad save-data subdirectories exposed via WHDBOOT_SAVE_DATA",
+		failures,
+	)
+	require(
+		"set_whdbootpath(" not in setup_whdload_paths,
+		"setup_whdload_paths() must not point WHDBooter at the frontend system dir, which may be read-only",
+		failures,
+	)
+	require(
+		"append_libretro_whdboot_seed_source_candidates(candidates, subdirectory);" in get_seed_source_candidates
+		and "AMIBERRY_WHDBOOT_PATH" in libretro_whdboot_seed_candidates
+		and "AMIBERRY_LIBRETRO_SYSTEM_DIR" in libretro_whdboot_seed_candidates,
+		"WHDLoad seed candidates must include libretro frontend asset directories",
+		failures,
+	)
+	require(
+		"path_strings_match(source_dir, destination_dir)" in copy_seed_dir,
+		"directory seeding must skip identical source/destination paths",
+		failures,
+	)
+	require(
+		"#ifdef LIBRETRO\nstatic bool seed_whdboot_files_from_candidates" in amiberry_text,
+		"libretro-specific WHDBooter seed validation must stay out of non-libretro builds",
+		failures,
+	)
+	require(
+		"#ifdef LIBRETRO\n\tif (!seed_whdboot_files_from_candidates(source_candidates))\n#else\n\tif (!seed_missing_directory_contents_from_candidates(whdboot_path, source_candidates))" in amiberry_text,
+		"non-libretro WHDBooter seeding must keep using the established generic seed-copy path",
+		failures,
+	)
+
+	if failures:
+		for failure in failures:
+			print(f"FAIL: {failure}")
+		return 1
+
+	print("libretro contract checks passed")
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/tools/check_libretro_contract.py
+++ b/tools/check_libretro_contract.py
@@ -8,6 +8,8 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE = ROOT / "libretro" / "libretro.cpp"
 AMIBERRY_SOURCE = ROOT / "src" / "osdep" / "amiberry.cpp"
+MAIN_SOURCE = ROOT / "src" / "main.cpp"
+MAIN_WINDOW_SOURCE = ROOT / "src" / "osdep" / "gui" / "main_window.cpp"
 
 
 def extract_body(text, signature):
@@ -54,6 +56,8 @@ def require(condition, message, failures):
 def main():
 	text = SOURCE.read_text(encoding="utf-8")
 	amiberry_text = AMIBERRY_SOURCE.read_text(encoding="utf-8")
+	main_text = MAIN_SOURCE.read_text(encoding="utf-8")
+	main_window_text = MAIN_WINDOW_SOURCE.read_text(encoding="utf-8")
 	failures = []
 
 	set_environment = extract_body(text, "void retro_set_environment(retro_environment_t cb)")
@@ -71,6 +75,8 @@ def main():
 		amiberry_text,
 		"static void append_libretro_whdboot_seed_source_candidates(std::vector<std::string>& candidates,\n\tconst std::string& subdirectory)",
 	)
+	parse_cmdline = extract_body(main_text, "static void parse_cmdline (int argc, TCHAR **argv)")
+	drop_handler = extract_body(main_window_text, "static void handle_drop_file_event(const SDL_Event& event)")
 	copy_seed_dir = extract_body(
 		amiberry_text,
 		"static bool copy_missing_directory_contents_if_exists(const std::string& source_dir, const std::string& destination_dir)",
@@ -106,6 +112,17 @@ def main():
 	require(
 		"info->block_extract    = true;" in retro_get_system_info,
 		"retro_get_system_info() must block frontend archive extraction for Amiberry-managed archive formats",
+		failures,
+	)
+	require(
+		'info->valid_extensions = "adf|adz|dms|fdi|raw|ipf|hdf|hdz|lha|lzh|zip|7z|uae|rp9|m3u|m3u8|iso|cue|ccd|nrg|mds|chd";' in retro_get_system_info
+		and '_tcscmp(txt2.c_str(), ".7z") == 0' in parse_cmdline,
+		"libretro must not block frontend extraction for advertised .7z content unless .7z loads directly",
+		failures,
+	)
+	require(
+		'strcasecmp(ext.c_str(), ".7z") == 0' in drop_handler,
+		"desktop drag/drop floppy archive handling must include .7z when CLI direct loading does",
 		failures,
 	)
 	require(


### PR DESCRIPTION
Fixes #2046 

## Summary
- keep libretro Amiberry paths rooted in the frontend-provided home/save directory instead of standalone XDG paths
- make WHDBooter seed its writable runtime tree from libretro frontend system/save/content asset locations
- tighten libretro lifecycle handling, archive loading flags, input polling, and unload/deinit fiber shutdown
- add a source-level libretro contract check covering the API and WHDBooter path expectations
