### PR TITLE
Fix libretro startup input crash

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -3353,11 +3353,15 @@ void retro_run(void)
 {
 	apply_minimum_audio_latency();
 
-	if (!ensure_core_fiber())
+	if (!ensure_core_fiber()) {
+		poll_frontend_input();
 		return;
+	}
 
-	if (core_shutdown_complete)
+	if (core_shutdown_complete) {
+		poll_frontend_input();
 		return;
+	}
 
 	if (!core_started) {
 		if (log_cb)

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -493,6 +493,11 @@ static void update_memory_map()
 	memory_map_set = true;
 }
 
+static bool core_is_running()
+{
+	return core_started && !core_shutdown_complete;
+}
+
 static void update_led_interface()
 {
 	if (!led_state_cb)
@@ -3338,6 +3343,9 @@ void retro_set_video_refresh(retro_video_refresh_t cb)
 
 void retro_reset(void)
 {
+	if (!core_is_running())
+		return;
+
 	uae_reset(0, 0);
 }
 
@@ -3348,11 +3356,16 @@ void retro_run(void)
 	if (!ensure_core_fiber())
 		return;
 
+	if (core_shutdown_complete)
+		return;
+
 	if (!core_started) {
 		if (log_cb)
 			log_cb(RETRO_LOG_INFO, "retro_run: starting core, core_fiber=%p\n", (void*)core_fiber);
 		poll_frontend_input();
 		co_switch(core_fiber);
+		if (core_shutdown_complete)
+			return;
 		core_started = true;
 		update_memory_map();
 		return;
@@ -3396,6 +3409,8 @@ void retro_run(void)
 	}
 	poll_input();
 	co_switch(core_fiber);
+	if (core_shutdown_complete)
+		return;
 	apply_cheats();
 	update_memory_map();
 	update_led_interface();
@@ -3651,6 +3666,9 @@ size_t retro_serialize_size(void)
 
 bool retro_serialize(void *data, size_t size)
 {
+	if (!core_is_running() || !data || size == 0)
+		return false;
+
 	struct zfile *f = zfile_fopen_empty(NULL, _T("libretro"));
 	if (!f) return false;
 
@@ -3678,6 +3696,9 @@ bool retro_serialize(void *data, size_t size)
 
 bool retro_unserialize(const void *data, size_t size)
 {
+	if (!core_is_running() || !data || size == 0)
+		return false;
+
 	struct zfile *f = zfile_fopen_data(_T("libretro"), (uae_u64)size, (const uae_u8*)data);
 	if (!f) return false;
 
@@ -3689,6 +3710,9 @@ extern addrbank chipmem_bank;
 
 void *retro_get_memory_data(unsigned id)
 {
+	if (!core_is_running() || !chipmem_bank.baseaddr)
+		return NULL;
+
 	switch (id)
 	{
 		case RETRO_MEMORY_SYSTEM_RAM:
@@ -3700,6 +3724,9 @@ void *retro_get_memory_data(unsigned id)
 
 size_t retro_get_memory_size(unsigned id)
 {
+	if (!core_is_running() || !chipmem_bank.baseaddr)
+		return 0;
+
 	switch (id)
 	{
 		case RETRO_MEMORY_SYSTEM_RAM:

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -2541,12 +2541,19 @@ static void keyboard_cb(bool down, unsigned keycode, uint32_t character, uint16_
 		my_kbd_handler(0, scancode, down ? 1 : 0, false);
 }
 
-static void poll_input(void)
+static bool poll_frontend_input(void)
 {
 	if (!input_poll_cb)
-		return;
+		return false;
 
 	input_poll_cb();
+	return true;
+}
+
+static void poll_input(void)
+{
+	if (!poll_frontend_input())
+		return;
 	if (!input_state_cb)
 		return;
 
@@ -3344,7 +3351,7 @@ void retro_run(void)
 	if (!core_started) {
 		if (log_cb)
 			log_cb(RETRO_LOG_INFO, "retro_run: starting core, core_fiber=%p\n", (void*)core_fiber);
-		poll_input();
+		poll_frontend_input();
 		co_switch(core_fiber);
 		core_started = true;
 		update_memory_map();

--- a/tools/check_libretro_contract.py
+++ b/tools/check_libretro_contract.py
@@ -69,9 +69,14 @@ def main():
 	poll_input = extract_body(text, "static void poll_input(void)")
 	retro_run = extract_body(text, "void retro_run(void)")
 	startup = extract_if_body(retro_run, "if (!core_started)")
+	retro_reset = extract_body(text, "void retro_reset(void)")
 	retro_deinit = extract_body(text, "void retro_deinit(void)")
 	retro_unload_game = extract_body(text, "void retro_unload_game(void)")
 	retro_get_system_info = extract_body(text, "void retro_get_system_info(struct retro_system_info *info)")
+	retro_serialize = extract_body(text, "bool retro_serialize(void *data, size_t size)")
+	retro_unserialize = extract_body(text, "bool retro_unserialize(const void *data, size_t size)")
+	retro_get_memory_data = extract_body(text, "void *retro_get_memory_data(unsigned id)")
+	retro_get_memory_size = extract_body(text, "size_t retro_get_memory_size(unsigned id)")
 	setup_whdload_paths = extract_body(text, "static void setup_whdload_paths()")
 	get_seed_source_candidates = extract_body(
 		amiberry_text,
@@ -113,6 +118,44 @@ def main():
 	require(
 		"input_poll_cb();" in poll_frontend_input and "poll_frontend_input()" in poll_input,
 		"normal libretro input polling must keep calling the frontend input_poll callback",
+		failures,
+	)
+	require(
+		"static bool core_is_running()" in text
+		and "return core_started && !core_shutdown_complete;" in text,
+		"libretro callbacks must have a shared live-core guard",
+		failures,
+	)
+	require(
+		"if (core_shutdown_complete)" in retro_run
+		and "if (core_shutdown_complete)\n\t\t\treturn;" in startup
+		and "if (core_shutdown_complete)\n\t\treturn;" in retro_run,
+		"retro_run() must not continue into runtime work after the core has shut down",
+		failures,
+	)
+	require(
+		"if (!core_is_running())\n\t\treturn;" in retro_reset,
+		"retro_reset() must not call UAE reset before the core is running",
+		failures,
+	)
+	require(
+		"if (!core_is_running() || !data || size == 0)\n\t\treturn false;" in retro_serialize,
+		"retro_serialize() must reject calls before live core state exists",
+		failures,
+	)
+	require(
+		"if (!core_is_running() || !data || size == 0)\n\t\treturn false;" in retro_unserialize,
+		"retro_unserialize() must reject calls before live core state exists",
+		failures,
+	)
+	require(
+		"if (!core_is_running() || !chipmem_bank.baseaddr)\n\t\treturn NULL;" in retro_get_memory_data,
+		"retro_get_memory_data() must not expose memory before chip RAM is live",
+		failures,
+	)
+	require(
+		"if (!core_is_running() || !chipmem_bank.baseaddr)\n\t\treturn 0;" in retro_get_memory_size,
+		"retro_get_memory_size() must not report memory before chip RAM is live",
 		failures,
 	)
 	require(

--- a/tools/check_libretro_contract.py
+++ b/tools/check_libretro_contract.py
@@ -128,9 +128,10 @@ def main():
 	)
 	require(
 		"if (core_shutdown_complete)" in retro_run
+		and "if (!ensure_core_fiber()) {\n\t\tpoll_frontend_input();\n\t\treturn;\n\t}" in retro_run
 		and "if (core_shutdown_complete)\n\t\t\treturn;" in startup
-		and "if (core_shutdown_complete)\n\t\treturn;" in retro_run,
-		"retro_run() must not continue into runtime work after the core has shut down",
+		and "if (core_shutdown_complete) {\n\t\tpoll_frontend_input();\n\t\treturn;\n\t}" in retro_run,
+		"retro_run() must poll the frontend before early returns that skip runtime work",
 		failures,
 	)
 	require(

--- a/tools/check_libretro_contract.py
+++ b/tools/check_libretro_contract.py
@@ -61,6 +61,12 @@ def main():
 	failures = []
 
 	set_environment = extract_body(text, "void retro_set_environment(retro_environment_t cb)")
+	poll_frontend_input = ""
+	try:
+		poll_frontend_input = extract_body(text, "static bool poll_frontend_input(void)")
+	except AssertionError:
+		failures.append("libretro first-frame input polling must be split from Amiberry input injection")
+	poll_input = extract_body(text, "static void poll_input(void)")
 	retro_run = extract_body(text, "void retro_run(void)")
 	startup = extract_if_body(retro_run, "if (!core_started)")
 	retro_deinit = extract_body(text, "void retro_deinit(void)")
@@ -92,11 +98,21 @@ def main():
 		"retro_run() must apply minimum audio latency from the allowed callback",
 		failures,
 	)
-	poll_pos = startup.find("poll_input();")
+	frontend_poll_pos = startup.find("poll_frontend_input();")
 	switch_pos = startup.find("co_switch(core_fiber)")
 	require(
-		poll_pos != -1 and switch_pos != -1 and poll_pos < switch_pos,
-		"the first retro_run() path must poll input before switching to the core fiber",
+		frontend_poll_pos != -1 and switch_pos != -1 and frontend_poll_pos < switch_pos,
+		"the first retro_run() path must poll the frontend before switching to the core fiber",
+		failures,
+	)
+	require(
+		"poll_input();" not in startup,
+		"the first retro_run() path must not inject frontend input before Amiberry input devices are initialized",
+		failures,
+	)
+	require(
+		"input_poll_cb();" in poll_frontend_input and "poll_frontend_input()" in poll_input,
+		"normal libretro input polling must keep calling the frontend input_poll callback",
 		failures,
 	)
 	require(


### PR DESCRIPTION
Root cause: PR #2070 added full poll_input() on the first retro_run() call, before the core fiber entered amiberry_main() and initialized inputdevice state. That let setjoybuttonstate() dereference the still-null joysticks pointer. This splits frontend input polling from Amiberry input injection: the first retro_run() only calls the frontend input_poll callback before switching to the core fiber, while normal frames still call full poll_input(). The libretro contract check now guards against injecting frontend input before Amiberry input devices are initialized. 