### PR TITLE
Fix libretro WHDLoad booting

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -69,6 +69,7 @@ retro_environment_t environ_cb;
 retro_input_poll_t input_poll_cb;
 retro_input_state_t input_state_cb;
 retro_log_printf_t log_cb;
+unsigned libretro_audio_frames_this_run;
 
 static char game_path[1024];
 static bool core_started = false;
@@ -1302,6 +1303,22 @@ static bool file_readable(const char* path)
 	return path && *path && access(path, R_OK) == 0;
 }
 
+static std::string canonicalize_existing_host_path(const std::string& path)
+{
+	if (path.empty())
+		return path;
+
+	char resolved[MAX_DPATH] = {};
+#ifdef _WIN32
+	if (_fullpath(resolved, path.c_str(), sizeof(resolved)) != nullptr)
+#else
+	if (realpath(path.c_str(), resolved) != nullptr)
+#endif
+		return resolved;
+
+	return path;
+}
+
 // Detected CD content type for auto-model selection
 enum cd_content_type {
 	CD_CONTENT_NONE = 0,    // Not a CD image, or unrecognized
@@ -1562,26 +1579,6 @@ static bool dir_exists(const std::string& path)
 		return false;
 	struct stat st {};
 	return stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
-}
-
-static bool find_kickstart_in_dir(const std::string& dir, const char* name, char* out, size_t out_size)
-{
-	if (dir.empty() || !name || !*name)
-		return false;
-	const std::string full = path_join(dir, name);
-	if (!file_readable(full.c_str()))
-		return false;
-	snprintf(out, out_size, "%s", full.c_str());
-	return true;
-}
-
-static bool pick_whdload_kickstart(const std::string& dir, char* out, size_t out_size)
-{
-	if (find_kickstart_in_dir(dir, "kick205.rom", out, out_size))
-		return true;
-	if (find_kickstart_in_dir(dir, "kick31.rom", out, out_size))
-		return true;
-	return false;
 }
 
 // Map a model preset name to its base model family for kickstart/CD detection.
@@ -2221,6 +2218,54 @@ static float get_core_refresh_rate()
 	if (vblank_hz > 1.0f)
 		return vblank_hz;
 	return currprefs.ntscmode ? 60.0f : 50.0f;
+}
+
+static double libretro_audio_deficit_frames = 0.0;
+
+static void libretro_emit_audio_starvation_guard()
+{
+	if (!audio_batch_cb && !audio_cb)
+		return;
+
+	const float refresh_rate = get_core_refresh_rate();
+	const int audio_rate = audio_rate_for_av_info();
+	if (refresh_rate <= 1.0f || audio_rate <= 0)
+		return;
+
+	const double expected_frames = static_cast<double>(audio_rate) / refresh_rate;
+	libretro_audio_deficit_frames += expected_frames;
+	libretro_audio_deficit_frames -= libretro_audio_frames_this_run;
+	const double max_deferred_frames = expected_frames * 2.0;
+
+	if (libretro_audio_deficit_frames < -max_deferred_frames)
+		libretro_audio_deficit_frames = -max_deferred_frames;
+	if (libretro_audio_deficit_frames > max_deferred_frames * 4.0)
+		libretro_audio_deficit_frames = max_deferred_frames * 4.0;
+
+	if (libretro_audio_frames_this_run > 0 || libretro_audio_deficit_frames <= max_deferred_frames)
+		return;
+
+	unsigned missing_frames = static_cast<unsigned>(libretro_audio_deficit_frames - max_deferred_frames);
+	while (missing_frames > 0) {
+		const unsigned chunk = std::min(missing_frames, 1024U);
+		int16_t silence[1024 * 2] = {};
+		if (audio_batch_cb) {
+			const size_t accepted = audio_batch_cb(silence, chunk);
+			if (accepted == 0)
+				break;
+			libretro_audio_frames_this_run += static_cast<unsigned>(accepted);
+			libretro_audio_deficit_frames -= accepted;
+			if (accepted < chunk)
+				break;
+			missing_frames -= chunk;
+		} else {
+			for (unsigned i = 0; i < chunk; i++)
+				audio_cb(0, 0);
+			libretro_audio_frames_this_run += chunk;
+			libretro_audio_deficit_frames -= chunk;
+			missing_frames -= chunk;
+		}
+	}
 }
 
 static int mousemap_from_option(const char* value)
@@ -2874,10 +2919,7 @@ static void core_entry(void)
 		if (user_kick_override) {
 			have_kick = resolve_kickstart_override_value(cached_kickstart_override.c_str(), kick_path, sizeof(kick_path)) ||
 				find_kickstart_in_system_dir(model, kick_path, sizeof(kick_path));
-		} else if (is_whdload) {
-			if (!rom_path_value.empty())
-				have_kick = pick_whdload_kickstart(rom_path_value, kick_path, sizeof(kick_path));
-		} else {
+		} else if (!is_whdload) {
 			have_kick = find_kickstart_in_system_dir(model, kick_path, sizeof(kick_path));
 		}
 
@@ -3029,6 +3071,7 @@ static void reset_core_runtime_state()
 	last_refresh_rate = -1.0f;
 	last_geometry_width = -1;
 	last_geometry_height = -1;
+	libretro_audio_deficit_frames = 0.0;
 }
 
 static void apply_minimum_audio_latency()
@@ -3367,7 +3410,10 @@ void retro_run(void)
 		if (log_cb)
 			log_cb(RETRO_LOG_INFO, "retro_run: starting core, core_fiber=%p\n", (void*)core_fiber);
 		poll_frontend_input();
+		libretro_audio_frames_this_run = 0;
 		co_switch(core_fiber);
+		if (!core_shutdown_complete)
+			libretro_emit_audio_starvation_guard();
 		if (core_shutdown_complete)
 			return;
 		core_started = true;
@@ -3412,7 +3458,10 @@ void retro_run(void)
 		}
 	}
 	poll_input();
+	libretro_audio_frames_this_run = 0;
 	co_switch(core_fiber);
+	if (!core_shutdown_complete)
+		libretro_emit_audio_starvation_guard();
 	if (core_shutdown_complete)
 		return;
 	apply_cheats();
@@ -3503,6 +3552,9 @@ bool retro_load_game(const struct retro_game_info *info)
 				}
 			}
 		}
+
+		if (!extracted)
+			whd_path = canonicalize_existing_host_path(whd_path);
 
 		if (!extracted && (has_non_ascii(whd_path) || !file_readable(whd_path.c_str()))) {
 			std::vector<uint8_t> data;

--- a/libretro/libretro_shared.h
+++ b/libretro/libretro_shared.h
@@ -16,6 +16,7 @@ extern retro_input_poll_t input_poll_cb;
 extern retro_input_state_t input_state_cb;
 extern retro_log_printf_t log_cb;
 extern bool pixel_format_xrgb8888;
+extern unsigned libretro_audio_frames_this_run;
 
 void libretro_yield(void);
 void reset_parse_cmdline(void);

--- a/libretro/libretro_stubs.cpp
+++ b/libretro/libretro_stubs.cpp
@@ -522,6 +522,13 @@ static int libretro_add_rom(UAEREG* fkey, struct romdata* rd, const TCHAR* name)
 	return 1;
 }
 
+static bool libretro_is_rom_key_file(const std::string& path)
+{
+	const auto name_pos = path.find_last_of("/\\");
+	const std::string name = name_pos == std::string::npos ? path : path.substr(name_pos + 1);
+	return _tcsicmp(name.c_str(), _T("rom.key")) == 0;
+}
+
 static bool libretro_is_rom_ext(const std::string& path, const bool deepscan)
 {
 	if (path.empty())
@@ -557,7 +564,11 @@ static int libretro_scan_rom_entry(struct zfile* f, void* user)
 {
 	auto* rsd = static_cast<libretro_rom_scan_data*>(user);
 	const TCHAR* path = zfile_getname(f);
-	const TCHAR* romkey = _T("rom.key");
+
+	if (libretro_is_rom_key_file(path)) {
+		addkeyfile(path);
+		return 0;
+	}
 
 	if (!libretro_is_rom_ext(path, true))
 		return 0;
@@ -568,15 +579,13 @@ static int libretro_scan_rom_entry(struct zfile* f, void* user)
 		if (rd->type & ROMTYPE_KEY)
 			addkeyfile(path);
 		rsd->got = 1;
-	} else if (_tcslen(path) > _tcslen(romkey) && !_tcsicmp(path + _tcslen(path) - _tcslen(romkey), romkey)) {
-		addkeyfile(path);
 	}
 	return 0;
 }
 
 static int libretro_scan_rom_file(const std::string& path, UAEREG* fkey, const bool deepscan)
 {
-	if (!libretro_is_rom_ext(path, deepscan))
+	if (!libretro_is_rom_key_file(path) && !libretro_is_rom_ext(path, deepscan))
 		return 0;
 
 	libretro_rom_scan_data rsd = { fkey, 0 };
@@ -589,6 +598,8 @@ static int libretro_scan_rom_dir(UAEREG* fkey, const std::string& path, const bo
 	struct dirent* entry;
 	struct stat statbuf {};
 	int ret = 0;
+	std::vector<std::string> files;
+	std::vector<std::string> dirs;
 
 	write_log(_T("libretro ROM scan directory '%s'\n"), path.c_str());
 
@@ -607,15 +618,26 @@ static int libretro_scan_rom_dir(UAEREG* fkey, const std::string& path, const bo
 			continue;
 
 		if (S_ISREG(statbuf.st_mode) && statbuf.st_size < 10000000) {
-			if (libretro_scan_rom_file(tmppath, fkey, deepscan))
-				ret = 1;
+			files.push_back(tmppath);
 		} else if (deepscan && S_ISDIR(statbuf.st_mode) && entry->d_name[0] != '.' && level < 2) {
-			if (libretro_scan_rom_dir(fkey, tmppath, deepscan, level + 1))
-				ret = 1;
+			dirs.push_back(tmppath);
 		}
 	}
 
 	closedir(dp);
+
+	for (const auto& file : files) {
+		if (libretro_is_rom_key_file(file))
+			libretro_scan_rom_file(file, fkey, deepscan);
+	}
+	for (const auto& file : files) {
+		if (!libretro_is_rom_key_file(file) && libretro_scan_rom_file(file, fkey, deepscan))
+			ret = 1;
+	}
+	for (const auto& dir : dirs) {
+		if (libretro_scan_rom_dir(fkey, dir, deepscan, level + 1))
+			ret = 1;
+	}
 	return ret;
 }
 

--- a/libretro/libretro_stubs.cpp
+++ b/libretro/libretro_stubs.cpp
@@ -5,10 +5,23 @@
 #include "filesys.h"
 #include "disk.h"
 #include "blkdev.h"
+#include "rommgr.h"
+#include "zfile.h"
+#include "registry.h"
+#include "fsdb.h"
+#include "uae.h"
 
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <dirent.h>
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <sys/stat.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
 
 #ifdef LIBRETRO
 unsigned int gui_ledstate = 0;
@@ -382,10 +395,275 @@ void save_theme(const std::string& theme_filename)
 	(void)theme_filename;
 }
 
+struct libretro_rom_scan_candidate
+{
+	std::string path;
+	bool deepscan;
+};
+
+struct libretro_rom_scan_data
+{
+	UAEREG* fkey;
+	int got;
+};
+
+static std::string libretro_path_join(const std::string& dir, const std::string& file)
+{
+	if (dir.empty())
+		return file;
+	if (file.empty())
+		return dir;
+	const char last = dir.back();
+	if (last == '/' || last == '\\')
+		return dir + file;
+	return dir + "/" + file;
+}
+
+static void libretro_append_scan_candidate(std::vector<libretro_rom_scan_candidate>& candidates,
+	const std::string& path, const bool deepscan)
+{
+	if (path.empty())
+		return;
+
+	TCHAR resolved[MAX_DPATH] = {};
+#ifdef _WIN32
+	if (_fullpath(resolved, path.c_str(), MAX_DPATH) == nullptr)
+		return;
+#else
+	if (realpath(path.c_str(), resolved) == nullptr)
+		return;
+#endif
+
+	for (auto& candidate : candidates) {
+		if (_tcsicmp(candidate.path.c_str(), resolved) == 0) {
+			candidate.deepscan = candidate.deepscan || deepscan;
+			return;
+		}
+	}
+
+	candidates.push_back({ resolved, deepscan });
+}
+
+static void libretro_append_scan_root(std::vector<libretro_rom_scan_candidate>& candidates,
+	const char* root)
+{
+	if (!root || !*root)
+		return;
+
+	const std::string root_path = root;
+	libretro_append_scan_candidate(candidates, root_path, false);
+	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "roms"), true);
+	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "Kickstarts"), true);
+	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "save-data/Kickstarts"), true);
+	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "whdboot/save-data/Kickstarts"), true);
+	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "amiberry/whdboot/save-data/Kickstarts"), true);
+}
+
+static int libretro_rom_ext_priority(const TCHAR* path, const int size)
+{
+	const TCHAR* s = _tcsrchr(path, '.');
+	if (s == nullptr)
+		return 80;
+	if (!my_existsfile(path))
+		return 100;
+
+	int pri = 10;
+	struct mystat ms {};
+	if (my_stat(path, &ms) && ms.size == size)
+		pri--;
+	return pri;
+}
+
+static int libretro_add_rom(UAEREG* fkey, struct romdata* rd, const TCHAR* name)
+{
+	TCHAR tmp1[MAX_DPATH], tmp2[MAX_DPATH], tmp3[MAX_DPATH];
+	char pathname[MAX_DPATH];
+
+	_sntprintf(tmp1, sizeof tmp1, _T("ROM_%03d"), rd->id);
+	if (rd->group) {
+		TCHAR* p = tmp1 + _tcslen(tmp1);
+		_sntprintf(p, sizeof tmp1 - _tcslen(tmp1), _T("_%02d_%02d"), rd->group >> 16, rd->group & 65535);
+	}
+	getromname(rd, tmp2);
+	pathname[0] = 0;
+
+	if (name)
+		_tcscpy(pathname, name);
+	if (rd->crc32 == 0xffffffff) {
+		if (rd->configname)
+			_sntprintf(tmp2, sizeof tmp2, _T(":%s"), rd->configname);
+		else
+			_sntprintf(tmp2, sizeof tmp2, _T(":ROM_%03d"), rd->id);
+	}
+
+	int size = sizeof tmp3 / sizeof(TCHAR);
+	if (regquerystr(fkey, tmp1, tmp3, &size)) {
+		TCHAR* s = _tcschr(tmp3, '"');
+		if (s && _tcslen(s) > 1) {
+			TCHAR* s2 = s + 1;
+			s = _tcschr(s2, '"');
+			if (s)
+				*s = 0;
+			const int pri1 = libretro_rom_ext_priority(s2, rd->size);
+			const int pri2 = libretro_rom_ext_priority(pathname, rd->size);
+			if (pri2 >= pri1)
+				return 1;
+		}
+	}
+
+	fullpath(pathname, sizeof(pathname) / sizeof(TCHAR));
+	if (pathname[0]) {
+		_tcscat(tmp2, _T(" / \""));
+		_tcscat(tmp2, pathname);
+		_tcscat(tmp2, _T("\""));
+	}
+	if (!regsetstr(fkey, tmp1, tmp2))
+		return 0;
+	return 1;
+}
+
+static bool libretro_is_rom_ext(const std::string& path, const bool deepscan)
+{
+	if (path.empty())
+		return false;
+	const auto ext_pos = path.find_last_of('.');
+	if (ext_pos == std::string::npos)
+		return false;
+
+	std::string ext = path.substr(ext_pos + 1);
+	std::transform(ext.begin(), ext.end(), ext.begin(), [](const unsigned char ch) {
+		return static_cast<char>(std::tolower(ch));
+	});
+
+	static const char* extensions[] = {
+		"rom", "roz", "bin", "a500", "a600", "a1200", "a3000", "a4000", "cdtv", "cd32"
+	};
+	for (const auto* candidate : extensions) {
+		if (ext == candidate)
+			return true;
+	}
+	if (ext.size() >= 2 && ext[0] == 'u' && std::isdigit(static_cast<unsigned char>(ext[1])))
+		return true;
+	if (!deepscan)
+		return false;
+	for (auto i = 0; uae_archive_extensions[i]; i++) {
+		if (_tcsicmp(ext.c_str(), uae_archive_extensions[i]) == 0)
+			return true;
+	}
+	return false;
+}
+
+static int libretro_scan_rom_entry(struct zfile* f, void* user)
+{
+	auto* rsd = static_cast<libretro_rom_scan_data*>(user);
+	const TCHAR* path = zfile_getname(f);
+	const TCHAR* romkey = _T("rom.key");
+
+	if (!libretro_is_rom_ext(path, true))
+		return 0;
+
+	struct romdata* rd = scan_single_rom_file(f);
+	if (rd) {
+		libretro_add_rom(rsd->fkey, rd, path);
+		if (rd->type & ROMTYPE_KEY)
+			addkeyfile(path);
+		rsd->got = 1;
+	} else if (_tcslen(path) > _tcslen(romkey) && !_tcsicmp(path + _tcslen(path) - _tcslen(romkey), romkey)) {
+		addkeyfile(path);
+	}
+	return 0;
+}
+
+static int libretro_scan_rom_file(const std::string& path, UAEREG* fkey, const bool deepscan)
+{
+	if (!libretro_is_rom_ext(path, deepscan))
+		return 0;
+
+	libretro_rom_scan_data rsd = { fkey, 0 };
+	zfile_zopen(path, libretro_scan_rom_entry, &rsd);
+	return rsd.got;
+}
+
+static int libretro_scan_rom_dir(UAEREG* fkey, const std::string& path, const bool deepscan, const int level)
+{
+	struct dirent* entry;
+	struct stat statbuf {};
+	int ret = 0;
+
+	write_log(_T("libretro ROM scan directory '%s'\n"), path.c_str());
+
+	DIR* dp = opendir(path.c_str());
+	if (dp == nullptr)
+		return 0;
+
+	while ((entry = readdir(dp)) != nullptr) {
+		if (entry->d_name[0] == '.' && (entry->d_name[1] == 0 ||
+			(entry->d_name[1] == '.' && entry->d_name[2] == 0))) {
+			continue;
+		}
+
+		const std::string tmppath = libretro_path_join(path, entry->d_name);
+		if (stat(tmppath.c_str(), &statbuf) == -1)
+			continue;
+
+		if (S_ISREG(statbuf.st_mode) && statbuf.st_size < 10000000) {
+			if (libretro_scan_rom_file(tmppath, fkey, deepscan))
+				ret = 1;
+		} else if (deepscan && S_ISDIR(statbuf.st_mode) && entry->d_name[0] != '.' && level < 2) {
+			if (libretro_scan_rom_dir(fkey, tmppath, deepscan, level + 1))
+				ret = 1;
+		}
+	}
+
+	closedir(dp);
+	return ret;
+}
+
 int scan_roms(int show)
 {
 	(void)show;
-	return 0;
+
+	static int recursive;
+	if (recursive)
+		return 0;
+	recursive++;
+
+	regdeletetree(nullptr, _T("DetectedROMs"));
+	UAEREG* fkey = regcreatetree(nullptr, _T("DetectedROMs"));
+	if (fkey == nullptr) {
+		recursive--;
+		return 0;
+	}
+
+	std::vector<libretro_rom_scan_candidate> candidates;
+	const std::string rom_path = get_rom_path();
+	libretro_append_scan_candidate(candidates, rom_path, false);
+	libretro_append_scan_root(candidates, getenv("AMIBERRY_LIBRETRO_SYSTEM_DIR"));
+	libretro_append_scan_root(candidates, getenv("AMIBERRY_LIBRETRO_SAVE_DIR"));
+	libretro_append_scan_root(candidates, getenv("AMIBERRY_WHDBOOT_ASSETS_DIR"));
+	libretro_append_scan_root(candidates, getenv("AMIBERRY_WHDBOOT_PATH"));
+	libretro_append_scan_root(candidates, getenv("WHDBOOT_SAVE_DATA"));
+	libretro_append_scan_candidate(candidates, changed_prefs.path_rom.path[0], false);
+
+	int cnt = 0;
+	for (const auto& candidate : candidates) {
+		if (libretro_scan_rom_dir(fkey, candidate.path, candidate.deepscan, 0))
+			cnt++;
+	}
+
+	for (int id = 1; ; id++) {
+		struct romdata* rd = getromdatabyid(id);
+		if (!rd)
+			break;
+		if (rd->crc32 == 0xffffffff)
+			libretro_add_rom(fkey, rd, nullptr);
+	}
+
+	write_log(_T("libretro ROM scan: %d matching path(s) across %zu candidate(s)\n"), cnt, candidates.size());
+	read_rom_list(false);
+	regclosetree(fkey);
+	recursive--;
+	return cnt;
 }
 
 void cancel_async_update_check()

--- a/libretro/sdl_stub.cpp
+++ b/libretro/sdl_stub.cpp
@@ -2,9 +2,7 @@
 #include "sdl_compat.h"
 
 #include <ctype.h>
-#include <errno.h>
 #include <pthread.h>
-#include <semaphore.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -34,7 +32,9 @@ struct SDL_Condition {
 };
 
 struct SDL_Semaphore {
-	sem_t sem;
+	pthread_mutex_t mutex;
+	pthread_cond_t cond;
+	Uint32 value;
 };
 
 struct SDL_Window {
@@ -479,54 +479,67 @@ SDL_Semaphore* SDL_CreateSemaphore(Uint32 initial_value)
 	if (!s) {
 		return nullptr;
 	}
-	if (sem_init(&s->sem, 0, initial_value) != 0) {
+	if (pthread_mutex_init(&s->mutex, nullptr) != 0) {
 		free(s);
 		return nullptr;
 	}
+	if (pthread_cond_init(&s->cond, nullptr) != 0) {
+		pthread_mutex_destroy(&s->mutex);
+		free(s);
+		return nullptr;
+	}
+	s->value = initial_value;
 	return s;
 }
 void SDL_DestroySemaphore(SDL_Semaphore* s)
 {
 	if (!s) return;
-	sem_destroy(&s->sem);
+	pthread_cond_destroy(&s->cond);
+	pthread_mutex_destroy(&s->mutex);
 	free(s);
 }
 void SDL_SignalSemaphore(SDL_Semaphore* s)
 {
 	if (s) {
-		sem_post(&s->sem);
+		pthread_mutex_lock(&s->mutex);
+		s->value++;
+		pthread_cond_signal(&s->cond);
+		pthread_mutex_unlock(&s->mutex);
 	}
 }
 void SDL_WaitSemaphore(SDL_Semaphore* s)
 {
 	if (!s) return;
-	while (sem_wait(&s->sem) != 0 && errno == EINTR) {
+	pthread_mutex_lock(&s->mutex);
+	while (s->value == 0) {
+		pthread_cond_wait(&s->cond, &s->mutex);
 	}
+	s->value--;
+	pthread_mutex_unlock(&s->mutex);
 }
 bool SDL_TryWaitSemaphore(SDL_Semaphore* s)
 {
-	return s && sem_trywait(&s->sem) == 0;
+	if (!s) {
+		return false;
+	}
+	pthread_mutex_lock(&s->mutex);
+	const bool available = s->value > 0;
+	if (available) {
+		s->value--;
+	}
+	pthread_mutex_unlock(&s->mutex);
+	return available;
 }
 bool SDL_WaitSemaphoreTimeout(SDL_Semaphore* s, Sint32 ms)
 {
 	if (!s) {
 		return false;
 	}
-#if defined(__APPLE__)
-	Uint64 start = SDL_GetTicks();
-	for (;;) {
-		if (sem_trywait(&s->sem) == 0) {
-			return true;
-		}
-		if (errno != EAGAIN && errno != EINTR) {
-			return false;
-		}
-		if ((SDL_GetTicks() - start) >= (Uint64)ms) {
-			return false;
-		}
-		SDL_Delay(1);
+	if (ms < 0) {
+		SDL_WaitSemaphore(s);
+		return true;
 	}
-#else
+
 	struct timespec ts;
 	clock_gettime(CLOCK_REALTIME, &ts);
 	ts.tv_sec += ms / 1000;
@@ -535,15 +548,26 @@ bool SDL_WaitSemaphoreTimeout(SDL_Semaphore* s, Sint32 ms)
 		ts.tv_sec++;
 		ts.tv_nsec -= 1000000000L;
 	}
-	return sem_timedwait(&s->sem, &ts) == 0;
-#endif
+
+	pthread_mutex_lock(&s->mutex);
+	int ret = 0;
+	while (s->value == 0 && ret == 0) {
+		ret = pthread_cond_timedwait(&s->cond, &s->mutex, &ts);
+	}
+	const bool available = s->value > 0;
+	if (available) {
+		s->value--;
+	}
+	pthread_mutex_unlock(&s->mutex);
+	return available;
 }
 Uint32 SDL_GetSemaphoreValue(SDL_Semaphore* s)
 {
 	if (!s) return 0;
-	int v = 0;
-	sem_getvalue(&s->sem, &v);
-	return (Uint32)((v < 0) ? 0 : v);
+	pthread_mutex_lock(&s->mutex);
+	const Uint32 value = s->value;
+	pthread_mutex_unlock(&s->mutex);
+	return value;
 }
 
 SDL_Thread* SDL_CreateThread(SDL_ThreadFunction fn, const char* name, void* data)

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -5471,9 +5471,18 @@ end:
 
 static uae_u8 *dump_xlate (uae_u32 addr)
 {
-	if (!mem_banks[addr >> 16]->check (addr, 1))
+	addrbank *bank = mem_banks[addr >> 16];
+	if (!bank || !bank->check || !bank->xlateaddr || !bank->check (addr, 1))
 		return NULL;
-	return mem_banks[addr >> 16]->xlateaddr (addr);
+	return bank->xlateaddr (addr);
+}
+
+static uae_u8 *dump_xlate_range (uae_u32 addr, uae_u32 size)
+{
+	addrbank *bank = mem_banks[addr >> 16];
+	if (!bank || !bank->check || !bank->xlateaddr || !bank->check(addr, size))
+		return NULL;
+	return bank->xlateaddr(addr);
 }
 
 #if 0
@@ -5501,11 +5510,18 @@ typedef struct UaeMemoryMap {
 
 static const TCHAR *bankmodes[] = { _T("F32"), _T("C16"), _T("C32"), _T("CIA"), _T("F16"), _T("F16X") };
 
+static const TCHAR *dump_bankmode (int mode)
+{
+	if (mode < 0 || mode >= static_cast<int>(sizeof bankmodes / sizeof bankmodes[0]))
+		return _T("?");
+	return bankmodes[mode];
+}
+
 static void memory_map_dump_3(UaeMemoryMap *map, int log)
 {
 	bool imold;
 	int i, j, max;
-	addrbank *a1 = mem_banks[0];
+	addrbank *a1 = mem_banks[0] ? mem_banks[0] : &dummy_bank;
 	TCHAR txt[256];
 
 	map->num_regions = 0;
@@ -5516,7 +5532,7 @@ static void memory_map_dump_3(UaeMemoryMap *map, int log)
 	for (i = 0; i < max + 1; i++) {
 		addrbank *a2 = NULL;
 		if (i < max)
-			a2 = mem_banks[i];
+			a2 = mem_banks[i] ? mem_banks[i] : &dummy_bank;
 		if (a1 != a2) {
 			int k, mirrored, mirrored2, size, size_out;
 			TCHAR size_ext;
@@ -5545,20 +5561,24 @@ static void memory_map_dump_3(UaeMemoryMap *map, int log)
 				int bankoffset2 = bankoffset;
 				if (sb) {
 					uaecptr daddr;
-					if (!sb->bank)
-						break;
-					daddr = (j << 16) | bankoffset;
-					a1 = get_sub_bank(&daddr);
-					name = a1->name;
-					for (;;) {
-						bankoffset2 += MEMORY_MIN_SUBBANK;
-						if (bankoffset2 >= 65536)
+						if (!sb->bank)
 							break;
-						daddr = (j << 16) | bankoffset2;
-						addrbank *dab = get_sub_bank(&daddr);
-						if (dab != a1)
-							break;
-					}
+						daddr = (j << 16) | bankoffset;
+						a1 = get_sub_bank(&daddr);
+						if (!a1)
+							a1 = &dummy_bank;
+						name = a1->name;
+						for (;;) {
+							bankoffset2 += MEMORY_MIN_SUBBANK;
+							if (bankoffset2 >= 65536)
+								break;
+							daddr = (j << 16) | bankoffset2;
+							addrbank *dab = get_sub_bank(&daddr);
+							if (!dab)
+								dab = &dummy_bank;
+							if (dab != a1)
+								break;
+						}
 					sb++;
 					size = (bankoffset2 - bankoffset) / 1024;
 					region_size = size * 1024;
@@ -5578,19 +5598,21 @@ static void memory_map_dump_3(UaeMemoryMap *map, int log)
 				}
 				_sntprintf (txt, sizeof txt, _T("%08X %7d%c/%d = %7d%c %s%s%c %s %s"), (j << 16) | bankoffset, size_out, size_ext,
 					mirrored, mirrored ? size_out / mirrored : size_out, size_ext,
-					(a1->flags & ABFLAG_CACHE_ENABLE_INS) ? _T("I") : _T("-"),
-					(a1->flags & ABFLAG_CACHE_ENABLE_DATA) ? _T("D") : _T("-"),
-					a1->baseaddr == NULL ? ' ' : '*',
-					bankmodes[ce_banktype[j]],
-					name);
-				tmp[0] = 0;
-				if ((a1->flags & ABFLAG_ROM) && mirrored) {
-					TCHAR *p = txt + _tcslen (txt);
-					uae_u32 crc = 0xffffffff;
-					if (a1->check(((j << 16) | bankoffset), (size * 1024) / mirrored))
-						crc = get_crc32 (a1->xlateaddr((j << 16) | bankoffset), (size * 1024) / mirrored);
-					struct romdata *rd = getromdatabycrc (crc);
-					_sntprintf (p, sizeof p, _T(" (%08X)"), crc);
+						(a1->flags & ABFLAG_CACHE_ENABLE_INS) ? _T("I") : _T("-"),
+						(a1->flags & ABFLAG_CACHE_ENABLE_DATA) ? _T("D") : _T("-"),
+						a1->baseaddr == NULL ? ' ' : '*',
+						dump_bankmode(ce_banktype[j]),
+						name);
+					tmp[0] = 0;
+					if ((a1->flags & ABFLAG_ROM) && mirrored) {
+						TCHAR *p = txt + _tcslen (txt);
+						uae_u32 crc = 0xffffffff;
+						uae_u32 crc_size = (size * 1024) / mirrored;
+						uae_u8 *crc_mem = dump_xlate_range((j << 16) | bankoffset, crc_size);
+						if (crc_mem)
+							crc = get_crc32(crc_mem, crc_size);
+						struct romdata *rd = getromdatabycrc (crc);
+						_sntprintf (p, sizeof p, _T(" (%08X)"), crc);
 					if (rd) {
 						tmp[0] = '=';
 						getromname (rd, tmp + 1);

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -7236,7 +7236,8 @@ static int filesys_iteration(UnitInfo *ui)
 	morelocks = (uae_u32)read_comm_pipe_int_blocking(ui->unit_pipe);
 
 	if (ui->reset_state == FS_GO_DOWN) {
-		trap_background_set_complete(ctx);
+		if (ctx)
+			trap_background_set_complete(ctx);
 		if (pck != 0)
 		   return 1;
 		/* Death message received. */

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4611,7 +4611,11 @@ void target_default_options(uae_prefs* p, const int type)
 		//p->filesystem_mangle_reserved_names = true;
 	}
 
+#ifdef LIBRETRO
+	multithread_enabled = false;
+#else
 	multithread_enabled = true;
+#endif
 
 	p->kbd_led_num = -1; // No status on numlock
 	p->kbd_led_scr = -1; // No status on scrollock
@@ -9877,7 +9881,12 @@ void read_rom_list(bool initial)
 	UAEREG* fkey = regcreatetree(nullptr, _T("DetectedROMs"));
 	if (fkey == nullptr)
 		return;
-	if (!exists || forceroms) {
+	bool rescan_roms = !exists || forceroms;
+#ifdef LIBRETRO
+	if (initial)
+		rescan_roms = true;
+#endif
+	if (rescan_roms) {
 		//if (initial) {
 		//	scaleresource_init(NULL, 0);
 		//}

--- a/src/osdep/amiberry_whdbooter.cpp
+++ b/src/osdep/amiberry_whdbooter.cpp
@@ -1371,9 +1371,8 @@ void create_startup_sequence()
 	whd_bootscript << "FAILAT 999\n";
 
 	if (whdload_prefs.slave_libraries)
-	{
 		whd_bootscript << "DH3:C/Assign LIBS: DH3:LIBS/ ADD\n";
-	}
+
 	if (amiberry_options.use_jst_instead_of_whd)
 		whd_bootscript << "IF NOT EXISTS JST\n";
 	else
@@ -1615,10 +1614,11 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)
 		write_log("WHDBooter - Could not load whdload_db.json or whdload_db.xml - do not exist?\n");
 	}
 
+	bool used_archive_auto_detect = false;
 	if (whdload_prefs.selected_slave.filename.empty())
 	{
 		write_log("WHDBooter - No XML match found, scanning archive for .slave files\n");
-		auto_detect_slave_from_archive(filepath, game_detail);
+		used_archive_auto_detect = auto_detect_slave_from_archive(filepath, game_detail);
 	}
 
 	build_uae_config_filename(whdload_prefs.filename);
@@ -1702,11 +1702,12 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)
 	const auto is_mt32 = _tcsstr(filename, _T("MT32")) != nullptr || _tcsstr(filename, _T("mt32")) != nullptr;
 
 	const auto chipset_unknown = strcmpi(game_detail.chipset.c_str(), "nul") == 0;
+	const auto use_a1200_for_unknown = chipset_unknown && used_archive_auto_detect;
 
-	if (is_aga || is_cd32 || !a600_available || chipset_unknown)
+	if (is_aga || is_cd32 || !a600_available || use_a1200_for_unknown)
 	{
 		write_log("WHDBooter - Host: A1200 ROM selected%s\n",
-			chipset_unknown ? " (no XML hardware info, using A1200 as default)" : "");
+			use_a1200_for_unknown ? " (no database hardware info, using A1200 as default)" : "");
 		built_in_prefs(prefs, 4, A1200_CONFIG, 0, 0);
 		prefs->fastmem[0].size = 0x800000;
 		_tcscpy(prefs->description, _T("AutoBoot Configuration [WHDLoad] [AGA]"));
@@ -1745,7 +1746,7 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)
 	//  SET THE GAME COMPATIBILITY SETTINGS
 	// BLITTER, SPRITES, MEMORY, JIT, BIG CPU ETC
 	write_log("WHDBooter - Host: setting up game compatibility settings\n");
-	set_compatibility_settings(prefs, game_detail, a600_available, is_aga || is_cd32);
+	set_compatibility_settings(prefs, game_detail, a600_available, is_aga || is_cd32 || use_a1200_for_unknown);
 
 	write_log("WHDBooter - Host: settings applied\n\n");
 }

--- a/src/sounddep/sound_platform_internal_libretro.h
+++ b/src/sounddep/sound_platform_internal_libretro.h
@@ -24,7 +24,7 @@ static inline bool sound_platform_output_audio(struct sound_data* sd, uae_u16* s
 {
 	const auto frames = sd->sndbufsize / (sd->channels * 2);
 	if (audio_batch_cb) {
-		audio_batch_cb((const int16_t*)sndbuffer, frames);
+		libretro_audio_frames_this_run += static_cast<unsigned>(audio_batch_cb((const int16_t*)sndbuffer, frames));
 	} else if (audio_cb) {
 		const auto* samples = reinterpret_cast<const int16_t*>(sndbuffer);
 		for (int i = 0; i < frames; i++) {
@@ -32,6 +32,7 @@ static inline bool sound_platform_output_audio(struct sound_data* sd, uae_u16* s
 			const int16_t right = (sd->channels > 1) ? samples[i * sd->channels + 1] : left;
 			audio_cb(left, right);
 		}
+		libretro_audio_frames_this_run += frames;
 	}
 	return true;
 }

--- a/tools/check_libretro_contract.py
+++ b/tools/check_libretro_contract.py
@@ -7,9 +7,15 @@ import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE = ROOT / "libretro" / "libretro.cpp"
+STUB_SOURCE = ROOT / "libretro" / "libretro_stubs.cpp"
+SDL_STUB_SOURCE = ROOT / "libretro" / "sdl_stub.cpp"
 AMIBERRY_SOURCE = ROOT / "src" / "osdep" / "amiberry.cpp"
+FILESYS_SOURCE = ROOT / "src" / "filesys.cpp"
+DEBUG_SOURCE = ROOT / "src" / "debug.cpp"
 MAIN_SOURCE = ROOT / "src" / "main.cpp"
 MAIN_WINDOW_SOURCE = ROOT / "src" / "osdep" / "gui" / "main_window.cpp"
+WHDBOOTER_SOURCE = ROOT / "src" / "osdep" / "amiberry_whdbooter.cpp"
+SOUND_LIBRETRO_SOURCE = ROOT / "src" / "sounddep" / "sound_platform_internal_libretro.h"
 
 
 def extract_body(text, signature):
@@ -55,9 +61,15 @@ def require(condition, message, failures):
 
 def main():
 	text = SOURCE.read_text(encoding="utf-8")
+	stub_text = STUB_SOURCE.read_text(encoding="utf-8")
+	sdl_stub_text = SDL_STUB_SOURCE.read_text(encoding="utf-8")
 	amiberry_text = AMIBERRY_SOURCE.read_text(encoding="utf-8")
+	filesys_text = FILESYS_SOURCE.read_text(encoding="utf-8")
+	debug_text = DEBUG_SOURCE.read_text(encoding="utf-8")
 	main_text = MAIN_SOURCE.read_text(encoding="utf-8")
 	main_window_text = MAIN_WINDOW_SOURCE.read_text(encoding="utf-8")
+	whdbooter_text = WHDBOOTER_SOURCE.read_text(encoding="utf-8")
+	sound_libretro_text = SOUND_LIBRETRO_SOURCE.read_text(encoding="utf-8")
 	failures = []
 
 	set_environment = extract_body(text, "void retro_set_environment(retro_environment_t cb)")
@@ -78,6 +90,16 @@ def main():
 	retro_get_memory_data = extract_body(text, "void *retro_get_memory_data(unsigned id)")
 	retro_get_memory_size = extract_body(text, "size_t retro_get_memory_size(unsigned id)")
 	setup_whdload_paths = extract_body(text, "static void setup_whdload_paths()")
+	retro_load_game = extract_body(text, "bool retro_load_game(const struct retro_game_info *info)")
+	reset_core_runtime_state = extract_body(text, "static void reset_core_runtime_state()")
+	libretro_emit_audio_starvation_guard = extract_body(text, "static void libretro_emit_audio_starvation_guard()")
+	libretro_scan_roms = extract_body(stub_text, "int scan_roms(int show)")
+	sdl_create_semaphore = extract_body(sdl_stub_text, "SDL_Semaphore* SDL_CreateSemaphore(Uint32 initial_value)")
+	sdl_wait_semaphore = extract_body(sdl_stub_text, "void SDL_WaitSemaphore(SDL_Semaphore* s)")
+	sound_platform_output_audio = extract_body(
+		sound_libretro_text,
+		"static inline bool sound_platform_output_audio(struct sound_data* sd, uae_u16* sndbuffer)",
+	)
 	get_seed_source_candidates = extract_body(
 		amiberry_text,
 		"static std::vector<std::string> get_seed_source_candidates(const std::string& subdirectory,\n\tconst bool include_usr_local_share)",
@@ -92,6 +114,14 @@ def main():
 		amiberry_text,
 		"static bool copy_missing_directory_contents_if_exists(const std::string& source_dir, const std::string& destination_dir)",
 	)
+	filesys_iteration = extract_body(filesys_text, "static int filesys_iteration(UnitInfo *ui)")
+	filesys_start_thread = extract_body(filesys_text, "static void filesys_start_thread (UnitInfo *ui, int nr)")
+	startup_handler = extract_body(filesys_text, "static uae_u32 REGPARAM2 startup_handler(TrapContext *ctx)")
+	filesys_start_threads = extract_body(filesys_text, "void filesys_start_threads (void)")
+	dump_xlate = extract_body(debug_text, "static uae_u8 *dump_xlate (uae_u32 addr)")
+	dump_xlate_range = extract_body(debug_text, "static uae_u8 *dump_xlate_range (uae_u32 addr, uae_u32 size)")
+	memory_map_dump_3 = extract_body(debug_text, "static void memory_map_dump_3(UaeMemoryMap *map, int log)")
+	whdload_auto_prefs = extract_body(whdbooter_text, "void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)")
 
 	require(
 		"RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY" not in set_environment,
@@ -101,6 +131,27 @@ def main():
 	require(
 		"apply_minimum_audio_latency();" in retro_run,
 		"retro_run() must apply minimum audio latency from the allowed callback",
+		failures,
+	)
+	require(
+		retro_run.count("libretro_audio_frames_this_run = 0;") >= 2
+		and retro_run.count("libretro_emit_audio_starvation_guard();") >= 2
+		and "audio_rate_for_av_info()" in libretro_emit_audio_starvation_guard
+		and "get_core_refresh_rate()" in libretro_emit_audio_starvation_guard
+		and "libretro_audio_deficit_frames += expected_frames;" in libretro_emit_audio_starvation_guard
+		and "libretro_audio_deficit_frames -= libretro_audio_frames_this_run;" in libretro_emit_audio_starvation_guard
+		and "libretro_audio_deficit_frames = max_deferred_frames * 4.0;" in libretro_emit_audio_starvation_guard
+		and "if (libretro_audio_frames_this_run > 0 || libretro_audio_deficit_frames <= max_deferred_frames)" in libretro_emit_audio_starvation_guard
+		and "audio_batch_cb(silence, chunk)" in libretro_emit_audio_starvation_guard
+		and "audio_cb(0, 0)" in libretro_emit_audio_starvation_guard
+		and "libretro_audio_deficit_frames = 0.0;" in reset_core_runtime_state,
+		"retro_run() must guard true libretro audio starvation without padding normal bursty audio frames",
+		failures,
+	)
+	require(
+		"libretro_audio_frames_this_run += static_cast<unsigned>(audio_batch_cb((const int16_t*)sndbuffer, frames));" in sound_platform_output_audio
+		and "libretro_audio_frames_this_run += frames;" in sound_platform_output_audio,
+		"libretro audio accounting must track frames accepted by the frontend callbacks",
 		failures,
 	)
 	frontend_poll_pos = startup.find("poll_frontend_input();")
@@ -215,6 +266,81 @@ def main():
 	require(
 		"#ifdef LIBRETRO\n\tif (!seed_whdboot_files_from_candidates(source_candidates))\n#else\n\tif (!seed_missing_directory_contents_from_candidates(whdboot_path, source_candidates))" in amiberry_text,
 		"non-libretro WHDBooter seeding must keep using the established generic seed-copy path",
+		failures,
+	)
+	require(
+		"scan_single_rom_file(f)" in stub_text
+		and "regcreatetree(nullptr, _T(\"DetectedROMs\"))" in libretro_scan_roms
+		and "AMIBERRY_LIBRETRO_SYSTEM_DIR" in libretro_scan_roms,
+		"libretro scan_roms() must populate checksum-backed DetectedROMs from frontend ROM paths",
+		failures,
+	)
+	require(
+		"if (initial)\n\t\trescan_roms = true;" in amiberry_text,
+		"libretro initial startup must rescan ROMs because it has no GUI rescan path",
+		failures,
+	)
+	require(
+		"#ifdef LIBRETRO\n\tmultithread_enabled = false;\n#else\n\tmultithread_enabled = true;\n#endif" in amiberry_text,
+		"libretro must default multithreaded Denise drawing off to avoid reset-time queue flush stalls",
+		failures,
+	)
+	require(
+		"pick_whdload_kickstart(" not in text,
+		"WHDLoad auto mode must rely on checksum ROM discovery, not strict Kickstart filenames",
+		failures,
+	)
+	require(
+		"whd_path = canonicalize_existing_host_path(whd_path);" in retro_load_game,
+		"WHDLoad archive paths must be canonicalized before being passed to WHDBooter",
+		failures,
+	)
+	require(
+		"bool used_archive_auto_detect = false;" in whdload_auto_prefs
+		and "used_archive_auto_detect = auto_detect_slave_from_archive(filepath, game_detail);" in whdload_auto_prefs
+		and "const auto use_a1200_for_unknown = chipset_unknown && used_archive_auto_detect;" in whdload_auto_prefs,
+		"WHDBooter must only use the A1200 unknown-chipset fallback for archive auto-detect, not matched database entries",
+		failures,
+	)
+	require(
+		"set_compatibility_settings(prefs, game_detail, a600_available, is_aga || is_cd32 || use_a1200_for_unknown);" in whdload_auto_prefs,
+		"WHDBooter A1200 unknown-chipset fallback must also keep CPU compatibility on the A1200 path",
+		failures,
+	)
+	require(
+		"if (ctx)\n\t\t\ttrap_background_set_complete(ctx);" in filesys_iteration,
+		"filesystem thread shutdown must not complete a null trap context from the death message",
+		failures,
+	)
+	require(
+		"clear_unit_state" not in filesys_start_thread
+		and "filesys_start_thread (ui, i);" in filesys_start_threads
+		and "is_virtual(i) && !ui->self" not in filesys_start_threads
+		and "filesys_start_thread(uinfo, nr);" in startup_handler
+		and "unit = startup_create_unit(ctx, uinfo, nr);" in startup_handler,
+		"virtual filesystem threads must keep the normal startup order; only null teardown contexts should be guarded",
+		failures,
+	)
+	require(
+		"pthread_mutex_init(&s->mutex" in sdl_create_semaphore
+		and "pthread_cond_init(&s->cond" in sdl_create_semaphore
+		and "sem_init(" not in sdl_create_semaphore
+		and "while (s->value == 0)" in sdl_wait_semaphore
+		and "pthread_cond_wait(&s->cond" in sdl_wait_semaphore,
+		"libretro SDL semaphore stub must use pthread condvars, not macOS-unsupported sem_init",
+		failures,
+	)
+	require(
+		"!bank->check || !bank->xlateaddr" in dump_xlate
+		and "!bank->check || !bank->xlateaddr" in dump_xlate_range,
+		"debug memory map dumping must validate bank callbacks before translating reset-time banks",
+		failures,
+	)
+	require(
+		"uae_u8 *crc_mem = dump_xlate_range((j << 16) | bankoffset, crc_size);" in memory_map_dump_3
+		and "get_crc32(crc_mem, crc_size)" in memory_map_dump_3
+		and "a1->xlateaddr((j << 16) | bankoffset)" not in memory_map_dump_3,
+		"debug memory map ROM CRC dumping must use guarded ranged translation",
 		failures,
 	)
 

--- a/tools/check_libretro_contract.py
+++ b/tools/check_libretro_contract.py
@@ -276,6 +276,14 @@ def main():
 		failures,
 	)
 	require(
+		"static bool libretro_is_rom_key_file" in stub_text
+		and "if (libretro_is_rom_key_file(path)) {\n\t\taddkeyfile(path);\n\t\treturn 0;\n\t}" in stub_text
+		and "if (!libretro_is_rom_key_file(path) && !libretro_is_rom_ext(path, deepscan))" in stub_text
+		and "for (const auto& file : files) {\n\t\tif (libretro_is_rom_key_file(file))\n\t\t\tlibretro_scan_rom_file(file, fkey, deepscan);\n\t}" in stub_text,
+		"libretro ROM scanning must let rom.key through and register keys before encrypted ROM candidates",
+		failures,
+	)
+	require(
 		"if (initial)\n\t\trescan_roms = true;" in amiberry_text,
 		"libretro initial startup must rescan ROMs because it has no GUI rescan path",
 		failures,

--- a/tools/run_libretro_local.sh
+++ b/tools/run_libretro_local.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: tools/run_libretro_local.sh [options]
+
+Options:
+  --roms PATH        Copy Kickstart ROM file(s) from PATH into the test system/Kickstarts dir.
+                     PATH may be a file or a directory. May be passed more than once.
+  --content PATH     Copy and launch this content file, usually a WHDLoad .lha/.lzh.
+  --test-root PATH   Use this test root. Default: build/libretro-test
+  --run-secs N       Launch RetroArch, wait N seconds, then terminate it.
+  --no-build         Reuse the existing libretro core.
+  --no-run           Prepare/build only, do not launch RetroArch.
+  --refresh-assets   Replace the test-root WHDBoot assets from the repo.
+  -h, --help         Show this help.
+
+Environment:
+  RETROARCH_BIN           RetroArch executable path.
+  AMIBERRY_TEST_ROMS      Optional colon-separated ROM source path(s).
+  AMIBERRY_TEST_CONTENT   Optional content path.
+  AMIBERRY_TEST_ROOT      Optional test root.
+  AMIBERRY_TEST_RUN_SECS  Optional timed-run duration.
+EOF
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root="${AMIBERRY_TEST_ROOT:-$repo_root/build/libretro-test}"
+content="${AMIBERRY_TEST_CONTENT:-}"
+run_secs="${AMIBERRY_TEST_RUN_SECS:-}"
+do_build=1
+do_run=1
+refresh_assets=0
+rom_sources=()
+
+if [[ -n "${AMIBERRY_TEST_ROMS:-}" ]]; then
+	IFS=':' read -r -a rom_sources <<< "$AMIBERRY_TEST_ROMS"
+fi
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--roms)
+			[[ $# -ge 2 ]] || { echo "--roms requires a path" >&2; exit 2; }
+			rom_sources+=("$2")
+			shift 2
+			;;
+		--content)
+			[[ $# -ge 2 ]] || { echo "--content requires a path" >&2; exit 2; }
+			content="$2"
+			shift 2
+			;;
+		--test-root)
+			[[ $# -ge 2 ]] || { echo "--test-root requires a path" >&2; exit 2; }
+			test_root="$2"
+			shift 2
+			;;
+		--run-secs)
+			[[ $# -ge 2 ]] || { echo "--run-secs requires seconds" >&2; exit 2; }
+			run_secs="$2"
+			shift 2
+			;;
+		--no-build)
+			do_build=0
+			shift
+			;;
+		--no-run)
+			do_run=0
+			shift
+			;;
+		--refresh-assets)
+			refresh_assets=1
+			shift
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "Unknown option: $1" >&2
+			usage >&2
+			exit 2
+			;;
+	esac
+done
+
+if [[ -n "${RETROARCH_BIN:-}" ]]; then
+	retroarch_bin="$RETROARCH_BIN"
+elif [[ -x /Applications/RetroArch.app/Contents/MacOS/RetroArch ]]; then
+	retroarch_bin=/Applications/RetroArch.app/Contents/MacOS/RetroArch
+elif command -v retroarch >/dev/null 2>&1; then
+	retroarch_bin="$(command -v retroarch)"
+else
+	echo "RetroArch not found. Install it or set RETROARCH_BIN." >&2
+	exit 1
+fi
+
+system_dir="$test_root/system"
+save_dir="$test_root/save"
+state_dir="$test_root/state"
+content_dir="$test_root/content"
+log_dir="$test_root/logs"
+kick_dir="$system_dir/Kickstarts"
+cfg="$test_root/retroarch-test.cfg"
+
+mkdir -p "$kick_dir" "$save_dir/Amiberry" "$state_dir/Amiberry" "$content_dir" "$log_dir"
+
+if [[ "$refresh_assets" -eq 1 || ! -e "$system_dir/whdboot/WHDLoad" ]]; then
+	rm -rf "$system_dir/whdboot"
+	cp -R "$repo_root/whdboot" "$system_dir/"
+fi
+
+for src in "${rom_sources[@]}"; do
+	[[ -n "$src" ]] || continue
+	if [[ -d "$src" ]]; then
+		find "$src" -maxdepth 1 -type f -exec cp -p {} "$kick_dir/" \;
+	elif [[ -f "$src" ]]; then
+		cp -p "$src" "$kick_dir/"
+	else
+		echo "ROM source not found: $src" >&2
+		exit 1
+	fi
+done
+
+launch_content=()
+if [[ -n "$content" ]]; then
+	if [[ ! -f "$content" ]]; then
+		echo "Content not found: $content" >&2
+		exit 1
+	fi
+	content_target="$content_dir/$(basename "$content")"
+	cp -p "$content" "$content_target"
+	launch_content=("$content_target")
+fi
+
+cat > "$cfg" <<EOF
+system_directory = "$system_dir"
+savefile_directory = "$save_dir"
+savestate_directory = "$state_dir"
+video_fullscreen = "false"
+video_shader_enable = "false"
+pause_nonactive = "false"
+menu_pause_libretro = "false"
+EOF
+
+os_name="$(uname -s)"
+host_arch="$(uname -m)"
+core_ext="so"
+target_arch="$host_arch"
+run_prefix=()
+
+if [[ "$os_name" == "Darwin" ]]; then
+	core_ext="dylib"
+	retroarch_file_info="$(file "$retroarch_bin")"
+	if [[ "$retroarch_file_info" == *"x86_64"* && "$retroarch_file_info" != *"arm64"* ]]; then
+		target_arch="x86_64"
+		if [[ "$host_arch" == "arm64" ]]; then
+			run_prefix=(arch -x86_64)
+		fi
+	elif [[ "$retroarch_file_info" == *"arm64"* ]]; then
+		target_arch="arm64"
+	fi
+fi
+
+core="$repo_root/libretro/amiberry_libretro.$core_ext"
+
+if [[ "$do_build" -eq 1 ]]; then
+	build_args=(ARCH="$target_arch")
+	if [[ "$os_name" == "Darwin" && "$target_arch" == "x86_64" ]]; then
+		build_args+=(CC="clang -arch x86_64" CXX="clang++ -arch x86_64")
+	fi
+
+	needs_clean=0
+	if [[ -e "$core" ]]; then
+		core_file_info="$(file "$core")"
+		if [[ "$core_file_info" != *"$target_arch"* ]]; then
+			needs_clean=1
+		fi
+	fi
+	if [[ "$needs_clean" -eq 1 ]]; then
+		make -C "$repo_root/libretro" clean
+	fi
+
+	if command -v sysctl >/dev/null 2>&1; then
+		jobs="$(sysctl -n hw.logicalcpu 2>/dev/null || true)"
+	else
+		jobs=""
+	fi
+	if [[ -z "$jobs" && -r /proc/cpuinfo ]]; then
+		jobs="$(grep -c '^processor' /proc/cpuinfo || true)"
+	fi
+	[[ -n "$jobs" ]] || jobs=4
+
+	make -C "$repo_root/libretro" -j"$jobs" "${build_args[@]}"
+	rm -f "$repo_root/libretro/amiberry_libretro.info" "$repo_root/libretro/libco/libco.o"
+fi
+
+if [[ ! -e "$core" ]]; then
+	echo "Core not found: $core" >&2
+	exit 1
+fi
+
+echo "RetroArch: $retroarch_bin"
+echo "Core:      $core ($(file "$core"))"
+echo "Test root: $test_root"
+echo "ROM dir:   $kick_dir"
+if [[ ${#launch_content[@]} -gt 0 ]]; then
+	echo "Content:   ${launch_content[0]}"
+else
+	echo "Content:   <none>"
+fi
+echo "Core log:  $save_dir/Amiberry/Amiberry.log"
+echo "RA log:    $log_dir/retroarch.log"
+
+if [[ "$do_run" -eq 0 ]]; then
+	exit 0
+fi
+
+if [[ "$os_name" == "Darwin" ]]; then
+	rm -rf "$HOME/Library/Saved Application State/com.libretro.RetroArch.savedState"
+fi
+
+run_env=(AMIBERRY_LIBRETRO_DEBUG=1)
+if [[ "$os_name" == "Darwin" ]]; then
+	run_env+=(ApplePersistenceIgnoreState=YES)
+fi
+
+cmd=("${run_prefix[@]}" "$retroarch_bin" --appendconfig "$cfg" -L "$core")
+if [[ ${#launch_content[@]} -gt 0 ]]; then
+	cmd+=("${launch_content[0]}")
+fi
+cmd+=(-v)
+
+if [[ -n "$run_secs" ]]; then
+	rm -f "$save_dir/Amiberry/Amiberry.log"
+	env "${run_env[@]}" "${cmd[@]}" >"$log_dir/retroarch.log" 2>&1 &
+	pid=$!
+	sleep "$run_secs"
+	kill -TERM "$pid" >/dev/null 2>&1 || true
+	wait "$pid" >/dev/null 2>&1 || true
+else
+	rm -f "$save_dir/Amiberry/Amiberry.log"
+	env "${run_env[@]}" "${cmd[@]}" 2>&1 | tee "$log_dir/retroarch.log"
+fi


### PR DESCRIPTION
## Summary

Fixes the libretro WHDLoad `.lha/.lzh` startup path so WHDBooter can use checksum-detected Kickstarts, reach game boot, and keep RetroArch paced without corrupting audio timing.

## Root Cause

The libretro build had several gaps in the standalone/desktop startup assumptions:

- ROM discovery was effectively stubbed, so WHDBooter could not rely on the normal checksum-backed `DetectedROMs` flow.
- WHDLoad autoloading used strict fallback Kickstart filenames instead of the normal Amiberry checksum detection path.
- macOS libretro semaphore stubs used unnamed POSIX semaphores, which are unsupported there and could leave worker paths stalled.
- Debug memory map dumping could translate reset-time banks without validating callbacks.
- A previous per-frame audio top-up approach over-padded normal bursty Amiberry audio and made playback sound slow.

## Changes

- Implement libretro ROM scanning into `DetectedROMs` from frontend system/save/WHDBoot paths.
- Remove strict WHD Kickstart filename selection and canonicalize WHD archive paths before WHDBooter sees them.
- Keep libretro initial startup rescanning ROMs and default multithreaded Denise drawing off for this core path.
- Adjust WHDBooter A600/A1200 fallback behavior for database-matched unknown-chipset games.
- Replace the libretro SDL semaphore stub with a pthread mutex/condvar implementation.
- Guard filesystem shutdown and debug memory map translation paths that were unsafe during libretro reset/startup.
- Add bounded libretro audio-starvation protection that only emits silence when true audio starvation occurs, without padding normal bursty real audio.
- Add `tools/run_libretro_local.sh` for repeatable local RetroArch/libretro testing.
- Extend `tools/check_libretro_contract.py` to cover the new libretro/WHDBooter contracts.

## Validation

- `bash -n tools/run_libretro_local.sh`
- `python3 tools/check_libretro_contract.py`
- `git diff --check`
- `tools/run_libretro_local.sh --roms "$HOME/Documents/Amiberry/ROMs" --content "$HOME/Documents/Amiberry/LHA/Turrican_v2.1_0092.lha" --run-secs 75`
- Re-ran the Turrican `.lha` harness after the code-review follow-up fix with `--run-secs 45`.

## Review Notes

A follow-up self-review found that the new audio starvation deficit could grow without bound in an unusual partial-audio case. This PR caps the deficit before it can create a later burst of silence.
