### PR TITLE
Fix Windows libretro stubs build

### DIFF
--- a/libretro/libretro_stubs.cpp
+++ b/libretro/libretro_stubs.cpp
@@ -19,9 +19,6 @@
 #include <vector>
 #include <algorithm>
 #include <sys/stat.h>
-#ifdef _WIN32
-#include <direct.h>
-#endif
 
 #ifdef LIBRETRO
 unsigned int gui_ledstate = 0;


### PR DESCRIPTION
Fixes the Windows libretro CI failure after #2072. The Windows job failed because libretro_stubs.cpp included <direct.h> after sysdeps.h had defined the libretro mkdir(a, b) macro, causing MinGW's one-argument mkdir declaration to be macro-expanded. The include is unused in this file, so remove it.\n\nLocal checks:\n- bash -n tools/run_libretro_local.sh\n- python3 tools/check_libretro_contract.py\n- git diff --check