### PR TITLE
Fix macOS qemu plugin bundling

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -333,17 +333,36 @@ jobs:
           echo "=== Verifying dylib dependencies resolve ==="
           missing_deps=0
           MAIN_BIN="universal-app/Amiberry.app/Contents/MacOS/Amiberry"
-          for arch in x86_64 arm64; do
-            while read -r line; do
-              dep_name=$(echo "$line" | sed -E 's|.*@executable_path/../Frameworks/([^ ]+).*|\1|')
-              if [ ! -f "$UNI_FW/$dep_name" ]; then
-                echo "  MISSING ($arch): $dep_name"
+
+          check_framework_refs() {
+            local binary="$1"
+            local label="$2"
+            for arch in x86_64 arm64; do
+              if ! lipo "$binary" -verify_arch "$arch" >/dev/null 2>&1; then
+                continue
+              fi
+              while read -r line; do
+                dep_name=$(echo "$line" | sed -E 's|.*@executable_path/../Frameworks/([^ ]+).*|\1|')
+                if [ ! -f "$UNI_FW/$dep_name" ]; then
+                  echo "  MISSING ($arch, $label): $dep_name"
+                  missing_deps=1
+                fi
+              done < <(otool -arch "$arch" -L "$binary" 2>/dev/null | grep '@executable_path/../Frameworks/' || true)
+              if otool -arch "$arch" -L "$binary" 2>/dev/null | grep -E '/opt/homebrew|/usr/local'; then
+                echo "  EXTERNAL HOMEBREW DEPENDENCY ($arch, $label)"
                 missing_deps=1
               fi
-            done < <(otool -arch "$arch" -L "$MAIN_BIN" 2>/dev/null | grep '@executable_path/../Frameworks/' || true)
+            done
+          }
+
+          check_framework_refs "$MAIN_BIN" "Amiberry"
+          for dylib in "$UNI_PLUGINS"/*.dylib "$UNI_FW"/*.dylib; do
+            [ -f "$dylib" ] || continue
+            [ -L "$dylib" ] && continue
+            check_framework_refs "$dylib" "$(basename "$dylib")"
           done
           if [ "$missing_deps" = "1" ]; then
-            echo "::error::Some @executable_path dylib references cannot be resolved — the app will crash on load"
+            echo "::error::Some dylib references are unresolved or still point at Homebrew paths"
             exit 1
           fi
 

--- a/cmake/macos/install.cmake
+++ b/cmake/macos/install.cmake
@@ -133,7 +133,7 @@ if (NOT "${CMAKE_GENERATOR}" MATCHES "Xcode")
     install(FILES $<TARGET_FILE:floppybridge>
             DESTINATION $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/plugins/)
     if(QEMU_UAE_PLUGIN)
-        install(FILES "${QEMU_UAE_PLUGIN}"
+        install(FILES "${_amiberry_qemu_uae_plugin_output}"
                 DESTINATION $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/plugins/)
     endif()
 

--- a/cmake/macos/install.cmake
+++ b/cmake/macos/install.cmake
@@ -26,16 +26,56 @@ add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:floppybridge>
         $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/plugins/$<TARGET_FILE_NAME:floppybridge>)
+
+set(_amiberry_dylibbundler_search_args
+        -s /usr/local/lib
+        -s /usr/local/opt/glib/lib
+        -s /usr/local/opt/gettext/lib
+        -s /usr/local/opt/pcre2/lib
+        -s /opt/homebrew/lib
+        -s /opt/homebrew/opt/glib/lib
+        -s /opt/homebrew/opt/gettext/lib
+        -s /opt/homebrew/opt/pcre2/lib)
+
 if(QEMU_UAE_PLUGIN)
+    get_filename_component(_amiberry_qemu_uae_plugin_name "${QEMU_UAE_PLUGIN}" NAME)
+    set(_amiberry_qemu_uae_plugin_output
+            "$<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/plugins/${_amiberry_qemu_uae_plugin_name}")
+
+    set(_amiberry_qemu_uae_plugin_arches ${CMAKE_OSX_ARCHITECTURES})
+    if(NOT _amiberry_qemu_uae_plugin_arches)
+        set(_amiberry_qemu_uae_plugin_arches "${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
+    list(LENGTH _amiberry_qemu_uae_plugin_arches _amiberry_qemu_uae_plugin_arch_count)
+    if(_amiberry_qemu_uae_plugin_arch_count EQUAL 1)
+        list(GET _amiberry_qemu_uae_plugin_arches 0 _amiberry_qemu_uae_plugin_arch)
+        if(_amiberry_qemu_uae_plugin_arch STREQUAL "aarch64")
+            set(_amiberry_qemu_uae_plugin_arch "arm64")
+        endif()
+    else()
+        set(_amiberry_qemu_uae_plugin_arch "")
+    endif()
+
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${QEMU_UAE_PLUGIN}"
-            $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Resources/plugins/)
+            COMMAND "${CMAKE_COMMAND}"
+                "-DQEMU_UAE_PLUGIN_INPUT=${QEMU_UAE_PLUGIN}"
+                "-DQEMU_UAE_PLUGIN_OUTPUT=${_amiberry_qemu_uae_plugin_output}"
+                "-DQEMU_UAE_PLUGIN_ARCH=${_amiberry_qemu_uae_plugin_arch}"
+                -P "${CMAKE_SOURCE_DIR}/cmake/macos/prepare_qemu_plugin.cmake"
+            COMMENT "Preparing QEMU-UAE PPC plugin"
+            VERBATIM)
 endif()
 
 # Gather all dependencies with dylibbundler
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND dylibbundler -od -b -x $<TARGET_FILE:${PROJECT_NAME}> -d $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Frameworks/ -p @executable_path/../Frameworks/ -s /usr/local/lib)
+        COMMAND dylibbundler -od -b -x $<TARGET_FILE:${PROJECT_NAME}> -d $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Frameworks/ -p @executable_path/../Frameworks/ ${_amiberry_dylibbundler_search_args})
+
+if(QEMU_UAE_PLUGIN)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND dylibbundler -of -cd -b -x "${_amiberry_qemu_uae_plugin_output}" -d $<TARGET_FILE_DIR:${PROJECT_NAME}>/../Frameworks/ -p @executable_path/../Frameworks/ ${_amiberry_dylibbundler_search_args}
+            COMMENT "Bundling QEMU-UAE PPC plugin dependencies"
+            VERBATIM)
+endif()
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -DAPP_BINARY=$<TARGET_FILE:${PROJECT_NAME}> -P ${CMAKE_SOURCE_DIR}/cmake/macos/dedupe_frameworks_rpath.cmake)

--- a/cmake/macos/prepare_qemu_plugin.cmake
+++ b/cmake/macos/prepare_qemu_plugin.cmake
@@ -1,0 +1,77 @@
+if(NOT DEFINED QEMU_UAE_PLUGIN_INPUT OR QEMU_UAE_PLUGIN_INPUT STREQUAL "")
+    message(FATAL_ERROR "QEMU_UAE_PLUGIN_INPUT is required")
+endif()
+
+if(NOT DEFINED QEMU_UAE_PLUGIN_OUTPUT OR QEMU_UAE_PLUGIN_OUTPUT STREQUAL "")
+    message(FATAL_ERROR "QEMU_UAE_PLUGIN_OUTPUT is required")
+endif()
+
+get_filename_component(_qemu_uae_output_dir "${QEMU_UAE_PLUGIN_OUTPUT}" DIRECTORY)
+file(MAKE_DIRECTORY "${_qemu_uae_output_dir}")
+
+execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+        "${QEMU_UAE_PLUGIN_INPUT}"
+        "${QEMU_UAE_PLUGIN_OUTPUT}"
+    RESULT_VARIABLE _qemu_uae_copy_result
+    OUTPUT_VARIABLE _qemu_uae_copy_out
+    ERROR_VARIABLE _qemu_uae_copy_err
+)
+
+if(NOT _qemu_uae_copy_result EQUAL 0)
+    message(FATAL_ERROR
+        "Failed to copy QEMU-UAE plugin '${QEMU_UAE_PLUGIN_INPUT}' to "
+        "'${QEMU_UAE_PLUGIN_OUTPUT}':\n"
+        "${_qemu_uae_copy_out}${_qemu_uae_copy_err}"
+    )
+endif()
+
+if(DEFINED QEMU_UAE_PLUGIN_ARCH AND NOT QEMU_UAE_PLUGIN_ARCH STREQUAL "")
+    execute_process(
+        COMMAND lipo -info "${QEMU_UAE_PLUGIN_OUTPUT}"
+        RESULT_VARIABLE _qemu_uae_lipo_info_result
+        OUTPUT_VARIABLE _qemu_uae_lipo_info_out
+        ERROR_VARIABLE _qemu_uae_lipo_info_err
+    )
+
+    if(NOT _qemu_uae_lipo_info_result EQUAL 0)
+        message(FATAL_ERROR
+            "Failed to inspect QEMU-UAE plugin architecture '${QEMU_UAE_PLUGIN_OUTPUT}':\n"
+            "${_qemu_uae_lipo_info_out}${_qemu_uae_lipo_info_err}"
+        )
+    endif()
+
+    if(_qemu_uae_lipo_info_out MATCHES "Architectures in the fat file")
+        if(NOT _qemu_uae_lipo_info_out MATCHES "(^| )${QEMU_UAE_PLUGIN_ARCH}( |$)")
+            message(FATAL_ERROR
+                "QEMU-UAE plugin '${QEMU_UAE_PLUGIN_OUTPUT}' does not contain "
+                "architecture '${QEMU_UAE_PLUGIN_ARCH}': ${_qemu_uae_lipo_info_out}"
+            )
+        endif()
+
+        set(_qemu_uae_thin_output "${QEMU_UAE_PLUGIN_OUTPUT}.thin")
+        execute_process(
+            COMMAND lipo "${QEMU_UAE_PLUGIN_OUTPUT}"
+                -thin "${QEMU_UAE_PLUGIN_ARCH}"
+                -output "${_qemu_uae_thin_output}"
+            RESULT_VARIABLE _qemu_uae_lipo_thin_result
+            OUTPUT_VARIABLE _qemu_uae_lipo_thin_out
+            ERROR_VARIABLE _qemu_uae_lipo_thin_err
+        )
+
+        if(NOT _qemu_uae_lipo_thin_result EQUAL 0)
+            message(FATAL_ERROR
+                "Failed to thin QEMU-UAE plugin '${QEMU_UAE_PLUGIN_OUTPUT}' to "
+                "'${QEMU_UAE_PLUGIN_ARCH}':\n"
+                "${_qemu_uae_lipo_thin_out}${_qemu_uae_lipo_thin_err}"
+            )
+        endif()
+
+        file(RENAME "${_qemu_uae_thin_output}" "${QEMU_UAE_PLUGIN_OUTPUT}")
+    elseif(NOT _qemu_uae_lipo_info_out MATCHES "architecture: ${QEMU_UAE_PLUGIN_ARCH}")
+        message(FATAL_ERROR
+            "QEMU-UAE plugin '${QEMU_UAE_PLUGIN_OUTPUT}' has unexpected "
+            "architecture for '${QEMU_UAE_PLUGIN_ARCH}': ${_qemu_uae_lipo_info_out}"
+        )
+    endif()
+endif()


### PR DESCRIPTION
## Summary
- Bundle qemu-uae.dylib dependencies into the macOS app Frameworks directory.
- Thin the universal qemu plugin during per-arch intermediate macOS builds before running dylibbundler.
- Extend macOS CI verification to inspect plugins and bundled Frameworks dylibs, and fail on remaining Homebrew paths.

## Root cause
qemu-uae.dylib was present and signed in the app bundle, but still referenced Homebrew GLib at /opt/homebrew or /usr/local. Under hardened runtime, macOS rejected that external ad-hoc signed library because it did not share the app Team ID.

## Validation
- cmake -S . -B /private/tmp/amiberry-cmake-qemu-check -DQEMU_UAE_PLUGIN=/Applications/Amiberry.app/Contents/Resources/plugins/qemu-uae.dylib -DMACOS_CODESIGN_BUNDLE=OFF
- cmake --build /private/tmp/amiberry-cmake-qemu-check -j8
- Verified the generated qemu plugin now references @executable_path/../Frameworks/libglib-2.0.0.dylib and libgmodule-2.0.0.dylib.
- Verified bundled GLib resolves libintl and libpcre2 from @executable_path/../Frameworks.
- Verified no /opt/homebrew or /usr/local references remain in the generated qemu/GLib chain.