### PR TITLE
Fix macOS arm64 EXC_BAD_ACCESS when switching to PPC (qemu-uae W^X)

### DIFF
--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -752,7 +752,15 @@ STATIC_INLINE void jit_end_write_window(void);
 #endif
 STATIC_INLINE void write_jmp_target(uae_u32 *jmpaddr, uintptr a);
 
-static int jit_write_window_depth = 0;
+/* pthread_jit_write_protect_np() toggles the W^X state per-thread, so the
+ * nesting counter that gates it must be per-thread too. With the QEMU PPC
+ * plugin a second thread (the TCG vCPU) drives the JIT via SMC/block
+ * invalidation (write_jmp_target) at the same time the main thread is inside
+ * compile_block(). A shared global counter lets the two threads' begin/end
+ * pairs interleave, so the main thread's "restore execute mode" is skipped and
+ * it faults (EXC_BAD_ACCESS code=2) the instant it runs the freshly compiled
+ * block. thread_local keeps each thread's window depth and W^X state coherent. */
+static thread_local int jit_write_window_depth = 0;
 
 STATIC_INLINE void jit_begin_write_window(void)
 {

--- a/src/newcpu.cpp
+++ b/src/newcpu.cpp
@@ -58,6 +58,7 @@
 #endif
 #ifdef JIT
 #include "jit/compemu.h"
+#include "uae/vm.h"
 #include <signal.h>
 volatile int jit_exception_pending = 0;
 #if defined(JIT_HAS_BUS_ERROR_RECOVERY)
@@ -5860,6 +5861,19 @@ static void m68k_run_jit(void)
 			jit_in_compiled_code = true;
 #endif
 			for (;;) {
+#if defined(__APPLE__) && defined(CPU_AARCH64)
+				/* The qemu-uae PPC plugin generates TCG code on this (m68k)
+				 * thread during PPC init/reset (reached via do_specialties()
+				 * below) and leaves the thread in JIT *write* mode through
+				 * pthread_jit_write_protect_np(). On Apple Silicon a MAP_JIT
+				 * page is per-thread either writable or executable, so the next
+				 * dispatch into translated m68k code would fault with
+				 * EXC_BAD_ACCESS (code=2). Re-assert execute mode here so we
+				 * never run a translated block from a write-protected page.
+				 * Only needed while the PPC CPU is in use. */
+				if (currprefs.ppc_mode)
+					uae_vm_jit_write_protect(true);
+#endif
 				((compiled_handler*)(pushall_call_handler))();
 				/* Check for pending exception from SIGSEGV handler (x86-64) */
 #if defined(CPU_x86_64) || defined(_M_AMD64)


### PR DESCRIPTION
## Problem

On macOS arm64 (Apple Silicon), starting a PPC config that uses the `qemu-uae` plugin (e.g. A4000 + CyberStorm PPC) crashes the instant control switches to the PPC — right after `QEMU: Resumed!` / `CS: M68K Halted`. Works fine on Windows x86_64.

## Root cause (captured under lldb)

The fault is `EXC_BAD_ACCESS (code=2)` (instruction-fetch / execute-protection) on the **main thread**, executing Amiberry's own m68k JIT cache:

```
thread #1 (main): EXC_BAD_ACCESS (code=2) at <jit-cache-addr>
  frame #0: <jit-cache-addr>          ; entered via pushall_call_handler
  frame #1: m68k_go + 444
  lr: m68k_run_jit + 328
```

Tracing `pthread_jit_write_protect_np` shows the trigger directly:

```
=== uae_ppc_cpu_reboot reached ===
WX mode=0 thr#1  qemu-uae.dylib`<fn>      ; QEMU sets WRITE mode on the m68k thread
thread #1: EXC_BAD_ACCESS (code=2) ...   ; m68k JIT then executes -> fault
```

On Apple Silicon `pthread_jit_write_protect_np()` controls MAP_JIT W^X **per-thread**. During PPC init/reset — reached from `m68k_run_jit` via `do_specialties()` → CSPPC reset → plugin load / CPU realize / TCG prologue generation — the `qemu-uae` plugin generates TCG code **on Amiberry's m68k thread** and leaves that thread in JIT *write* (non-executable) mode. The next dispatch into a translated m68k block faults. Windows is unaffected (no per-thread W^X).

## Fix

1. **`newcpu.cpp` (`m68k_run_jit`)** — before dispatching into translated code, when the PPC CPU is in use, re-assert execute mode via `uae_vm_jit_write_protect(true)` so we never run a block from a write-protected page (macOS arm64 only; gated by `currprefs.ppc_mode` so non-PPC configs are unaffected).
2. **`compemu_support_arm.cpp`** — make `jit_write_window_depth` `thread_local`. It gates a per-thread W^X state, so a process-global counter is incorrect once a second thread (the QEMU TCG vCPU) touches the m68k JIT via SMC/block invalidation concurrently with `compile_block()`.

## Verification

Tested with a hardened-runtime + `allow-jit` build (matching release W^X enforcement — an earlier non-hardened test was a false positive because it disabled W^X entirely):

- **Before:** `EXC_BAD_ACCESS (code=2)` in the m68k JIT immediately at the PPC switch.
- **After:** switches to PPC and boots — Picasso IV RTG active (`RTG=1/1`, 640×480), `Chipset emulation inactive`, ~187% CPU across the m68k + TCG threads, no exception.