### PR TITLE
Fix macOS crash: SDL/Cocoa event pump on the qemu-uae PPC thread

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -3376,9 +3376,20 @@ void update_clipboard()
 	osdep_platform_update_clipboard();
 }
 
+extern bool uae_self_is_ppc(void);
+
 int handle_msgpump(bool vblank)
 {
 	if (!osdep_platform_use_event_pump())
+		return 0;
+	/* SDL/Cocoa event pumping must never run on the qemu-uae PPC CPU thread.
+	 * That thread can reach here through a CIA register read
+	 * (uae_ppc_io_mem_read -> ReadCIAA -> handle_joystick_buttons ->
+	 * handle_msgpump); on macOS, calling the Cocoa event loop off the main
+	 * thread aborts the process ("nextEventMatchingMask should only be called
+	 * from the Main Thread!"). The host event loop is pumped by the emulation
+	 * thread every frame, so skipping it here is safe. */
+	if (uae_self_is_ppc())
 		return 0;
 	lctrl_pressed = rctrl_pressed = lalt_pressed = ralt_pressed = lshift_pressed = rshift_pressed = lgui_pressed = rgui_pressed = false;
 	auto got_event = 0;


### PR DESCRIPTION
## Problem

On macOS arm64, after a PPC config (A4000 + CyberStorm PPC) switches control to the qemu-uae plugin, the process can abort with:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
    reason: 'nextEventMatchingMask should only be called from the Main Thread!'
```

## Root cause (full stack, captured under lldb)

```
rr_cpu_thread_fn → tcg_cpu_exec → cpu_exec        (qemu-uae PPC/TCG thread)
 → helper_ldub_mmu → memory_region_dispatch_read → indirect_read
  → uae_ppc_io_mem_read → cia_bget → ReadCIAA
   → handle_joystick_buttons → handle_msgpump
    → SDL_PumpEvents → Cocoa_PumpEvents → nextEventMatchingMask   ← main-thread only
```

When the PPC reads a CIA-A register (joystick/fire-button port), `ReadCIAA` pumps the SDL event loop. On the PPC CPU thread that reaches Cocoa's `nextEventMatchingMask`, which is main-thread-only on macOS → abort. Harmless on Windows.

## Fix

Guard `handle_msgpump` to return immediately when called on the PPC CPU thread (`uae_self_is_ppc()`). The emulation thread pumps the host event loop every frame, so skipping the pump on the PPC thread is safe — the CIA read returns the already-current input state. `uae_self_is_ppc()` is false during normal m68k execution and on non-PPC configs, so there is no behavior change off the PPC thread.

## Verification

Built locally (hardened runtime + `allow-jit`, matching release W^X enforcement):
- **Before:** `nextEventMatchingMask` abort shortly after the PPC switch.
- **After:** no abort; the PPC continues running (kernel alive, decrementer ticking).

## Note — not the whole story

This removes a real crash, but it is **not** the end of PPC-on-macOS bring-up. With this fix the OS4.1/PPC kernel boots and idles (timer interrupts fire ~20 Hz), but the installer does not yet appear: the PPC sits in its idle loop with no **external** (Amiga→PPC) interrupts ever forwarded while the m68k is halted, so a boot task waiting on a device/chipset interrupt (e.g. CD/SCSI completion) never wakes. That interrupt-forwarding path is a separate, still-open investigation.