### PR TITLE
Fix macOS PPC interrupt stall: atomic CyberStorm IPL register update

### DIFF
--- a/src/cpuboard.cpp
+++ b/src/cpuboard.cpp
@@ -232,8 +232,20 @@ bool ppc_interrupt(int new_m68k_ipl)
 		uae_u8 ppcipl = (~io_reg[CSIII_REG_IPL_EMU]) & P5_PPC_IPL_MASK;
 		if (new_m68k_ipl < 0)
 			new_m68k_ipl = 0;
-		io_reg[CSIII_REG_IPL_EMU] &= ~P5_M68k_IPL_MASK;
-		io_reg[CSIII_REG_IPL_EMU] |= (new_m68k_ipl << 3) ^ P5_M68k_IPL_MASK;
+		/* This runs on the emulation thread while the PPC CPU thread can
+		 * concurrently write io_reg[CSIII_REG_IPL_EMU] (the CyberStorm IO bank
+		 * is ABFLAG_THREADSAFE, so PPC writes skip the spinlock). The two
+		 * threads own disjoint bitfields of this byte: the PPC owns the PPC-IPL
+		 * bits (P5_PPC_IPL_MASK), we own only the M68k-IPL bits
+		 * (P5_M68k_IPL_MASK). A plain read-modify-write here writes back the
+		 * PPC-IPL bits as we read them and can lose the PPC's update (e.g. the
+		 * PPC lowering its IPL to 0 to accept interrupts), leaving ppcipl stuck
+		 * and no interrupts ever forwarded. Use atomic bit ops so we only ever
+		 * modify the M68k-IPL bits and never clobber the PPC-IPL bits. */
+		__atomic_and_fetch(&io_reg[CSIII_REG_IPL_EMU],
+			(uae_u8)~P5_M68k_IPL_MASK, __ATOMIC_SEQ_CST);
+		__atomic_or_fetch(&io_reg[CSIII_REG_IPL_EMU],
+			(uae_u8)((new_m68k_ipl << 3) ^ P5_M68k_IPL_MASK), __ATOMIC_SEQ_CST);
 		if (new_m68k_ipl > ppcipl) {
 			set_ppc_interrupt();
 		} else {

--- a/src/cpuboard.cpp
+++ b/src/cpuboard.cpp
@@ -1536,15 +1536,22 @@ static void REGPARAM2 blizzardio_bput(uaecptr addr, uae_u32 v)
 						io_reg[CSIII_REG_RESET] |= oldval & P5_AMIGA_RESET;
 					}
 				} else if (addr == CSIII_REG_IPL_EMU) {
-					// M68K_IPL_MASK is read-only
+					// M68k-IPL bits (P5_M68k_IPL_MASK) are read-only here and are
+					// owned by the emulation thread (ppc_interrupt()). The PPC owns
+					// the rest. The CyberStorm IO bank is ABFLAG_THREADSAFE, so this
+					// handler can run on the PPC thread concurrently with
+					// ppc_interrupt() on the emulation thread. Update only the
+					// PPC-owned bits atomically so we never clobber a concurrent
+					// M68k-IPL update with a stale full-byte store (which would make
+					// the PPC read a stale Amiga interrupt level and stall).
 					regval &= ~P5_M68k_IPL_MASK;
-					regval |= oldval & P5_M68k_IPL_MASK;
 					bool active = (regval & P5_DISABLE_INT) == 0;
 #ifdef WITH_PPC
 					if (!active)
 						clear_ppc_interrupt();
 #endif
-					io_reg[addr] = regval;
+					__atomic_and_fetch(&io_reg[addr], (uae_u8)P5_M68k_IPL_MASK, __ATOMIC_SEQ_CST);
+					__atomic_or_fetch(&io_reg[addr], (uae_u8)regval, __ATOMIC_SEQ_CST);
 #if CPUBOARD_IRQ_LOG > 0
 					if ((regval & P5_DISABLE_INT) != (oldval & P5_DISABLE_INT))
 						write_log(_T("CS: interrupt state: %s\n"), (regval & P5_DISABLE_INT) ? _T("disabled") : _T("enabled"));


### PR DESCRIPTION
## Problem

On macOS arm64, an OS4.1 + CyberStorm PPC config boots but **freezes at the loading screen** (RTG renders it, but nothing progresses and the PPC never reaches the installer). Works on Windows. The PPC kernel is alive (its decrementer ticks), but it's blocked waiting on Amiga interrupts (timer/IO) that are **never delivered to the PPC**.

## Root cause — a data race on `io_reg[CSIII_REG_IPL_EMU]`

The CyberStorm PPC interrupt mask (`ppcipl`, low 3 bits of `io_reg[CSIII_REG_IPL_EMU]`) gets **stuck at 3** on macOS, so `ppc_interrupt()`'s forward test `new_m68k_ipl > ppcipl` is never satisfied → `set_ppc_interrupt()` is never called → VBlank (level 3) stays permanently pending/unserviced and timer/IO-driven boot tasks wait forever.

`io_reg[CSIII_REG_IPL_EMU]` is written by two threads with **disjoint bitfields**:
- the **PPC CPU thread** writes the PPC-IPL bits (`P5_PPC_IPL_MASK`, 0x07) — and the CyberStorm IO bank is `ABFLAG_THREADSAFE`, so these writes **skip the ppc spinlock**;
- the **emulation thread** (`ppc_interrupt()`, from the halt loop) does a non-atomic read-modify-write of the M68k-IPL bits (`P5_M68k_IPL_MASK`, 0x38) of the same byte.

The emulation thread's RMW writes back the PPC-IPL bits *as it read them*, so when the PPC lowers its IPL to 0 (to accept interrupts) the RMW races and **clobbers it back to 3**. Windows scheduling/locking hides the race; on macOS it loses the update every time.

## Fix

Make the emulation-thread update atomic (atomic-AND then atomic-OR over only the M68k-IPL bits), so it can never clobber the PPC-IPL bits regardless of interleaving. Same `__atomic_*` builtins already used elsewhere in the tree; no behavior change off the PPC path.

## Verification (instrumented CyberStorm interrupt trace, macOS vs Windows)

| | before (macOS) | Windows (baseline) | after fix (macOS) |
|---|---|---|---|
| `ppcipl` | stuck at 3 | cycles 3↔0 | **cycles 3↔0** |
| `set_ppc_interrupt` | 0 | thousands | **forwarding works** |
| VBlank | permanently pending | serviced each frame | **serviced** |

With the fix the config goes from frozen at the loading screen to **actively booting** (display mode reconfiguration, log advancing, ~2 cores busy) instead of a static screen.