### PR TITLE
PPC: re-present pending CyberStorm board IRQ to fix OS4 boot stall

### DIFF
--- a/src/newcpu.cpp
+++ b/src/newcpu.cpp
@@ -4357,6 +4357,26 @@ static void check_uae_int_request(void)
 #endif
 				atomic_and(&uae_int_requested, ~0x010000);
 #ifdef WITH_PPC
+			} else if (!irq2 && !(intreq & 0x0008)) {
+				/*
+				 * The CyberStorm board IRQ (e.g. an NCR SCSI completion) is
+				 * still pending, but the level-2 PORTS bit it raised has been
+				 * acknowledged without the PPC having serviced the controller.
+				 * The board IRQ is level-triggered (it stays asserted in
+				 * io_reg[CSIII_REG_IRQ] until the PPC acks the NCR), yet the
+				 * PORTS bit forwarding it is edge-driven - cpuboard_rethink()
+				 * only re-raises it on a device state change. The PPC runs on
+				 * its own QEMU vCPU thread, so the first PORTS delivery can be
+				 * missed/raced; after that the pending board IRQ has no path
+				 * back to the PPC and the OS4 boot hangs until a manual
+				 * pause/resume ("the kick"). Re-present it here so OS4 gets
+				 * another chance to service the controller. Gated on the PORTS
+				 * bit being clear, so it is self-limiting (one interrupt at a
+				 * time) and stops as soon as the NCR is serviced and the board
+				 * IRQ clears.
+				 */
+				int_request_do(false);
+				irq2 = true;
 			}
 #endif
 		}


### PR DESCRIPTION
The CyberStorm PPC board IRQ (e.g. an NCR SCSI completion) is level-triggered in io_reg[CSIII_REG_IRQ], but the level-2 PORTS bit that forwards it to the PPC is edge-driven: cpuboard_rethink() only raises it on a device state change. With the QEMU-11 qemu-uae plugin the PPC runs on its own vCPU thread, so the first PORTS delivery can be raced/missed. Once missed, the still-pending board IRQ has no path back to the PPC and the AmigaOS 4.1 boot hangs on a black screen until a manual GUI/IPC pause+resume ("the kick").

Re-present the IRQ from check_uae_int_request() while cpuboard_is_ppcboard_irq() is still asserted and the level-2 PORTS bit has been acknowledged, so the OS gets another chance to service the controller. The re-raise is gated on the PORTS bit being clear, so it is self-limiting (one interrupt at a time) and stops as soon as the controller is serviced and the board IRQ clears.

Headless A4000 + CyberStorm PPC now boots to the AmigaOS 4.1 installer with no kick (validated across repeated runs); previously it required a manual pause/resume every time.
