### PR TITLE
Fix stray ~/.ccache directory leaking into Debian packages

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -624,18 +624,16 @@ jobs:
 
       - name: make for Ubuntu ${{ matrix.name }} with setup-sdl
         if: matrix.sdl_source == 'setup-sdl'
-        env:
-          CCACHE_DIR: ~/.ccache
         run: |
+          export CCACHE_DIR="$HOME/.ccache"
           export PATH="/usr/lib/ccache:$PATH"
           cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_PREFIX_PATH="${{ steps.sdl.outputs.prefix }}" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DDISTRO_CODENAME=${{ matrix.codename }} -DQEMU_UAE_PLUGIN="$QEMU_UAE_PLUGIN" ${{ matrix.extra_cmake_args }} && cmake --build build -j$(nproc)
           cpack -G DEB --config build/CPackConfig.cmake
 
       - name: make for Ubuntu ${{ matrix.name }} with apt SDL3
         if: matrix.sdl_source == 'apt'
-        env:
-          CCACHE_DIR: ~/.ccache
         run: |
+          export CCACHE_DIR="$HOME/.ccache"
           export PATH="/usr/lib/ccache:$PATH"
           cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DDISTRO_CODENAME=${{ matrix.codename }} -DQEMU_UAE_PLUGIN="$QEMU_UAE_PLUGIN" && cmake --build build -j$(nproc)
           cpack -G DEB --config build/CPackConfig.cmake


### PR DESCRIPTION
Fixes #2081

## Problem
The released `.deb` packages contained a stray directory literally named `~`:

```
drwxr-xr-x root/root  0 ./~/
drwxr-xr-x root/root  0 ./~/.ccache/
...
```

## Root cause
The Ubuntu/Debian build steps in `.github/workflows/c-cpp.yml` set `CCACHE_DIR: ~/.ccache` as a GitHub Actions `env:` value. The Actions env context does **not** expand `~`, so ccache received the literal string `~/.ccache` and created a directory literally named `~` in the build tree. CPack then swept that directory into the `.deb`.

(The neighboring `actions/cache` step's `path: ~/.ccache` is unaffected — the cache action does expand `~` to the home directory.)

## Fix
Export `CCACHE_DIR="$HOME/.ccache"` inside the `run:` script for both Ubuntu build steps, where the shell expands `$HOME` to `/home/runner/.ccache`. This matches the `actions/cache` location (caching still works) and prevents the literal `~` directory from ever being created, so it can no longer leak into the package.