### PR TITLE
Fix saved Dark theme ignored on startup (#2082)

### DIFF
--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -1955,9 +1955,15 @@ void save_theme(const std::string& theme_filename)
 
 void load_theme(const std::string& theme_filename)
 {
-	// Pre-fill all fields with light-theme defaults so that old theme files
-	// missing the new color fields get sensible values instead of black.
-	load_default_theme();
+	// Pre-fill all fields with sensible defaults so that old theme files
+	// missing the new color fields get usable values instead of black.
+	// For the built-in "Dark.theme" preset, fall back to the dark defaults:
+	// it has no file on disk by default, so without this the saved dark
+	// theme would silently revert to the light preset on startup.
+	if (theme_filename == "Dark.theme")
+		load_default_dark_theme();
+	else
+		load_default_theme();
 
 	std::string filename = get_themes_path();
 	filename.append(theme_filename);


### PR DESCRIPTION
## Problem

Selecting the **Dark** theme, saving, and restarting reverts the GUI to the light theme (issue #2082).

## Root cause

`Dark.theme` is a built-in preset that has **no file on disk** by default. At startup, both `prefs_to_gui()` (`amiberry_gui.cpp`) and `main_window.cpp` call `load_theme("Dark.theme")` directly. `load_theme()` applied the *light* defaults first, then tried to open the (non-existent) `Dark.theme` file. The open failed, leaving the GUI on the light preset — so the saved `gui_theme=Dark.theme` was silently ignored.

The Themes panel's own `load_selected_theme()` handled this special case (falling back to `load_default_dark_theme()`), but the startup paths did not.

## Fix

In `load_theme()`, use `load_default_dark_theme()` as the baseline when the requested theme is the built-in `"Dark.theme"`, instead of always using the light defaults. This fixes both startup paths and the Misc-panel dark toggle in one place. A real `Dark.theme` file on disk still loads normally on top of the correct dark baseline.

The config persistence itself was already correct (`amiberry.conf` records `gui_theme=Dark.theme`); only the load-time fallback was wrong.

## Testing

- Translation unit compiles cleanly.

Fixes #2082