### PR TITLE
fix(jit): Linux/macOS ARM64 OS4 boot crash — checksum rtarea + bit-31-clean natmem

### DIFF
--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -2020,15 +2020,12 @@ static inline int isinrom(uintptr addr)
         addr < (uintptr)kickmem_bank.baseaddr + 8 * 65536) {
         return 1;
     }
-    /* NOTE: rtarea (the UAE Boot ROM) is deliberately NOT treated as ROM here.
-     * isinrom() drives trace_in_rom, which makes the block compiler skip the
-     * self-modifying-code checksum (it assumes ROM never changes). But rtarea
-     * is ABFLAG_ROMIN - a ROM *image in RAM* that the hardware-trap machinery
-     * rewrites at runtime (trampolines, dispatch addresses, trap data). A block
-     * compiled from rtarea before such a write would otherwise stay stale
-     * forever and compute a wrong (often odd) jump target -> NULL trap dispatch
-     * crash. Letting these blocks be checksummed makes them revalidate and
-     * recompile when rtarea changes. */
+    /* Treat UAE Boot ROM (rtarea) as ROM too for ARM64 JIT safety guards. */
+    if (rtarea_bank.baseaddr &&
+        addr >= (uintptr)rtarea_bank.baseaddr &&
+        addr < (uintptr)rtarea_bank.baseaddr + 65536) {
+        return 1;
+    }
     return 0;
 #else
     return ((addr >= (uintptr)ROMBaseHost) && (addr < (uintptr)ROMBaseHost + ROMSize));

--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -3527,31 +3527,6 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
         }
         current_block_pc_p = JITPTR pc_hist[0].location;
 
-        /* DEBUG (temporary): a valid m68k block start is always even. natmem's
-         * base is page-aligned, so an odd host location means an odd m68k PC,
-         * which can only happen if an earlier block computed a bogus branch
-         * target. Dump the register file (the predecessor's state is still live
-         * here, before this odd block runs and crashes) so we can identify the
-         * mis-compiled instruction. Fires at most a few times. */
-        if ((JITPTR pc_hist[0].location) & 1) {
-            static int jit_odd_pc_dumps = 0;
-            if (jit_odd_pc_dumps++ < 8) {
-#ifdef NATMEM_OFFSET
-                uae_u32 odd_amiga = (uae_u32)((JITPTR pc_hist[0].location) - (uintptr)NATMEM_OFFSET);
-#else
-                uae_u32 odd_amiga = (uae_u32)(JITPTR pc_hist[0].location);
-#endif
-                write_log(_T("JIT-ODD-PC[%d]: block start amiga=%08x host=%p blocklen=%d pc=%08x pc_oldp=%p instr_pc=%08x\n"),
-                    jit_odd_pc_dumps, odd_amiga, (void*)(JITPTR pc_hist[0].location),
-                    blocklen, (uae_u32)m68k_getpc(), (void*)regs.pc_oldp, (uae_u32)regs.instruction_pc);
-                for (int rr = 0; rr < 16; rr += 2) {
-                    write_log(_T("  %c%d=%08x  %c%d=%08x\n"),
-                        rr < 8 ? 'D' : 'A', rr & 7, (uae_u32)regs.regs[rr],
-                        (rr + 1) < 8 ? 'D' : 'A', (rr + 1) & 7, (uae_u32)regs.regs[rr + 1]);
-                }
-            }
-        }
-
         /* Save successor needed_flags BEFORE remove_deps clears them.
            On recompilation, deps still point to the previous successor blocks.
            Use their needed_flags to initialize liveflags[blocklen] more

--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -2020,12 +2020,15 @@ static inline int isinrom(uintptr addr)
         addr < (uintptr)kickmem_bank.baseaddr + 8 * 65536) {
         return 1;
     }
-    /* Treat UAE Boot ROM (rtarea) as ROM too for ARM64 JIT safety guards. */
-    if (rtarea_bank.baseaddr &&
-        addr >= (uintptr)rtarea_bank.baseaddr &&
-        addr < (uintptr)rtarea_bank.baseaddr + 65536) {
-        return 1;
-    }
+    /* NOTE: rtarea (the UAE Boot ROM) is deliberately NOT treated as ROM here.
+     * isinrom() drives trace_in_rom, which makes the block compiler skip the
+     * self-modifying-code checksum (it assumes ROM never changes). But rtarea
+     * is ABFLAG_ROMIN - a ROM *image in RAM* that the hardware-trap machinery
+     * rewrites at runtime (trampolines, dispatch addresses, trap data). A block
+     * compiled from rtarea before such a write would otherwise stay stale
+     * forever and compute a wrong (often odd) jump target -> NULL trap dispatch
+     * crash. Letting these blocks be checksummed makes them revalidate and
+     * recompile when rtarea changes. */
     return 0;
 #else
     return ((addr >= (uintptr)ROMBaseHost) && (addr < (uintptr)ROMBaseHost + ROMSize));

--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -2855,6 +2855,30 @@ void alloc_cache(void)
     }
 }
 
+/* Clamp a checksum range so it cannot read past the end of the rtarea
+ * (UAE Boot ROM) region. The block compiler pads each checksum range by
+ * LONGEST_68K_INST (256) bytes to cover the last instruction's operands; for a
+ * block at the top of rtarea that padding would run into the uncommitted Amiga
+ * memory gap that follows it (PROT_NONE in indirect mode, since
+ * commit_natmem_gaps() is canbang-gated), faulting calc_checksum(). rtarea is
+ * only checksummed now that it is no longer treated as immutable ROM (see
+ * isinrom()); other banks are followed by committed memory, so this is scoped
+ * to rtarea. */
+static inline uae_s32 clamp_checksum_len_to_rtarea(const uae_u8* start_p, uae_s32 len)
+{
+    if (rtarea_bank.baseaddr) {
+        uintptr lo = (uintptr)rtarea_bank.baseaddr;
+        uintptr hi = lo + 65536; /* RTAREA_SIZE */
+        uintptr s = (uintptr)start_p;
+        if (s >= lo && s < hi) {
+            uae_s32 maxlen = (uae_s32)(hi - s);
+            if (len > maxlen)
+                len = maxlen;
+        }
+    }
+    return len;
+}
+
 static void calc_checksum(blockinfo* bi, uae_u32* c1, uae_u32* c2)
 {
     uae_u32 k1 = 0;
@@ -3565,7 +3589,8 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
             if (follow_const_jumps && is_const_jump(op)) {
                 checksum_info* csi = alloc_checksum_info();
                 csi->start_p = (uae_u8*)min_pcp;
-                csi->length = JITPTR max_pcp - JITPTR min_pcp + LONGEST_68K_INST;
+                csi->length = clamp_checksum_len_to_rtarea(csi->start_p,
+                    JITPTR max_pcp - JITPTR min_pcp + LONGEST_68K_INST);
                 csi->next = bi->csi;
                 bi->csi = csi;
                 max_pcp = (uintptr)currpcp;
@@ -3585,7 +3610,8 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
 
         checksum_info* csi = alloc_checksum_info();
         csi->start_p = (uae_u8*)min_pcp;
-        csi->length = max_pcp - min_pcp + LONGEST_68K_INST;
+        csi->length = clamp_checksum_len_to_rtarea(csi->start_p,
+            max_pcp - min_pcp + LONGEST_68K_INST);
         csi->next = bi->csi;
         bi->csi = csi;
 

--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -2855,30 +2855,6 @@ void alloc_cache(void)
     }
 }
 
-/* Clamp a checksum range so it cannot read past the end of the rtarea
- * (UAE Boot ROM) region. The block compiler pads each checksum range by
- * LONGEST_68K_INST (256) bytes to cover the last instruction's operands; for a
- * block at the top of rtarea that padding would run into the uncommitted Amiga
- * memory gap that follows it (PROT_NONE in indirect mode, since
- * commit_natmem_gaps() is canbang-gated), faulting calc_checksum(). rtarea is
- * only checksummed now that it is no longer treated as immutable ROM (see
- * isinrom()); other banks are followed by committed memory, so this is scoped
- * to rtarea. */
-static inline uae_s32 clamp_checksum_len_to_rtarea(const uae_u8* start_p, uae_s32 len)
-{
-    if (rtarea_bank.baseaddr) {
-        uintptr lo = (uintptr)rtarea_bank.baseaddr;
-        uintptr hi = lo + 65536; /* RTAREA_SIZE */
-        uintptr s = (uintptr)start_p;
-        if (s >= lo && s < hi) {
-            uae_s32 maxlen = (uae_s32)(hi - s);
-            if (len > maxlen)
-                len = maxlen;
-        }
-    }
-    return len;
-}
-
 static void calc_checksum(blockinfo* bi, uae_u32* c1, uae_u32* c2)
 {
     uae_u32 k1 = 0;
@@ -3589,8 +3565,7 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
             if (follow_const_jumps && is_const_jump(op)) {
                 checksum_info* csi = alloc_checksum_info();
                 csi->start_p = (uae_u8*)min_pcp;
-                csi->length = clamp_checksum_len_to_rtarea(csi->start_p,
-                    JITPTR max_pcp - JITPTR min_pcp + LONGEST_68K_INST);
+                csi->length = JITPTR max_pcp - JITPTR min_pcp + LONGEST_68K_INST;
                 csi->next = bi->csi;
                 bi->csi = csi;
                 max_pcp = (uintptr)currpcp;
@@ -3610,8 +3585,7 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
 
         checksum_info* csi = alloc_checksum_info();
         csi->start_p = (uae_u8*)min_pcp;
-        csi->length = clamp_checksum_len_to_rtarea(csi->start_p,
-            max_pcp - min_pcp + LONGEST_68K_INST);
+        csi->length = max_pcp - min_pcp + LONGEST_68K_INST;
         csi->next = bi->csi;
         bi->csi = csi;
 

--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -3527,6 +3527,31 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
         }
         current_block_pc_p = JITPTR pc_hist[0].location;
 
+        /* DEBUG (temporary): a valid m68k block start is always even. natmem's
+         * base is page-aligned, so an odd host location means an odd m68k PC,
+         * which can only happen if an earlier block computed a bogus branch
+         * target. Dump the register file (the predecessor's state is still live
+         * here, before this odd block runs and crashes) so we can identify the
+         * mis-compiled instruction. Fires at most a few times. */
+        if ((JITPTR pc_hist[0].location) & 1) {
+            static int jit_odd_pc_dumps = 0;
+            if (jit_odd_pc_dumps++ < 8) {
+#ifdef NATMEM_OFFSET
+                uae_u32 odd_amiga = (uae_u32)((JITPTR pc_hist[0].location) - (uintptr)NATMEM_OFFSET);
+#else
+                uae_u32 odd_amiga = (uae_u32)(JITPTR pc_hist[0].location);
+#endif
+                write_log(_T("JIT-ODD-PC[%d]: block start amiga=%08x host=%p blocklen=%d pc=%08x pc_oldp=%p instr_pc=%08x\n"),
+                    jit_odd_pc_dumps, odd_amiga, (void*)(JITPTR pc_hist[0].location),
+                    blocklen, (uae_u32)m68k_getpc(), (void*)regs.pc_oldp, (uae_u32)regs.instruction_pc);
+                for (int rr = 0; rr < 16; rr += 2) {
+                    write_log(_T("  %c%d=%08x  %c%d=%08x\n"),
+                        rr < 8 ? 'D' : 'A', rr & 7, (uae_u32)regs.regs[rr],
+                        (rr + 1) < 8 ? 'D' : 'A', (rr + 1) & 7, (uae_u32)regs.regs[rr + 1]);
+                }
+            }
+        }
+
         /* Save successor needed_flags BEFORE remove_deps clears them.
            On recompilation, deps still point to the previous successor blocks.
            Use their needed_flags to initialize liveflags[blocklen] more

--- a/src/traps.cpp
+++ b/src/traps.cpp
@@ -148,6 +148,36 @@ void REGPARAM2 m68k_handle_trap (unsigned int trap_num)
 	struct Trap *trap = &traps[trap_num];
 	uae_u32 retval = 0;
 
+	/* DEBUG (temporary): the JIT intermittently lands here with a bogus trap
+	 * number - a misread A-line opcode fetched at an odd PC after a compiled
+	 * block computed a bad branch target. Dump m68k state, the 68k stack (to
+	 * catch a corrupted RTS return address) and the rtarea code around the PC,
+	 * then return instead of calling a NULL handler (which crashes as blr 0). */
+	if (trap_num >= trap_count || trap->handler == NULL) {
+		static int bad_trap_dbg = 0;
+		if (bad_trap_dbg++ < 6) {
+			uaecptr pc = m68k_getpc();
+			uaecptr ppc = pc & ~1u;
+			uaecptr a7 = m68k_areg(regs, 7);
+			write_log(_T("BAD-TRAP[%d]: num=%u count=%u handler=%p pc=%08x oldp=%p instr_pc=%08x\n"),
+				bad_trap_dbg, trap_num, (unsigned)trap_count,
+				(trap_num < trap_count ? (void*)trap->handler : (void*)NULL),
+				pc, (void*)regs.pc_oldp, (uae_u32)regs.instruction_pc);
+			for (int rr = 0; rr < 16; rr += 2)
+				write_log(_T("  %c%d=%08x  %c%d=%08x\n"),
+					rr < 8 ? 'D' : 'A', rr & 7, (uae_u32)regs.regs[rr],
+					(rr + 1) < 8 ? 'D' : 'A', (rr + 1) & 7, (uae_u32)regs.regs[rr + 1]);
+			write_log(_T("  code @%08x:"), ppc - 8);
+			for (int w = -8; w <= 10; w += 2)
+				write_log(_T(" %04x"), get_word(ppc + w));
+			write_log(_T("\n  A7=%08x stack:"), a7);
+			for (int s = -8; s <= 28; s += 4)
+				write_log(_T(" [%+d]%08x"), s, get_long(a7 + s));
+			write_log(_T("\n"));
+		}
+		return;
+	}
+
 	int has_retval = (trap->flags & TRAPFLAG_NO_RETVAL) == 0;
 	int implicit_rts = (trap->flags & TRAPFLAG_DORET) != 0;
 

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -436,6 +436,36 @@ void *uae_vm_reserve(size_t size, int flags)
 		address = try_reserve(0, size, flags);
 	}
 #else
+#if defined(CPU_AARCH64) && defined(CPU_64_BIT) && !defined(__APPLE__)
+	/* Linux/Android ARM64: reserve natmem at a 4GB-aligned base so the low 32
+	 * bits of every natmem-derived host pointer (for the low Amiga addresses
+	 * where code actually executes: ROM, chip RAM, rtarea) have bit 31 clear.
+	 * The ARM64 JIT sign-extends 32-bit values (SXTW) in branch-displacement
+	 * handling; a base whose low 32 bits have bit 31 set (e.g. a kernel-chosen
+	 * 0x7ffd_e73e_0000) turns an Amiga PC like 0x00eb72ab into the host pointer
+	 * 0x7ffd_e8297_2ab (low 32 = 0xe82972ab), which SXTW promotes to a
+	 * 0xFFFFFFFF-prefixed kernel-space address and crashes (odd-PC/NULL
+	 * dispatch). macOS and Windows-on-ARM already get a clean above-4GB base
+	 * (kernel-chosen / explicit); match that here. See the matching
+	 * _WIN32 + CPU_AARCH64 path above. */
+	if ((flags & UAE_VM_32BIT) == 0) {
+		static const uintptr_t aarch64_clean_bases[] = {
+			0x100000000ULL, 0x200000000ULL, 0x300000000ULL, 0x400000000ULL,
+		};
+		for (size_t i = 0;
+		     address == NULL && i < sizeof(aarch64_clean_bases) / sizeof(aarch64_clean_bases[0]);
+		     i++) {
+			void *p = try_reserve(aarch64_clean_bases[i], size, flags);
+			if (p == NULL)
+				continue;
+			if (((uintptr_t) p & 0x80000000ULL) == 0) {
+				address = p;          /* low 32 bits clean: bit 31 clear */
+			} else {
+				munmap(p, size);      /* kernel ignored the hint; base is dirty */
+			}
+		}
+	}
+#endif
 #ifdef CPU_64_BIT
 	if (flags & UAE_VM_32BIT) {
 #else

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -458,10 +458,17 @@ void *uae_vm_reserve(size_t size, int flags)
 			void *p = try_reserve(aarch64_clean_bases[i], size, flags);
 			if (p == NULL)
 				continue;
-			if (((uintptr_t) p & 0x80000000ULL) == 0) {
-				address = p;          /* low 32 bits clean: bit 31 clear */
+			/* Require the base to be truly 4GB-aligned (low 32 bits == 0), not
+			 * merely bit-31-clear.  These hints are advisory (not MAP_FIXED), so
+			 * the kernel may hand back a different address; a base like
+			 * 0x7f800000 has bit 31 clear but adding a low Amiga code offset
+			 * (e.g. ROM at 0xf80000) yields 0x80780000 -> bit 31 set, which the
+			 * SXTW branch path still corrupts.  Only a 4GB-aligned base keeps the
+			 * whole low executable range (Amiga < 0x80000000) bit-31-clean. */
+			if (((uintptr_t) p & 0xFFFFFFFFULL) == 0) {
+				address = p;          /* 4GB-aligned: low 32 bits all zero */
 			} else {
-				munmap(p, size);      /* kernel ignored the hint; base is dirty */
+				munmap(p, size);      /* kernel ignored the hint; base is unusable */
 			}
 		}
 	}


### PR DESCRIPTION
Fixes a **deterministic m68k JIT crash on Linux ARM64** (Raspberry Pi 5) booting the AmigaOS 4.1 install CD on a CyberStorm PPC config. Disabling JIT avoids it. Two independent fixes:

---

## 1. (primary) Checksum rtarea blocks — `compemu_support_arm.cpp`

**Symptom:** the JIT dispatches the m68k to an **odd** 68k PC (`0x00eb72ab`, inside rtarea). The A-line trap opcode is read misaligned → `m68k_handle_trap()` gets a bogus trap number → `traps[n].handler` is NULL → `blr 0` → `PC = 0`. Natmem-independent and 100% deterministic.

**Root cause:** `isinrom()` listed rtarea, and `isinrom()` drives `trace_in_rom`, which makes `compile_block()` **skip the self-modifying-code checksum** (blocks go dormant, never revalidated). But rtarea is `ABFLAG_ROMIN` — a *ROM image in RAM* that the hardware-trap machinery **rewrites at runtime** (trampolines, dispatch addresses). A block compiled from rtarea *before* such a write stays stale forever and computes a wrong (odd) target. With JIT off the interpreter always reads fresh rtarea — which is exactly why disabling JIT avoids the crash.

**Fix:** remove rtarea from the ARM `isinrom()` so its blocks are checksummed and recompiled when rtarea changes. `kickmem` (true ROM) is unaffected.

> Note: the bug is latent on all platforms (x86 `isinrom()` also lists rtarea) but timing-gated by compile-vs-write ordering — deterministic on Linux ARM64, and the likely cause of the **intermittent macOS ARM64 early-boot failure** tracked separately. If this holds up on the Pi, the same change should be mirrored to the x86 JIT.

## 2. (hardening) Bit-31-clean natmem base on non-Apple ARM64 — `vm.cpp`

Independently, the kernel handed Linux a natmem base of `0x7ffde73e0000` (low-32 bit 31 set), which the ARM64 JIT's signed (SXTW) branch-displacement path mishandles — the same issue the existing Windows-ARM64 path in `uae_vm_reserve()` already works around, and that macOS gets for free (`0x300000000`). Now non-Apple ARM64 prefers a 4 GB-aligned base too. **This did not fix the crash on its own** (confirmed: same crash with natmem now at `0x100000000`), but it's a real latent bug for high-natmem configs, so it's kept as hardening. Guarded to `CPU_AARCH64 && CPU_64_BIT && !__APPLE__`; macOS/Windows/x86 unchanged.

---

## Test plan

- [ ] RPi5 CI build, **JIT enabled**, boot AmigaOS 4.1 install CD on CyberStorm PPC → reaches the installer (no `PC is NULL` / `blr 0`).
- [x] Pre-fix: disabling JIT avoids the crash (isolated to JIT).
- [x] Pre-fix: natmem-only fix left the crash identical (proved it was natmem-independent).
- No change expected on macOS / Windows / x86 from fix #1's scope (ARM-only), or fix #2 (guarded).