### PR TITLE
fix(jit/arm64): avoid translating indirect rtarea blocks

### DIFF
--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -185,6 +185,18 @@ static inline int distrust_addr(void)
     return distrust_check(currprefs.comptrustnaddr);
 }
 
+#if defined(CPU_AARCH64)
+static inline bool jit_use_memory_helpers(void)
+{
+    return jit_n_addr_bank_unsafe || (jit_n_addr_unsafe && !canbang);
+}
+
+static inline bool jit_use_compile_fallbacks(void)
+{
+    return jit_n_addr_bank_unsafe;
+}
+#endif
+
 //#if DEBUG
 //#define PROFILE_COMPILE_TIME        1
 //#endif
@@ -2032,6 +2044,19 @@ static inline int isinrom(uintptr addr)
 #endif
 }
 
+#if defined(CPU_AARCH64)
+static inline int isinrtarea(uintptr addr)
+{
+#ifdef UAE
+    return rtarea_bank.baseaddr &&
+        addr >= (uintptr)rtarea_bank.baseaddr &&
+        addr < (uintptr)rtarea_bank.baseaddr + 65536;
+#else
+    return 0;
+#endif
+}
+#endif
+
 #if defined(UAE) || defined(FLIGHT_RECORDER)
 static void flush_all(void)
 {
@@ -3483,6 +3508,13 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
         blockinfo* bi = NULL;
         blockinfo* bi2;
 		int extra_len=0;
+#if defined(CPU_AARCH64)
+        const bool indirect_rtarea_block =
+            currprefs.uaeboard > 2 && isinrtarea((uintptr)pc_hist[0].location) != 0;
+        bool unsafe_special_mem_block = indirect_rtarea_block;
+        const bool unsafe_memory_helpers = jit_use_memory_helpers();
+        const bool unsafe_compile_fallbacks = jit_use_compile_fallbacks();
+#endif
 
         redo_current_block = 0;
         if (current_compile_p >= MAX_COMPILE_PTR)
@@ -3558,6 +3590,10 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
             uae_u16* currpcp = pc_hist[i].location;
             uae_u32 op = DO_GET_OPCODE(currpcp);
 
+#if defined(CPU_AARCH64)
+            if ((unsafe_compile_fallbacks || unsafe_memory_helpers) && pc_hist[i].specmem)
+                unsafe_special_mem_block = true;
+#endif
             trace_in_rom = trace_in_rom && isinrom((uintptr)currpcp);
             if (follow_const_jumps && is_const_jump(op)) {
                 checksum_info* csi = alloc_checksum_info();
@@ -3601,7 +3637,11 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
             compemu_raw_dec_m((uintptr) & (bi->count));
             compemu_raw_maybe_recompile();
         }
-        if (optlev == 0) { /* No need to actually translate */
+        if (optlev == 0
+#if defined(CPU_AARCH64)
+            || unsafe_special_mem_block
+#endif
+            ) { /* No need to actually translate */
           /* Execute normally without keeping stats */
             compemu_raw_exec_nostats((uintptr)pc_hist[0].location);
         } else {


### PR DESCRIPTION
## Summary
- Avoid translating UAE Boot ROM rtarea blocks when UAE Boot ROM Indirect is active on ARM64 JIT.
- Fall back to the existing exec_nostats path for special-memory blocks when ARM64 helper/fallback access is required.
- Keep the PR scoped to one ARM64 JIT source file; no VM experiment, checksum churn, or trap debug instrumentation is included.

## Validation
- cmake --build build --parallel
- A4000-PPC.uae with the AmigaOS 4.1 installation CD reached RTG modes: GFXBOARD 640x480x4 and 760x602x4.
- No Illegal instruction, BAD-TRAP, SIGBUS, or SIGSEGV signatures appeared in the validation log.