### PR TITLE
fix(libretro): smooth per-frame audio delivery to fix crackle

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -2222,6 +2222,87 @@ static float get_core_refresh_rate()
 
 static double libretro_audio_deficit_frames = 0.0;
 
+// Smoothing FIFO between the Amiga audio engine and the libretro frontend.
+// The engine flushes audio in fixed 768-frame chunks that do not align with
+// the video-frame boundary, producing a 768/1536 sawtooth in the per-frame
+// sample count. The standalone build absorbs this in the SDL host audio queue;
+// libretro has no such queue, so we buffer here and emit a steady ~samples-per
+// -frame each video frame. This mirrors what SDL does for the standalone path.
+static std::vector<int16_t> libretro_audio_fifo;   // interleaved stereo S16
+static double libretro_audio_emit_frac = 0.0;
+
+void libretro_audio_enqueue(const int16_t* stereo_frames, unsigned frames)
+{
+	if (!frames || !stereo_frames)
+		return;
+	libretro_audio_fifo.insert(libretro_audio_fifo.end(),
+		stereo_frames, stereo_frames + static_cast<size_t>(frames) * 2);
+}
+
+void libretro_audio_reset(void)
+{
+	libretro_audio_fifo.clear();
+	libretro_audio_emit_frac = 0.0;
+	libretro_audio_deficit_frames = 0.0;
+}
+
+// Emit one video frame worth of audio from the FIFO, steering the queue toward
+// a small target depth so the output stays close to a constant samples-per-frame
+// instead of the raw sawtooth. Called once per retro_run after the core fiber
+// has produced the frame's audio.
+static void libretro_drain_audio_frame()
+{
+	if (!audio_batch_cb && !audio_cb) {
+		libretro_audio_fifo.clear();
+		return;
+	}
+
+	const float refresh_rate = get_core_refresh_rate();
+	const int audio_rate = audio_rate_for_av_info();
+	if (refresh_rate <= 1.0f || audio_rate <= 0)
+		return;
+
+	const double per_frame = static_cast<double>(audio_rate) / refresh_rate;
+	const size_t avail = libretro_audio_fifo.size() / 2;
+
+	// Keep ~1.5 video frames buffered as a shock absorber and steer gently
+	// toward it. The correction is small (tens of samples), so per-frame output
+	// stays smooth while average throughput still tracks the core's true rate.
+	const double target_depth = per_frame * 1.5;
+	libretro_audio_emit_frac += per_frame + (static_cast<double>(avail) - target_depth) * 0.05;
+
+	long want = static_cast<long>(libretro_audio_emit_frac);
+	if (want < 0)
+		want = 0;
+	libretro_audio_emit_frac -= want;
+	if (static_cast<size_t>(want) > avail) {
+		want = static_cast<long>(avail);
+		libretro_audio_emit_frac = 0.0;
+	}
+	if (want <= 0)
+		return;
+
+	if (audio_batch_cb) {
+		size_t done = 0;
+		while (done < static_cast<size_t>(want)) {
+			const size_t chunk = std::min(static_cast<size_t>(want) - done, static_cast<size_t>(2048));
+			const size_t accepted = audio_batch_cb(libretro_audio_fifo.data() + done * 2, chunk);
+			libretro_audio_frames_this_run += static_cast<unsigned>(accepted);
+			done += accepted;
+			if (accepted < chunk)
+				break;   // frontend back-pressure; keep the rest for next frame
+		}
+		libretro_audio_fifo.erase(libretro_audio_fifo.begin(),
+			libretro_audio_fifo.begin() + done * 2);
+	} else {
+		for (long i = 0; i < want; i++)
+			audio_cb(libretro_audio_fifo[i * 2], libretro_audio_fifo[i * 2 + 1]);
+		libretro_audio_frames_this_run += static_cast<unsigned>(want);
+		libretro_audio_fifo.erase(libretro_audio_fifo.begin(),
+			libretro_audio_fifo.begin() + static_cast<size_t>(want) * 2);
+	}
+}
+
 static void libretro_emit_audio_starvation_guard()
 {
 	if (!audio_batch_cb && !audio_cb)
@@ -3071,7 +3152,7 @@ static void reset_core_runtime_state()
 	last_refresh_rate = -1.0f;
 	last_geometry_width = -1;
 	last_geometry_height = -1;
-	libretro_audio_deficit_frames = 0.0;
+	libretro_audio_reset();
 }
 
 static void apply_minimum_audio_latency()
@@ -3389,6 +3470,7 @@ void retro_reset(void)
 	if (!core_is_running())
 		return;
 
+	libretro_audio_reset();
 	uae_reset(0, 0);
 }
 
@@ -3412,8 +3494,10 @@ void retro_run(void)
 		poll_frontend_input();
 		libretro_audio_frames_this_run = 0;
 		co_switch(core_fiber);
-		if (!core_shutdown_complete)
+		if (!core_shutdown_complete) {
+			libretro_drain_audio_frame();
 			libretro_emit_audio_starvation_guard();
+		}
 		if (core_shutdown_complete)
 			return;
 		core_started = true;
@@ -3460,8 +3544,10 @@ void retro_run(void)
 	poll_input();
 	libretro_audio_frames_this_run = 0;
 	co_switch(core_fiber);
-	if (!core_shutdown_complete)
+	if (!core_shutdown_complete) {
+		libretro_drain_audio_frame();
 		libretro_emit_audio_starvation_guard();
+	}
 	if (core_shutdown_complete)
 		return;
 	apply_cheats();

--- a/libretro/libretro_shared.h
+++ b/libretro/libretro_shared.h
@@ -20,6 +20,8 @@ extern unsigned libretro_audio_frames_this_run;
 
 void libretro_yield(void);
 void reset_parse_cmdline(void);
+void libretro_audio_enqueue(const int16_t* stereo_frames, unsigned frames);
+void libretro_audio_reset(void);
 
 #endif
 

--- a/src/sounddep/sound_platform_internal_libretro.h
+++ b/src/sounddep/sound_platform_internal_libretro.h
@@ -22,17 +22,23 @@ static inline bool sound_platform_open_audio(struct sound_data* sd, int index)
 
 static inline bool sound_platform_output_audio(struct sound_data* sd, uae_u16* sndbuffer)
 {
+	// The Amiga audio engine flushes in fixed-size chunks (paula_sndbufsize)
+	// that don't divide evenly into the per-video-frame sample count, so the
+	// raw per-frame output is a 768/1536 sawtooth. The standalone build hides
+	// this behind the SDL host audio queue; the libretro frontend does not get
+	// that buffer, so we enqueue here and re-pace the stream once per video
+	// frame in retro_run (see libretro_drain_audio_frame). Always feed stereo.
 	const auto frames = sd->sndbufsize / (sd->channels * 2);
-	if (audio_batch_cb) {
-		libretro_audio_frames_this_run += static_cast<unsigned>(audio_batch_cb((const int16_t*)sndbuffer, frames));
-	} else if (audio_cb) {
-		const auto* samples = reinterpret_cast<const int16_t*>(sndbuffer);
+	const auto* samples = reinterpret_cast<const int16_t*>(sndbuffer);
+	if (sd->channels == 2) {
+		libretro_audio_enqueue(samples, static_cast<unsigned>(frames));
+	} else {
 		for (int i = 0; i < frames; i++) {
 			const int16_t left = samples[i * sd->channels];
 			const int16_t right = (sd->channels > 1) ? samples[i * sd->channels + 1] : left;
-			audio_cb(left, right);
+			const int16_t pair[2] = { left, right };
+			libretro_audio_enqueue(pair, 1);
 		}
-		libretro_audio_frames_this_run += frames;
 	}
 	return true;
 }

--- a/tools/check_libretro_contract.py
+++ b/tools/check_libretro_contract.py
@@ -93,6 +93,8 @@ def main():
 	retro_load_game = extract_body(text, "bool retro_load_game(const struct retro_game_info *info)")
 	reset_core_runtime_state = extract_body(text, "static void reset_core_runtime_state()")
 	libretro_emit_audio_starvation_guard = extract_body(text, "static void libretro_emit_audio_starvation_guard()")
+	libretro_drain_audio_frame = extract_body(text, "static void libretro_drain_audio_frame()")
+	libretro_audio_reset = extract_body(text, "void libretro_audio_reset(void)")
 	libretro_scan_roms = extract_body(stub_text, "int scan_roms(int show)")
 	sdl_create_semaphore = extract_body(sdl_stub_text, "SDL_Semaphore* SDL_CreateSemaphore(Uint32 initial_value)")
 	sdl_wait_semaphore = extract_body(sdl_stub_text, "void SDL_WaitSemaphore(SDL_Semaphore* s)")
@@ -144,14 +146,26 @@ def main():
 		and "if (libretro_audio_frames_this_run > 0 || libretro_audio_deficit_frames <= max_deferred_frames)" in libretro_emit_audio_starvation_guard
 		and "audio_batch_cb(silence, chunk)" in libretro_emit_audio_starvation_guard
 		and "audio_cb(0, 0)" in libretro_emit_audio_starvation_guard
-		and "libretro_audio_deficit_frames = 0.0;" in reset_core_runtime_state,
+		and "libretro_audio_deficit_frames = 0.0;" in libretro_audio_reset
+		and "libretro_audio_reset();" in reset_core_runtime_state,
 		"retro_run() must guard true libretro audio starvation without padding normal bursty audio frames",
 		failures,
 	)
+	# The Amiga engine flushes audio in fixed chunks that do not align with the
+	# video-frame boundary (a 768/1536 per-frame sawtooth). The libretro path has
+	# no SDL host queue to absorb it, so it must buffer in a FIFO and re-pace the
+	# stream once per video frame, accounting only the frames the frontend accepts.
 	require(
-		"libretro_audio_frames_this_run += static_cast<unsigned>(audio_batch_cb((const int16_t*)sndbuffer, frames));" in sound_platform_output_audio
-		and "libretro_audio_frames_this_run += frames;" in sound_platform_output_audio,
-		"libretro audio accounting must track frames accepted by the frontend callbacks",
+		"libretro_audio_enqueue(samples" in sound_platform_output_audio
+		and "libretro_audio_frames_this_run" not in sound_platform_output_audio,
+		"libretro audio output must enqueue into the smoothing FIFO, not push to the frontend directly",
+		failures,
+	)
+	require(
+		retro_run.count("libretro_drain_audio_frame();") >= 2
+		and "libretro_audio_fifo" in libretro_drain_audio_frame
+		and "libretro_audio_frames_this_run += static_cast<unsigned>(accepted);" in libretro_drain_audio_frame,
+		"libretro audio must be paced per video frame and account frames accepted by the frontend callbacks",
 		failures,
 	)
 	frontend_poll_pos = startup.find("poll_frontend_input();")


### PR DESCRIPTION
## Problem

Closes the remaining audio issue from #2046. Sustained music that plays fine in standalone Amiberry crackles in the libretro core — most audibly on the **Shadow of the Beast** scrolling title screen.

## Root cause (pre-existing/structural, surfaced by libretro)

The Amiga audio engine (`audio.cpp`) flushes sound in fixed `paula_sndbufsize` chunks (768 stereo frames). At 50 Hz / 44100 Hz the Amiga produces ~883 frames per video frame, which does **not** divide evenly into 768 — so the per-frame sample count delivered to the frontend is a **768/1536 sawtooth** (768 for ~6 frames, then a 1536 burst).

This sawtooth exists in *both* builds. The difference is what absorbs it:

- **Standalone** pushes into the **SDL host audio queue** (multi-buffer target) drained at the exact hardware rate, plus a feedback loop (`docorrection` → `sound_setadjust`). The queue is a shock absorber — the sawtooth is never heard.
- **Libretro** handed each raw chunk **directly** to `audio_batch_cb` with no host queue and no feedback loop (`sound_platform_output_audio` returned before any smoothing ran). RetroArch — tuned for cores that deliver a consistent per-frame count — had to absorb the ±17 ms swing in a smaller buffer and crackled.

So this is not a new libretro bug; libretro removed the smoothing layer standalone gets for free from SDL.

## Fix (libretro-only)

Restore the equivalent of the SDL host queue **in the libretro path only**:

- `sound_platform_output_audio` enqueues into a smoothing FIFO (downmixing to stereo) instead of pushing directly to the frontend.
- `libretro_drain_audio_frame()` emits ~one video frame's worth of audio each `retro_run`, steering the FIFO toward a ~1.5-frame depth with a gentle proportional correction. Average throughput still tracks the core's true rate, but per-frame output is near-constant.
- `libretro_audio_reset()` clears the FIFO on reset / load / `retro_reset`.
- The starvation guard is kept as a backstop for genuine underruns.

Standalone is unaffected — its sound platform header (`sound_platform_internal_host.h`) is unchanged.

## Verification

Measured per-frame sample count delivered to the frontend (RetroArch + SOTB WHDLoad, 40 s):

| | min | max | avg | starved frames |
|---|---|---|---|---|
| **Before** | 768 | 1536 | 883 | 0 |
| **After** | 869 | 905 | 886 | 0 |

The ±17 ms sawtooth swing collapses to ±0.4 ms, average throughput is unchanged, the FIFO stays bounded (0.25–1 frame), and there is no starvation. RetroArch's dynamic rate control then handles the clean stream as designed.

`tools/check_libretro_contract.py` is updated to pin the new FIFO/enqueue/drain invariants (replacing the old direct-push invariants).