### PR TITLE
Improve performance on slow ARM hosts (RPi4): diagnostics, slow-host downshift, and aarch64 tuning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,18 @@ elseif(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(USE_UAENET_TAP OFF CACHE BOOL "TAP backend only available on Linux" FORCE)
 endif()
 
+# Tune Linux aarch64 builds for the slowest supported board (Raspberry Pi 4 /
+# Cortex-A72). -mtune only affects instruction scheduling - the ISA baseline
+# stays generic armv8-a, so the same binary runs unchanged (and essentially
+# unaffected) on faster out-of-order cores such as the A76 or Neoverse.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND ARCH_LOWER MATCHES "aarch64|arm64" AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set(AMIBERRY_ARM_TUNE "cortex-a72" CACHE STRING "CPU passed to -mtune for Linux aarch64 builds (set empty to disable)")
+    if(AMIBERRY_ARM_TUNE)
+        add_compile_options(-mtune=${AMIBERRY_ARM_TUNE})
+        message(STATUS "Linux aarch64: adding -mtune=${AMIBERRY_ARM_TUNE}")
+    endif()
+endif()
+
 if(QEMU_UAE_PLUGIN)
     if(NOT USE_PPC OR NOT USE_QEMU_PPC)
         message(FATAL_ERROR "QEMU_UAE_PLUGIN requires USE_PPC=ON and USE_QEMU_PPC=ON")

--- a/cmake/SourceFiles.cmake
+++ b/cmake/SourceFiles.cmake
@@ -217,6 +217,7 @@ set(SOURCE_FILES
         src/osdep/amiberry_hardfile.cpp
         src/osdep/keyboard.cpp
         src/osdep/midi.cpp
+        src/osdep/perf_monitor.cpp
         src/osdep/mp3decoder.cpp
         src/osdep/picasso96.cpp
         src/osdep/writelog.cpp

--- a/cmake/SourceFiles.cmake
+++ b/cmake/SourceFiles.cmake
@@ -216,6 +216,7 @@ set(SOURCE_FILES
         src/osdep/clipboard.cpp
         src/osdep/amiberry_hardfile.cpp
         src/osdep/keyboard.cpp
+        src/osdep/host_detect.cpp
         src/osdep/midi.cpp
         src/osdep/perf_monitor.cpp
         src/osdep/mp3decoder.cpp

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -329,6 +329,8 @@ SOURCES_OSDEP := $(LIBRETRO_DIR)/libretro.cpp \
                 $(LIBRETRO_DIR)/sdl_stub.cpp \
                 $(LIBRETRO_DIR)/libretro_gui_stubs.cpp \
                 $(AMIBERRY_DIR)/src/osdep/amiberry.cpp \
+                $(AMIBERRY_DIR)/src/osdep/perf_monitor.cpp \
+                $(AMIBERRY_DIR)/src/osdep/host_detect.cpp \
                 $(AMIBERRY_DIR)/src/osdep/amiberry_gfx.cpp \
                 $(AMIBERRY_DIR)/src/osdep/gfx_window.cpp \
                 $(AMIBERRY_DIR)/src/osdep/gfx_colors.cpp \

--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -10565,12 +10565,20 @@ static bool checkprevfieldlinestateequal(void)
 			if (always > 0) {
 				draw_blank_fast(l, linear_display_vpos + 1);
 			}
+#ifdef AMIBERRY
+			else {
+				perf_lines.skipped++;
+			}
+#endif
 			ret = true;
 		} else if (type == LINETYPE_BORDER) {
 			if (1) {
 				bool brdblank = (bplcon0 & 1) && (bplcon3 & 0x20);
 				uae_u32 c = aga_mode ? agnus_colors.color_regs_aga[0] : agnus_colors.color_regs_ecs[0];
 				if (!always && c == l->color0 && brdblank == l->brdblank) {
+#ifdef AMIBERRY
+					perf_lines.skipped++;
+#endif
 					ret = true;
 				} else if (always || currprefs.cs_optimizations == DISPLAY_OPTIMIZATIONS_FULL) {
 					storelinestate();

--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -57,6 +57,9 @@
 #ifdef WITH_SPECIALMONITORS
 #include "specialmonitors.h"
 #endif
+#ifdef AMIBERRY
+#include "perf_monitor.h"
+#endif
 
 #define VPOSW_DISABLED 0
 #define VPOSW_DEBUG 0
@@ -4792,6 +4795,9 @@ void fpscounter_reset(void)
 	bogusframe = 2;
 	lastframetime = read_processor_time();
 	idletime = 0;
+#ifdef AMIBERRY
+	perf_monitor_reset();
+#endif
 }
 
 static void fpscounter(bool frameok)
@@ -4808,6 +4814,9 @@ static void fpscounter(bool frameok)
 
 	mavg(&fps_mavg, last / 10, FPSCOUNTER_MAVG_SIZE);
 	mavg(&idle_mavg, idletime / 10, FPSCOUNTER_MAVG_SIZE);
+#ifdef AMIBERRY
+	perf_monitor_frame(last, idletime, vsynctimebase, frameok);
+#endif
 	idletime = 0;
 
 	frametime += last;

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -42,6 +42,9 @@
 #endif
 #include "devices.h"
 #include "gfxboard.h"
+#ifdef AMIBERRY
+#include "perf_monitor.h"
+#endif
 
 #if defined(CPU_AARCH64)
 #include <arm_neon.h>
@@ -8256,6 +8259,9 @@ static bool multithread_denise_active(void)
 
 void draw_denise_border_line_fast_queue(int gfx_ypos, bool blank, enum nln_how how, struct linestate *ls)
 {
+#ifdef AMIBERRY
+	perf_lines.fast++;
+#endif
 	if (multithread_denise_active()) {
 		
 		if (!waitqueue(2)) {
@@ -8285,6 +8291,9 @@ void draw_denise_border_line_fast_queue(int gfx_ypos, bool blank, enum nln_how h
 
 void draw_denise_bitplane_line_fast_queue(int gfx_ypos, enum nln_how how, struct linestate *ls)
 {
+#ifdef AMIBERRY
+	perf_lines.fast++;
+#endif
 	if (multithread_denise_active()) {
 		
 		if (!waitqueue(1)) {
@@ -8371,6 +8380,9 @@ void denise_handle_quick_strobe_queue(uae_u16 strobe, int strobe_pos, int endpos
 void draw_denise_line_queue(int gfx_ypos, nln_how how, uae_u32 linecnt, int startpos, int endpos, int startcycle, int endcycle, int skip_start, int skip_end, int dtotal,
 	int calib_start, int calib_len, bool lof, bool lol, int hdelay, bool blanked, bool borderline, bool finalseg, struct linestate *ls)
 {
+#ifdef AMIBERRY
+	perf_lines.full++;
+#endif
 	if (multithread_denise_active()) {
 
 		if (!waitqueue(0)) {

--- a/src/include/options.h
+++ b/src/include/options.h
@@ -1377,6 +1377,10 @@ struct amiberry_options
 	int default_scaling_method = -1;
 	int default_gfx_autoresolution = 0;
 	bool default_frameskip = false;
+	bool perf_log = false;
+	bool slow_host_warning = true;
+	bool default_disable_cycle_exact = false;
+	int default_quickstart_compatibility = 0;
 	bool default_correct_aspect_ratio = true;
 	bool default_auto_crop = false;
 	int default_width = 720;

--- a/src/include/perf_monitor.h
+++ b/src/include/perf_monitor.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "uae/types.h"
+
+// Per-frame line rendering statistics. Incremented from the main emulation
+// thread (drawing queue entry points and the custom.cpp line cache),
+// sampled and zeroed once per frame by perf_monitor_frame().
+struct perf_line_counters
+{
+	int full;     // type-0 lines: full per-CCK Denise pipeline
+	int fast;     // type-1/2 lines: fast bitplane/border rendering
+	int skipped;  // border/blank lines reused from the previous field without redraw
+};
+extern struct perf_line_counters perf_lines;
+
+void perf_monitor_reset(void);
+
+// Called once per emulated frame from fpscounter() in custom.cpp.
+// All durations are in nanoseconds.
+// frame_ns: measured duration of the frame just completed
+// idle_ns:  time the emulator spent sleeping during that frame
+// vsynctime_ns: the frame duration budget (vsynctimebase)
+// frameok:  frame was rendered on time
+void perf_monitor_frame(uae_s64 frame_ns, uae_s64 idle_ns, uae_s64 vsynctime_ns, bool frameok);
+
+// Render/present GPU-path timing, accumulated from osdep/amiberry_gfx.cpp.
+void perf_monitor_add_render(uae_s64 ns);
+void perf_monitor_add_present(uae_s64 ns);
+
+// Slow-host warning: set internally by perf_monitor_frame() after sustained
+// frame overruns; surfaced by the GUI, which clears it after handling.
+bool perf_monitor_warning_pending(void);
+void perf_monitor_clear_warning(void);

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -131,6 +131,7 @@ int multithread_enabled = 1;
 static TCHAR* inipath = nullptr;
 extern FILE* debugfile;
 static int forceroms;
+static bool force_perf_log;
 static void* tablet;
 SDL_Cursor* normalcursor;
 
@@ -5955,6 +5956,10 @@ void save_amiberry_settings()
 
 	// Enable frameskip by default?
 	write_bool_option("default_frameskip", amiberry_options.default_frameskip);
+	write_bool_option("perf_log", amiberry_options.perf_log);
+	write_bool_option("slow_host_warning", amiberry_options.slow_host_warning);
+	write_bool_option("default_disable_cycle_exact", amiberry_options.default_disable_cycle_exact);
+	write_int_option("default_quickstart_compatibility", amiberry_options.default_quickstart_compatibility);
 
 	// Correct Aspect Ratio by default?
 	write_bool_option("default_correct_aspect_ratio", amiberry_options.default_correct_aspect_ratio);
@@ -6347,6 +6352,10 @@ static int parse_amiberry_settings_line(const char *path, char *linea)
 		ret |= cfgfile_intval(option, value, "default_scaling_method", &amiberry_options.default_scaling_method, 1);
 		ret |= cfgfile_intval(option, value, "default_gfx_autoresolution", &amiberry_options.default_gfx_autoresolution, 1);
 		ret |= cfgfile_yesno(option, value, "default_frameskip", &amiberry_options.default_frameskip);
+		ret |= cfgfile_yesno(option, value, "perf_log", &amiberry_options.perf_log);
+		ret |= cfgfile_yesno(option, value, "slow_host_warning", &amiberry_options.slow_host_warning);
+		ret |= cfgfile_yesno(option, value, "default_disable_cycle_exact", &amiberry_options.default_disable_cycle_exact);
+		ret |= cfgfile_intval(option, value, "default_quickstart_compatibility", &amiberry_options.default_quickstart_compatibility, 1);
 		ret |= cfgfile_yesno(option, value, "default_correct_aspect_ratio", &amiberry_options.default_correct_aspect_ratio);
 		ret |= cfgfile_yesno(option, value, "default_auto_height", &amiberry_options.default_auto_crop);
 		ret |= cfgfile_yesno(option, value, "default_auto_crop", &amiberry_options.default_auto_crop);
@@ -10180,6 +10189,8 @@ int amiberry_main(int argc, char* argv[])
 			download_whdboot = true;
 		if (_tcscmp(argv[i], _T("--rescan-roms")) == 0)
 			forceroms = 1;
+		if (_tcscmp(argv[i], _T("--perf-log")) == 0)
+			force_perf_log = true;
 	}
 
 	if (run_jit_selftest)
@@ -10254,6 +10265,8 @@ int amiberry_main(int argc, char* argv[])
 	init_amiberry_dirs(portable_mode);
 	if (config_found)
 		load_amiberry_settings();
+	if (force_perf_log)
+		amiberry_options.perf_log = true;
 	migrate_legacy_configuration_directories(portable_mode);
 	migrate_legacy_visual_asset_directories();
 	migrate_legacy_lowercase_content_directories();

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -166,6 +166,7 @@ static volatile bool cpu_wakeup_event_triggered;
 
 int quickstart_model = 0;
 int quickstart_conf = 0;
+int quickstart_compa = 0;
 bool host_poweroff = false;
 int relativepaths = 0;
 int saveimageoriginalpath = 0;
@@ -10283,6 +10284,7 @@ int amiberry_main(int argc, char* argv[])
 	}
 	if (force_perf_log)
 		amiberry_options.perf_log = true;
+	quickstart_compa = amiberry_options.default_quickstart_compatibility;
 	migrate_legacy_configuration_directories(portable_mode);
 	migrate_legacy_visual_asset_directories();
 	migrate_legacy_lowercase_content_directories();

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -10276,11 +10276,14 @@ int amiberry_main(int argc, char* argv[])
 		load_amiberry_settings();
 	else if (host_detect_slow_sbc())
 	{
-		// First run on a known-slow board: default new configs and the
-		// Quickstart compatibility slider to Approximate accuracy.
-		// Persisted to amiberry.conf, so the user can change it.
-		amiberry_options.default_disable_cycle_exact = true;
-		amiberry_options.default_quickstart_compatibility = 1;
+		// First run on a known-slow board: enable resolution autoswitch by
+		// default. It drops the output to lores only when the displayed content
+		// allows it (lossless), cutting per-CCK Denise cost while keeping full
+		// cycle-exact accuracy and compatibility. Persisted to amiberry.conf,
+		// so the user can change it. (Accuracy is deliberately NOT lowered here:
+		// clearing the cycle-exact flags is a no-op for the common <=68020
+		// cpu_compatible case and only risks breaking timing-sensitive titles.)
+		amiberry_options.default_gfx_autoresolution = 1;
 	}
 	if (force_perf_log)
 		amiberry_options.perf_log = true;

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4613,6 +4613,14 @@ void target_default_options(uae_prefs* p, const int type)
 			p->gf[GF_NORMAL].gfx_filter = 1;
 		if (p->gf[GF_RTG].gfx_filter == 0)
 			p->gf[GF_RTG].gfx_filter = 1;
+		if (amiberry_options.default_disable_cycle_exact)
+		{
+			// Slow-host default: Approximate accuracy instead of full cycle-exact.
+			// Quickstart presets and explicit configs may still re-enable it.
+			p->cpu_cycle_exact = false;
+			p->cpu_memory_cycle_exact = false;
+			p->blitter_cycle_exact = false;
+		}
 		//WIN32GUI_LoadUIString(IDS_INPUT_CUSTOM, buf, sizeof buf / sizeof(TCHAR));
 		//for (int i = 0; i < GAMEPORT_INPUT_SETTINGS; i++)
 		//	_sntprintf(p->input_config_name[i], sizeof p->input_config_name[i] / sizeof(TCHAR), buf, i + 1);
@@ -10265,6 +10273,14 @@ int amiberry_main(int argc, char* argv[])
 	init_amiberry_dirs(portable_mode);
 	if (config_found)
 		load_amiberry_settings();
+	else if (host_detect_slow_sbc())
+	{
+		// First run on a known-slow board: default new configs and the
+		// Quickstart compatibility slider to Approximate accuracy.
+		// Persisted to amiberry.conf, so the user can change it.
+		amiberry_options.default_disable_cycle_exact = true;
+		amiberry_options.default_quickstart_compatibility = 1;
+	}
 	if (force_perf_log)
 		amiberry_options.perf_log = true;
 	migrate_legacy_configuration_directories(portable_mode);

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -28,6 +28,7 @@
 #include "picasso96.h"
 #include "gui.h"
 #include "amiberry_gfx.h"
+#include "perf_monitor.h"
 #include "sounddep/sound.h"
 #include "inputdevice.h"
 #ifdef WITH_MIDI
@@ -438,7 +439,9 @@ bool render_screen(const int monid, const int mode, const bool immediate)
 			return mon->render_ok;
 		}
 	}
+	const frame_time_t perf_t0 = read_processor_time();
 	mon->render_ok = amiberry_renderframe(monid, mode, immediate);
+	perf_monitor_add_render(read_processor_time() - perf_t0);
 	return mon->render_ok;
 }
 
@@ -515,7 +518,9 @@ void show_screen(const int monid, int mode)
 		return;
 	}
 
+	const frame_time_t perf_t0 = read_processor_time();
 	renderer->present_frame(monid, mode);
+	perf_monitor_add_present(read_processor_time() - perf_t0);
 	mon->render_ok = false;
 }
 

--- a/src/osdep/gui/gui_handling.h
+++ b/src/osdep/gui/gui_handling.h
@@ -341,6 +341,7 @@ void gui_config_mark_clean();
 
 extern int quickstart_model;
 extern int quickstart_conf;
+extern int quickstart_compa;
 
 typedef struct {
 	char Name[MAX_DPATH];

--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -36,6 +36,7 @@
 #include "imgui_internal.h"
 #include "savestate.h"
 #include "target.h"
+#include "perf_monitor.h"
 #include "tinyxml2.h"
 #include "file_dialog.h"
 #include "macos_window.h"
@@ -1921,6 +1922,7 @@ static bool show_disk_info = false;
 static char disk_info_title[128] = {0};
 static std::vector<std::string> disk_info_text;
 static bool open_legacy_cleanup_popup = false;
+static bool open_perf_warning_popup = false;
 static std::vector<std::string> legacy_cleanup_text;
 static std::string legacy_cleanup_error_message;
 
@@ -1988,6 +1990,10 @@ void run_gui()
 	legacy_cleanup_text = get_legacy_cleanup_prompt_items();
 	if (open_legacy_cleanup_popup)
 		legacy_cleanup_error_message.clear();
+
+	// Slow-host warning raised during emulation: surface it now that the GUI is open
+	if (perf_monitor_warning_pending())
+		open_perf_warning_popup = true;
 
 	if (!emulating && amiberry_options.quickstart_start)
 		last_active_panel = 2;
@@ -2666,6 +2672,51 @@ void run_gui()
 				ImGui::CloseCurrentPopup();
 			}
 
+			ImGui::EndPopup();
+		}
+
+		if (open_perf_warning_popup && !show_message_box) {
+			const float pw_vw = vp->Size.x;
+			ImGui::SetNextWindowPos(vp->GetCenter(), ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+			ImGui::SetNextWindowSize(ImVec2(pw_vw * 0.56f, 0.0f), ImGuiCond_Appearing);
+			ImGui::OpenPopup("Performance Warning");
+			open_perf_warning_popup = false;
+		}
+		if (ImGui::BeginPopupModal("Performance Warning", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings))
+		{
+			ImGui::TextWrapped("This system cannot maintain full emulation speed with the current "
+				"accuracy settings (the emulated Amiga is running below 100%% speed, which also "
+				"distorts audio).");
+			ImGui::Spacing();
+			ImGui::TextWrapped("Switching to Approximate accuracy disables cycle-exact CPU, memory "
+				"and blitter timing. Most games and applications run correctly with it, and it is "
+				"significantly faster. A few timing-sensitive titles may require full cycle-exact "
+				"accuracy.");
+			ImGui::Spacing();
+			ImGui::Separator();
+			static bool perf_warning_dont_ask = false;
+			ImGui::Checkbox("Don't warn me again", &perf_warning_dont_ask);
+			ImGui::Spacing();
+			if (AmigaButton("Switch to Approximate", ImVec2(BUTTON_WIDTH * 2, BUTTON_HEIGHT))) {
+				changed_prefs.cpu_cycle_exact = false;
+				changed_prefs.cpu_memory_cycle_exact = false;
+				changed_prefs.blitter_cycle_exact = false;
+				perf_monitor_clear_warning();
+				if (perf_warning_dont_ask) {
+					amiberry_options.slow_host_warning = false;
+					save_amiberry_settings();
+				}
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::SameLine();
+			if (AmigaButton("Keep settings", ImVec2(BUTTON_WIDTH * 2, BUTTON_HEIGHT)) || ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+				perf_monitor_clear_warning();
+				if (perf_warning_dont_ask) {
+					amiberry_options.slow_host_warning = false;
+					save_amiberry_settings();
+				}
+				ImGui::CloseCurrentPopup();
+			}
 			ImGui::EndPopup();
 		}
 

--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -2684,23 +2684,20 @@ void run_gui()
 		}
 		if (ImGui::BeginPopupModal("Performance Warning", nullptr, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings))
 		{
-			ImGui::TextWrapped("This system cannot maintain full emulation speed with the current "
-				"accuracy settings (the emulated Amiga is running below 100%% speed, which also "
-				"distorts audio).");
+			ImGui::TextWrapped("This system cannot keep up with the current settings - the emulated "
+				"Amiga is running below full speed, which also affects audio.");
 			ImGui::Spacing();
-			ImGui::TextWrapped("Switching to Approximate accuracy disables cycle-exact CPU, memory "
-				"and blitter timing. Most games and applications run correctly with it, and it is "
-				"significantly faster. A few timing-sensitive titles may require full cycle-exact "
-				"accuracy.");
+			ImGui::TextWrapped("Enabling resolution autoswitch lets Amiberry drop the output to low "
+				"resolution when the displayed screen allows it, which significantly reduces the "
+				"rendering cost. Emulation accuracy is unchanged - only horizontal sharpness is "
+				"softened on high-resolution screens.");
 			ImGui::Spacing();
 			ImGui::Separator();
 			static bool perf_warning_dont_ask = false;
 			ImGui::Checkbox("Don't warn me again", &perf_warning_dont_ask);
 			ImGui::Spacing();
-			if (AmigaButton("Switch to Approximate", ImVec2(BUTTON_WIDTH * 2, BUTTON_HEIGHT))) {
-				changed_prefs.cpu_cycle_exact = false;
-				changed_prefs.cpu_memory_cycle_exact = false;
-				changed_prefs.blitter_cycle_exact = false;
+			if (AmigaButton("Enable resolution autoswitch", ImVec2(BUTTON_WIDTH * 2.4f, BUTTON_HEIGHT))) {
+				changed_prefs.gfx_autoresolution = 1;
 				perf_monitor_clear_warning();
 				if (perf_warning_dont_ask) {
 					amiberry_options.slow_host_warning = false;

--- a/src/osdep/host_detect.cpp
+++ b/src/osdep/host_detect.cpp
@@ -1,0 +1,61 @@
+#include "sysconfig.h"
+#include "sysdeps.h"
+#include "options.h"
+#include "uae.h"
+
+#if defined(__linux__) && !defined(__ANDROID__)
+
+#include <cstdio>
+#include <cstring>
+
+static bool read_device_tree_model(char* buf, const size_t len)
+{
+	FILE* f = fopen("/proc/device-tree/model", "rb");
+	if (!f) {
+		return false;
+	}
+	const size_t n = fread(buf, 1, len - 1, f);
+	fclose(f);
+	if (n == 0) {
+		return false;
+	}
+	buf[n] = 0;
+	return true;
+}
+
+// Returns true when running on a single-board computer known to be too slow
+// for full cycle-exact emulation (Raspberry Pi 4 and older). The Pi 5 is
+// deliberately NOT in this list.
+bool host_detect_slow_sbc(void)
+{
+	char model[256];
+	if (!read_device_tree_model(model, sizeof model)) {
+		return false;
+	}
+	static const char* slow_boards[] = {
+		"Raspberry Pi 4",
+		"Raspberry Pi 3",
+		"Raspberry Pi 2",
+		"Raspberry Pi Zero",
+		"Raspberry Pi Model",
+		"Raspberry Pi Compute Module 4",
+		"Raspberry Pi Compute Module 3",
+		nullptr
+	};
+	for (int i = 0; slow_boards[i] != nullptr; i++) {
+		if (strstr(model, slow_boards[i]) != nullptr) {
+			write_log("Host board '%s' detected as a slow SBC\n", model);
+			return true;
+		}
+	}
+	return false;
+}
+
+#else
+
+bool host_detect_slow_sbc(void)
+{
+	return false;
+}
+
+#endif

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -330,6 +330,7 @@ void render_panel_quickstart() {
         if (ImGui::SliderInt("##QSCompatibility", &quickstart_compa, 0, compa_max, compa_labels[quickstart_compa])) {
             Quickstart_ApplyDefaults();
         }
+        AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
             ImGui::SetTooltip("Trade emulation accuracy for less host CPU usage.\n"
                 "Use 'Good compatibility' or lower on slow systems (e.g. Raspberry Pi 4).");

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -103,8 +103,21 @@ static void qs_set_control_state(int model, bool &df1_visible, bool &cd_visible,
     }
 }
 
+// Maximum compatibility-slider level per Quickstart model. Models routed to
+// set_68020_compa (A1200=4, CD32=8) support level 4 (JIT); the 68000 models
+// top out at level 3 (see set_68000_compa in cfgfile.cpp).
+static int qs_compa_max(const int model) {
+    return (model == 4 || model == 8) ? 4 : 3;
+}
+
 void Quickstart_ApplyDefaults() {
-    built_in_prefs(&changed_prefs, quickstart_model, quickstart_conf, 0, 0);
+    // Compatibility tier: 0 = full cycle-exact ... 3/4 = fastest (see
+    // set_68000_compa / set_68020_compa in cfgfile.cpp)
+    if (quickstart_compa < 0)
+        quickstart_compa = 0;
+    if (quickstart_compa > qs_compa_max(quickstart_model))
+        quickstart_compa = qs_compa_max(quickstart_model);
+    built_in_prefs(&changed_prefs, quickstart_model, quickstart_conf, quickstart_compa, 0);
 
     // Enforce constraints similar to WinUAE
     if (quickstart_model <= 4) { // A500, A500+, A600, A1000, A1200
@@ -294,6 +307,34 @@ void render_panel_quickstart() {
             // Bevel around the combo frame
             AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActive());
         }
+
+        // Compatibility vs Required CPU Power row
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Compatibility:");
+        ImGui::TableSetColumnIndex(1);
+        static const char* compa_labels[] = {
+            "Best compatibility (cycle-exact)",
+            "Good compatibility (approximate)",
+            "Less compatible (faster CPU)",
+            "Low compatibility (fastest CPU)",
+            "Low compatibility (JIT)"
+        };
+        const int compa_max = qs_compa_max(quickstart_model);
+        if (quickstart_compa > compa_max)
+            quickstart_compa = compa_max;
+        if (quickstart_compa < 0)
+            quickstart_compa = 0;
+        ImGui::SetNextItemWidth(-1);
+        if (ImGui::SliderInt("##QSCompatibility", &quickstart_compa, 0, compa_max, compa_labels[quickstart_compa])) {
+            Quickstart_ApplyDefaults();
+        }
+        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+            ImGui::SetTooltip("Trade emulation accuracy for less host CPU usage.\n"
+                "Use 'Good compatibility' or lower on slow systems (e.g. Raspberry Pi 4).");
+        }
+
         ImGui::EndTable();
     }
     EndGroupBox("Emulated Hardware");

--- a/src/osdep/perf_monitor.cpp
+++ b/src/osdep/perf_monitor.cpp
@@ -1,0 +1,129 @@
+#include "sysconfig.h"
+#include "sysdeps.h"
+#include "options.h"
+#include "perf_monitor.h"
+
+struct perf_line_counters perf_lines;
+
+// Accumulators for the periodic stats log
+static uae_s64 acc_frames;
+static uae_s64 acc_frame_ns;
+static uae_s64 acc_idle_ns;
+static uae_s64 acc_render_ns;
+static uae_s64 acc_present_ns;
+static uae_s64 acc_lines_full;
+static uae_s64 acc_lines_fast;
+static uae_s64 acc_lines_skipped;
+static int acc_late_frames;
+
+// Rolling window for slow-host detection: one entry per frame,
+// 1 = frame exceeded its budget by more than 10%.
+#define PERF_OVERRUN_WINDOW 256
+#define PERF_OVERRUN_TRIGGER (PERF_OVERRUN_WINDOW * 3 / 4)
+static uae_u8 overrun_window[PERF_OVERRUN_WINDOW];
+static int overrun_pos;
+static int overrun_count;
+static bool overrun_window_filled;
+static bool warning_pending;
+static bool warning_emitted;
+
+void perf_monitor_reset(void)
+{
+	memset(&perf_lines, 0, sizeof perf_lines);
+	acc_frames = acc_frame_ns = acc_idle_ns = acc_render_ns = acc_present_ns = 0;
+	acc_lines_full = acc_lines_fast = acc_lines_skipped = 0;
+	acc_late_frames = 0;
+	memset(overrun_window, 0, sizeof overrun_window);
+	overrun_pos = 0;
+	overrun_count = 0;
+	overrun_window_filled = false;
+	warning_pending = false;
+	warning_emitted = false;
+}
+
+void perf_monitor_add_render(uae_s64 ns)
+{
+	acc_render_ns += ns;
+}
+
+void perf_monitor_add_present(uae_s64 ns)
+{
+	acc_present_ns += ns;
+}
+
+bool perf_monitor_warning_pending(void)
+{
+	return warning_pending;
+}
+
+void perf_monitor_clear_warning(void)
+{
+	warning_pending = false;
+}
+
+void perf_monitor_frame(uae_s64 frame_ns, uae_s64 idle_ns, uae_s64 vsynctime_ns, bool frameok)
+{
+	// Sample and reset the per-frame line counters regardless of logging state
+	const int lines_full = perf_lines.full;
+	const int lines_fast = perf_lines.fast;
+	const int lines_skipped = perf_lines.skipped;
+	memset(&perf_lines, 0, sizeof perf_lines);
+
+	if (vsynctime_ns <= 0 || frame_ns <= 0) {
+		return;
+	}
+
+	// --- Slow-host detection (always active unless disabled or already fired) ---
+	if (amiberry_options.slow_host_warning && !warning_emitted && !currprefs.turbo_emulation) {
+		const uae_u8 over = frame_ns > vsynctime_ns + vsynctime_ns / 10 ? 1 : 0;
+		overrun_count += over - overrun_window[overrun_pos];
+		overrun_window[overrun_pos] = over;
+		overrun_pos++;
+		if (overrun_pos >= PERF_OVERRUN_WINDOW) {
+			overrun_pos = 0;
+			overrun_window_filled = true;
+		}
+		if (overrun_window_filled && overrun_count >= PERF_OVERRUN_TRIGGER) {
+			warning_pending = true;
+			warning_emitted = true;
+			write_log(_T("PERF: sustained frame overruns detected (%d of last %d frames >10%% over budget). ")
+				_T("This host cannot maintain full emulation speed with the current accuracy settings.\n"),
+				overrun_count, PERF_OVERRUN_WINDOW);
+		}
+	}
+
+	// --- Periodic statistics log ---
+	if (!amiberry_options.perf_log) {
+		return;
+	}
+
+	acc_frames++;
+	acc_frame_ns += frame_ns;
+	acc_idle_ns += idle_ns;
+	acc_lines_full += lines_full;
+	acc_lines_fast += lines_fast;
+	acc_lines_skipped += lines_skipped;
+	if (!frameok) {
+		acc_late_frames++;
+	}
+
+	if (acc_frames >= 256) {
+		const double f = (double)acc_frames;
+		const double frame_ms = acc_frame_ns / f / 1e6;
+		const double idle_ms = acc_idle_ns / f / 1e6;
+		const double render_ms = acc_render_ns / f / 1e6;
+		const double present_ms = acc_present_ns / f / 1e6;
+		double emu_ms = frame_ms - idle_ms - render_ms - present_ms;
+		if (emu_ms < 0) {
+			emu_ms = 0;
+		}
+		write_log(_T("PERF: fps=%.1f frame=%.2fms emu=%.2fms render=%.2fms present=%.2fms idle=%.2fms ")
+			_T("late=%d%% lines/frame: full=%.0f fast=%.0f skipped=%.0f\n"),
+			1e9 / (acc_frame_ns / f), frame_ms, emu_ms, render_ms, present_ms, idle_ms,
+			(int)(acc_late_frames * 100 / acc_frames),
+			acc_lines_full / f, acc_lines_fast / f, acc_lines_skipped / f);
+		acc_frames = acc_frame_ns = acc_idle_ns = acc_render_ns = acc_present_ns = 0;
+		acc_lines_full = acc_lines_fast = acc_lines_skipped = 0;
+		acc_late_frames = 0;
+	}
+}

--- a/src/osdep/perf_monitor.cpp
+++ b/src/osdep/perf_monitor.cpp
@@ -87,7 +87,7 @@ void perf_monitor_frame(uae_s64 frame_ns, uae_s64 idle_ns, uae_s64 vsynctime_ns,
 			warning_pending = true;
 			warning_emitted = true;
 			write_log(_T("PERF: sustained frame overruns detected (%d of last %d frames >10%% over budget). ")
-				_T("This host cannot maintain full emulation speed with the current accuracy settings.\n"),
+				_T("This host cannot maintain full emulation speed with the current settings.\n"),
 				overrun_count, PERF_OVERRUN_WINDOW);
 		}
 	}

--- a/src/osdep/target.h
+++ b/src/osdep/target.h
@@ -125,6 +125,7 @@ extern int net_enumerated;
 extern struct netdriverdata** target_ethernet_enumerate();
 extern void target_startup_msg(const TCHAR* title, const TCHAR* msg);
 extern int multithread_enabled;
+extern bool host_detect_slow_sbc(void);
 
 void save_amiberry_settings();
 void update_display(struct uae_prefs*);


### PR DESCRIPTION
1. Performance monitor (perf_monitor)
New self-contained module (src/include/perf_monitor.h, src/osdep/perf_monitor.cpp). Enable with --perf-log or perf_log=yes in amiberry.conf. Every ~256 frames it logs a breakdown:
`PERF: fps=49.9 frame=20.04ms emu=14.8ms render=2.1ms present=2.9ms idle=0.2ms late=3% lines/frame: full=210 fast=40 skipped=63` emu/render/present/idle split per frame, plus full / fast / skipped line counts so we can see whether the fast paths ever engage. Hooks are tiny: a call in fpscounter(), two timing wraps in render_screen()/show_screen(), and counter increments in the drawing queue entry points and the line cache. All core-file changes are #ifdef AMIBERRY-guarded to keep WinUAE merges clean.

2. Slow-host warning with one-click downshift
A rolling detector (≥75% of the last 256 frames >10% over budget) raises a flag; the GUI surfaces it as a "Performance Warning" modal with Resolution Autoswitch ON / Keep settings, and a "don't warn again" option.
Hardware-agnostic — it reacts to the symptom, so it covers any slow host, not just the Pi.

3. "Compatibility vs Required CPU Power" slider in Quickstart
WinUAE has this; Amiberry never exposed it and hardcoded compa=0 (the most expensive tier). The slider now passes the chosen tier to the core's existing built_in_prefs() / set_680x0_compa() machinery (0 = cycle-exact … up to JIT on 020+ models). No new emulation logic — just exposing what the shared core already implements.

4. First-run defaults on known-slow SBCs
On first launch (no amiberry.conf), Linux reads /proc/device-tree/model and, for Raspberry Pi 4 and older, seeds Approximate accuracy + slider position 1. Distro-agnostic; Pi 5 deliberately excluded; never fires on Apple Silicon, Ampere, x86, etc. Written to the config so the user can override it like any setting.

5. -mtune=cortex-a72 for Linux aarch64 builds
Scheduling-only (-mtune, not -mcpu) — the ISA baseline stays generic armv8-a, so the identical binary runs unchanged on faster cores (A76/Neoverse). Applies to all three Linux aarch64 CI jobs (Debian cross-compile sets CMAKE_SYSTEM_PROCESSOR=aarch64 via the toolchain file; Ubuntu/Fedora build natively on ubuntu-24.04-arm). Overridable via -DAMIBERRY_ARM_TUNE=. macOS and 32-bit ARM are excluded.
