### PR TITLE
Use statically linked QEMU-UAE plugin release

### DIFF
--- a/.github/scripts/download-qemu-uae-plugin.ps1
+++ b/.github/scripts/download-qemu-uae-plugin.ps1
@@ -15,7 +15,7 @@ if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
 }
 
 $repo = if ([string]::IsNullOrWhiteSpace($env:QEMU_UAE_RELEASE_REPO)) { "BlitterStudio/amiberry-qemu-uae" } else { $env:QEMU_UAE_RELEASE_REPO }
-$tag = if ([string]::IsNullOrWhiteSpace($env:QEMU_UAE_RELEASE_TAG)) { "v11.0.1-amiberry.3" } else { $env:QEMU_UAE_RELEASE_TAG }
+$tag = if ([string]::IsNullOrWhiteSpace($env:QEMU_UAE_RELEASE_TAG)) { "v11.0.1-amiberry.5" } else { $env:QEMU_UAE_RELEASE_TAG }
 $downloadDir = Join-Path $OutputDirectory "download"
 $extractDir = Join-Path $OutputDirectory "extract"
 

--- a/.github/scripts/download-qemu-uae-plugin.sh
+++ b/.github/scripts/download-qemu-uae-plugin.sh
@@ -8,7 +8,7 @@ fi
 
 asset="$1"
 repo="${QEMU_UAE_RELEASE_REPO:-BlitterStudio/amiberry-qemu-uae}"
-tag="${QEMU_UAE_RELEASE_TAG:-v11.0.1-amiberry.3}"
+tag="${QEMU_UAE_RELEASE_TAG:-v11.0.1-amiberry.5}"
 output_dir="${2:-${GITHUB_WORKSPACE:-$PWD}/.qemu-uae-plugin}"
 download_dir="$output_dir/download"
 extract_dir="$output_dir/extract"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   QEMU_UAE_RELEASE_REPO: BlitterStudio/amiberry-qemu-uae
-  QEMU_UAE_RELEASE_TAG: v11.0.1-amiberry.4
+  QEMU_UAE_RELEASE_TAG: v11.0.1-amiberry.5
   GH_TOKEN: ${{ github.token }}
 
 jobs:
@@ -1030,14 +1030,6 @@ jobs:
           if (-not (Test-Path $qemuPluginPath)) {
             throw "Portable ZIP is missing plugins/qemu-uae.dll."
           }
-          $runtimeDlls = @("zlib1.dll", "libglib-2.0-0.dll", "libgmodule-2.0-0.dll", "libwinpthread-1.dll")
-          foreach ($runtimeDll in $runtimeDlls) {
-            $runtimeDllPath = Join-Path $portableDir.FullName $runtimeDll
-            if (-not (Test-Path $runtimeDllPath)) {
-              throw "Portable ZIP is missing $runtimeDll beside Amiberry.exe."
-            }
-          }
-
           $loaderSource = Join-Path $verifyRoot "load-qemu-uae.c"
           $loaderExe = Join-Path $verifyRoot "load-qemu-uae.exe"
           @'
@@ -1514,14 +1506,6 @@ jobs:
           if (-not (Test-Path $exePath)) { throw "Amiberry.exe missing from portable ZIP." }
           $qemuPluginPath = Join-Path $portableDir.FullName "plugins/qemu-uae.dll"
           if (-not (Test-Path $qemuPluginPath)) { throw "plugins/qemu-uae.dll missing from portable ZIP." }
-          $runtimeDlls = @("zlib1.dll", "libglib-2.0-0.dll", "libgmodule-2.0-0.dll", "libwinpthread-1.dll")
-          foreach ($runtimeDll in $runtimeDlls) {
-            $runtimeDllPath = Join-Path $portableDir.FullName $runtimeDll
-            if (-not (Test-Path $runtimeDllPath)) {
-              throw "$runtimeDll missing from portable ZIP beside Amiberry.exe."
-            }
-          }
-
           $loaderSource = Join-Path $verifyRoot "load-qemu-uae.c"
           $loaderExe = Join-Path $verifyRoot "load-qemu-uae.exe"
           @'

--- a/docs/ppc-qemu-plugin.md
+++ b/docs/ppc-qemu-plugin.md
@@ -32,10 +32,10 @@ Android and iOS currently build with PPC plugin support disabled because dynamic
 
 ## Runtime Dependencies
 
-The QEMU-UAE plugin is dynamically loaded at runtime, so packages must ship both the plugin and the libraries needed to load it:
+The QEMU-UAE plugin is dynamically loaded at runtime, so packages must ship the plugin and ensure any libraries needed to load it are available:
 
 - macOS app bundles include `qemu-uae.dylib` under `Contents/Resources/plugins` and bundle dependent dylibs under `Contents/Frameworks`.
-- Windows packages include `plugins/qemu-uae.dll`; plugin runtime DLLs such as GLib, GModule, zlib, and libwinpthread are installed beside `Amiberry.exe`.
+- Windows packages include `plugins/qemu-uae.dll`. Official Windows plugin release artifacts are statically linked for their GLib/GModule/zlib plugin dependencies, so no extra QEMU-UAE runtime DLLs are expected beside `Amiberry.exe`.
 - Linux DEB/RPM packages install `qemu-uae.so` under Amiberry's plugin library directory and declare required system packages, including libglib/GLib and zlib.
 
 Package CI must verify both plugin presence and dependency resolution. A package that contains the plugin file but cannot load it is broken.
@@ -95,6 +95,6 @@ The QEMU-UAE PPC plugin repository should publish artifacts for the desktop plat
 - macOS universal: `qemu-uae.dylib`
 - Windows x64 and ARM64: `qemu-uae.dll`
 
-Linux artifacts should be built from an older baseline such as Ubuntu 22.04 so they remain usable on newer supported distributions. macOS artifacts should be merged into a universal dylib before bundling into the universal app. Windows artifacts should be built with a UCRT/Clang toolchain compatible with Amiberry's llvm-mingw Windows builds.
+Linux artifacts should be built from an older baseline such as Ubuntu 22.04 so they remain usable on newer supported distributions. macOS artifacts should be merged into a universal dylib before bundling into the universal app. Windows artifacts should be built with a UCRT/Clang toolchain compatible with Amiberry's llvm-mingw Windows builds and should statically link their non-system plugin dependencies.
 
 Android and iOS remain unsupported for QEMU-UAE PPC until dynamic plugin loading and platform packaging constraints are solved. FreeBSD and Haiku are not release blockers for the first multi-platform plugin artifact set, but the host build must remain clean without bundled plugin artifacts.


### PR DESCRIPTION
## Summary
- bump the QEMU-UAE plugin release consumed by CI to v11.0.1-amiberry.5
- align both local download helper defaults with the workflow pin
- use the Windows plugin release that ships only qemu-uae.dll with static external plugin dependencies
- remove Windows CI checks that required old QEMU-UAE sidecar DLLs beside Amiberry.exe
- update QEMU-UAE PPC plugin docs to describe Windows static plugin dependencies

## Validation
- bash -n .github/scripts/download-qemu-uae-plugin.sh
- parsed .github/workflows/c-cpp.yml with Ruby YAML
- verified v11.0.1-amiberry.5 release assets exist
- downloaded qemu-uae-windows-x64.zip via the helper and verified SHA256
- confirmed qemu-uae-windows-x64.zip contains only qemu-uae.dll
- checked active docs/CI for stale sidecar DLL references

Note: pwsh is not installed locally, so PowerShell syntax parsing was skipped; the .ps1 change is only the default tag literal.