### PR TITLE
Fix CCK counter wrap assertions

### DIFF
--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -813,7 +813,7 @@ static bool safecpu(void)
 static void check_nocustom(void)
 {
 	struct amigadisplay* ad = &adisplays[0];
-	if (ad->picasso_on) {
+	if (ad->picasso_on && currprefs.picasso96_nocustom) {
 		custom_disabled = true;
 		line_disabled |= 2;
 	} else {

--- a/src/include/events.h
+++ b/src/include/events.h
@@ -122,9 +122,10 @@ STATIC_INLINE evt_t get_cck_cycles(void)
 }
 STATIC_INLINE uae_s32 get_cck_cycles_sub(evt_t cck1, evt_t cck2)
 {
-	assert(cck1 - cck2 < 0x10000000);
-	assert(cck1 - cck2 > -0x10000000);
-	return (uae_s32)(cck1 - cck2);
+	const uae_s32 diff = (uae_s32)((uae_u32)cck1 - (uae_u32)cck2);
+	assert(diff < 0x10000000);
+	assert(diff > -0x10000000);
+	return diff;
 }
 STATIC_INLINE uae_s32 get_cck_cycles_diff(evt_t cck)
 {


### PR DESCRIPTION
## Summary
- compute CCK deltas with 32-bit modulo arithmetic so currcycle_cck wraparound does not trip signed evt_t assertions
- honor rtg_nocustom when deciding whether RTG disables custom chipset emulation

Refs #2098