### PR TITLE
Fix threaded device shutdown

### DIFF
--- a/src/osdep/amiberry_uaenet.cpp
+++ b/src/osdep/amiberry_uaenet.cpp
@@ -310,6 +310,21 @@ static int uaenet_checkpacket(struct uaenet_data *ud)
     return 1;
 }
 
+static void uaenet_request_worker_stop(struct uaenet_data *ud)
+{
+    if (!ud)
+        return;
+
+    ud->active = false;
+    ud->active2 = false;
+
+#ifdef WITH_UAENET_PCAP
+    if (ud->handle) {
+        pcap_breakloop(ud->handle);
+    }
+#endif
+}
+
 #ifdef WITH_UAENET_PCAP
 // Thread to handle network traffic
 static int uaenet_worker_thread(void *arg)
@@ -331,6 +346,11 @@ static int uaenet_worker_thread(void *arg)
             int res = pcap_next_ex(ud->handle, &header, &pkt_data);
             if (res == 1 && header && pkt_data) {
                 uaenet_queue(ud, pkt_data, header->caplen);
+            } else if (res == PCAP_ERROR_BREAK) {
+                break;
+            } else if (res == PCAP_ERROR) {
+                write_log(_T("UAENET: pcap_next_ex failed: %s\n"), pcap_geterr(ud->handle));
+                break;
             }
         }
     }
@@ -346,8 +366,7 @@ static void uaenet_close_driver_internal(struct uaenet_data *ud)
     if (!ud)
         return;
 
-    ud->active = false;
-    ud->active2 = false;
+    uaenet_request_worker_stop(ud);
 
     if (ud->tid) {
         write_log(_T("UAENET: Waiting for thread to terminate..\n"));
@@ -444,8 +463,7 @@ int uaenet_open(void *vsd, struct netdriverdata *ndd, void *userdata, ethernet_g
 #endif
     ) {
         write_log(_T("UAENET: Re-opening '%s', shutting down existing state\n"), ndd->name);
-        ud->active = false;
-        ud->active2 = false;
+        uaenet_request_worker_stop(ud);
         if (ud->tid) {
             uae_wait_thread(&ud->tid);
             ud->tid = 0;

--- a/src/pcem/vid_voodoo.cpp
+++ b/src/pcem/vid_voodoo.cpp
@@ -1023,6 +1023,7 @@ void *voodoo_card_init()
         voodoo->render_not_full_event[1] = thread_create_event();
         voodoo->render_not_full_event[2] = thread_create_event();
         voodoo->render_not_full_event[3] = thread_create_event();
+        voodoo->thread_run = 1;
         voodoo->fifo_thread = thread_create(voodoo_fifo_thread, voodoo);
         voodoo->render_thread[0] = thread_create(voodoo_render_thread_1, voodoo);
         if (voodoo->render_threads >= 2)
@@ -1145,6 +1146,7 @@ void *voodoo_2d3d_card_init(int type)
         voodoo->render_not_full_event[1] = thread_create_event();
         voodoo->render_not_full_event[2] = thread_create_event();
         voodoo->render_not_full_event[3] = thread_create_event();
+        voodoo->thread_run = 1;
         voodoo->fifo_thread = thread_create(voodoo_fifo_thread, voodoo);
         voodoo->render_thread[0] = thread_create(voodoo_render_thread_1, voodoo);
         if (voodoo->render_threads >= 2)
@@ -1298,6 +1300,23 @@ void voodoo_card_close(voodoo_t *voodoo)
 #endif
 #endif
 
+        voodoo->thread_run = 0;
+        thread_set_event(voodoo->wake_fifo_thread);
+        thread_set_event(voodoo->wake_render_thread[0]);
+        thread_set_event(voodoo->render_not_full_event[0]);
+        if (voodoo->render_threads >= 2)
+        {
+                thread_set_event(voodoo->wake_render_thread[1]);
+                thread_set_event(voodoo->render_not_full_event[1]);
+        }
+        if (voodoo->render_threads == 4)
+        {
+                thread_set_event(voodoo->wake_render_thread[2]);
+                thread_set_event(voodoo->wake_render_thread[3]);
+                thread_set_event(voodoo->render_not_full_event[2]);
+                thread_set_event(voodoo->render_not_full_event[3]);
+        }
+
         thread_kill(voodoo->fifo_thread);
         thread_kill(voodoo->render_thread[0]);
         if (voodoo->render_threads >= 2)
@@ -1312,8 +1331,12 @@ void voodoo_card_close(voodoo_t *voodoo)
         thread_destroy_event(voodoo->wake_fifo_thread);
         thread_destroy_event(voodoo->wake_render_thread[0]);
         thread_destroy_event(voodoo->wake_render_thread[1]);
+        thread_destroy_event(voodoo->wake_render_thread[2]);
+        thread_destroy_event(voodoo->wake_render_thread[3]);
         thread_destroy_event(voodoo->render_not_full_event[0]);
         thread_destroy_event(voodoo->render_not_full_event[1]);
+        thread_destroy_event(voodoo->render_not_full_event[2]);
+        thread_destroy_event(voodoo->render_not_full_event[3]);
 
         for (c = 0; c < TEX_CACHE_MAX; c++)
         {

--- a/src/pcem/vid_voodoo_common.h
+++ b/src/pcem/vid_voodoo_common.h
@@ -267,6 +267,9 @@ typedef struct voodoo_t
         event_t *render_not_full_event[4];
         event_t *wake_render_thread[4];
 
+        /* Amiberry local delta: SDL helper threads are joinable, so Voodoo
+           workers must observe device teardown and return before close joins. */
+        volatile int thread_run;
         int voodoo_busy;
         int render_voodoo_busy[4];
 

--- a/src/pcem/vid_voodoo_fifo.cpp
+++ b/src/pcem/vid_voodoo_fifo.cpp
@@ -86,10 +86,12 @@ void voodoo_wake_fifo_threads(voodoo_set_t *set, voodoo_t *voodoo)
 
 void voodoo_wait_for_swap_complete(voodoo_t *voodoo)
 {
-        while (voodoo->swap_pending)
+        while (voodoo->thread_run && voodoo->swap_pending)
         {
                 thread_wait_event(voodoo->wake_fifo_thread, -1);
                 thread_reset_event(voodoo->wake_fifo_thread);
+                if (!voodoo->thread_run)
+                        break;
 
                 thread_wait_mutex(voodoo->swap_mutex);
                 if ((voodoo->swap_pending && voodoo->flush) || FIFO_FULL)
@@ -109,30 +111,33 @@ void voodoo_wait_for_swap_complete(voodoo_t *voodoo)
 }
 
 
-static uint32_t cmdfifo_get(voodoo_t *voodoo)
+static int cmdfifo_get(voodoo_t *voodoo, uint32_t *val)
 {
-        uint32_t val;
+        if (!voodoo->thread_run)
+                return 0;
 
         if (!voodoo->cmdfifo_in_sub)
         {
-                while (voodoo->cmdfifo_depth_rd == voodoo->cmdfifo_depth_wr)
+                while (voodoo->thread_run && voodoo->cmdfifo_depth_rd == voodoo->cmdfifo_depth_wr)
                 {
                         thread_wait_event(voodoo->wake_fifo_thread, -1);
                         thread_reset_event(voodoo->wake_fifo_thread);
                 }
+                if (!voodoo->thread_run)
+                        return 0;
         }
 
-        val = *(uint32_t *)&voodoo->fb_mem[voodoo->cmdfifo_rp & voodoo->fb_mask];
+        *val = *(uint32_t *)&voodoo->fb_mem[voodoo->cmdfifo_rp & voodoo->fb_mask];
 
         if (!voodoo->cmdfifo_in_sub)
                 voodoo->cmdfifo_depth_rd++;
         voodoo->cmdfifo_rp += 4;
 
 //        pclog("  CMDFIFO get %08x\n", val);
-        return val;
+        return 1;
 }
 
-static inline float cmdfifo_get_f(voodoo_t *voodoo)
+static inline int cmdfifo_get_f(voodoo_t *voodoo, float *val)
 {
         union
         {
@@ -140,8 +145,10 @@ static inline float cmdfifo_get_f(voodoo_t *voodoo)
                 float f;
         } tempif;
 
-        tempif.i = cmdfifo_get(voodoo);
-        return tempif.f;
+        if (!cmdfifo_get(voodoo, &tempif.i))
+                return 0;
+        *val = tempif.f;
+        return 1;
 }
 
 enum
@@ -162,11 +169,17 @@ int voodoo_fifo_thread(void *param)
 {
         voodoo_t *voodoo = (voodoo_t *)param;
 
-        while (1)
+#define CMDFIFO_GET(val) do { if (!cmdfifo_get(voodoo, &(val))) goto fifo_thread_shutdown; } while (0)
+#define CMDFIFO_GET_F(val) do { if (!cmdfifo_get_f(voodoo, &(val))) goto fifo_thread_shutdown; } while (0)
+#define CMDFIFO_SKIP() do { uint32_t dummy; if (!cmdfifo_get(voodoo, &dummy)) goto fifo_thread_shutdown; } while (0)
+
+        while (voodoo->thread_run)
         {
                 thread_set_event(voodoo->fifo_not_full_event);
                 thread_wait_event(voodoo->wake_fifo_thread, -1);
                 thread_reset_event(voodoo->wake_fifo_thread);
+                if (!voodoo->thread_run)
+                        break;
                 voodoo->voodoo_busy = 1;
                 while (!FIFO_EMPTY)
                 {
@@ -246,17 +259,19 @@ int voodoo_fifo_thread(void *param)
                         voodoo->time += end_time - start_time;
                 }
 
-                while (voodoo->cmdfifo_enabled && (voodoo->cmdfifo_depth_rd != voodoo->cmdfifo_depth_wr || voodoo->cmdfifo_in_sub))
+                while (voodoo->thread_run && voodoo->cmdfifo_enabled && (voodoo->cmdfifo_depth_rd != voodoo->cmdfifo_depth_wr || voodoo->cmdfifo_in_sub))
                 {
                         uint64_t start_time = timer_read();
                         uint64_t end_time;
-                        uint32_t header = cmdfifo_get(voodoo);
+                        uint32_t header;
                         uint32_t addr;
                         uint32_t mask;
                         int smode;
                         int num;
                         int num_verticies;
                         int v_num;
+
+                        CMDFIFO_GET(header);
 
 //                        pclog(" CMDFIFO header %08x at %08x\n", header, voodoo->cmdfifo_rp);
 
@@ -297,7 +312,8 @@ int voodoo_fifo_thread(void *param)
 //                                pclog("CMDFIFO1 addr=%08x\n",addr);
                                 while (num--)
                                 {
-                                        uint32_t val = cmdfifo_get(voodoo);
+                                        uint32_t val;
+                                        CMDFIFO_GET(val);
                                         if ((addr & (1 << 13)) && voodoo->type >= VOODOO_BANSHEE)
                                         {
 //                                                if (voodoo->type != VOODOO_BANSHEE)
@@ -330,7 +346,8 @@ int voodoo_fifo_thread(void *param)
                                 {
                                         if (mask & 1)
                                         {
-                                                uint32_t val = cmdfifo_get(voodoo);
+                                                uint32_t val;
+                                                CMDFIFO_GET(val);
 
                                                 voodoo_2d_reg_writel(voodoo, addr, val);
                                         }
@@ -354,13 +371,14 @@ int voodoo_fifo_thread(void *param)
 
                                 while (num_verticies--)
                                 {
-                                        voodoo->verts[3].sVx = cmdfifo_get_f(voodoo);
-                                        voodoo->verts[3].sVy = cmdfifo_get_f(voodoo);
+                                        CMDFIFO_GET_F(voodoo->verts[3].sVx);
+                                        CMDFIFO_GET_F(voodoo->verts[3].sVy);
                                         if (mask & CMDFIFO3_PC_MASK_RGB)
                                         {
                                                 if (header & CMDFIFO3_PC)
                                                 {
-                                                        uint32_t val = cmdfifo_get(voodoo);
+                                                        uint32_t val;
+                                                        CMDFIFO_GET(val);
                                                         voodoo->verts[3].sBlue  = (float)(val & 0xff);
                                                         voodoo->verts[3].sGreen = (float)((val >> 8) & 0xff);
                                                         voodoo->verts[3].sRed   = (float)((val >> 16) & 0xff);
@@ -368,30 +386,30 @@ int voodoo_fifo_thread(void *param)
                                                 }
                                                 else
                                                 {
-                                                        voodoo->verts[3].sRed = cmdfifo_get_f(voodoo);
-                                                        voodoo->verts[3].sGreen = cmdfifo_get_f(voodoo);
-                                                        voodoo->verts[3].sBlue = cmdfifo_get_f(voodoo);
+                                                        CMDFIFO_GET_F(voodoo->verts[3].sRed);
+                                                        CMDFIFO_GET_F(voodoo->verts[3].sGreen);
+                                                        CMDFIFO_GET_F(voodoo->verts[3].sBlue);
                                                 }
                                         }
                                         if ((mask & CMDFIFO3_PC_MASK_ALPHA) && !(header & CMDFIFO3_PC))
-                                                voodoo->verts[3].sAlpha = cmdfifo_get_f(voodoo);
+                                                CMDFIFO_GET_F(voodoo->verts[3].sAlpha);
                                         if (mask & CMDFIFO3_PC_MASK_Z)
-                                                voodoo->verts[3].sVz = cmdfifo_get_f(voodoo);
+                                                CMDFIFO_GET_F(voodoo->verts[3].sVz);
                                         if (mask & CMDFIFO3_PC_MASK_Wb)
-                                                voodoo->verts[3].sWb = cmdfifo_get_f(voodoo);
+                                                CMDFIFO_GET_F(voodoo->verts[3].sWb);
                                         if (mask & CMDFIFO3_PC_MASK_W0)
-                                                voodoo->verts[3].sW0 = cmdfifo_get_f(voodoo);
+                                                CMDFIFO_GET_F(voodoo->verts[3].sW0);
                                         if (mask & CMDFIFO3_PC_MASK_S0_T0)
                                         {
-                                                voodoo->verts[3].sS0 = cmdfifo_get_f(voodoo);
-                                                voodoo->verts[3].sT0 = cmdfifo_get_f(voodoo);
+                                                CMDFIFO_GET_F(voodoo->verts[3].sS0);
+                                                CMDFIFO_GET_F(voodoo->verts[3].sT0);
                                         }
                                         if (mask & CMDFIFO3_PC_MASK_W1)
-                                                voodoo->verts[3].sW1 = cmdfifo_get_f(voodoo);
+                                                CMDFIFO_GET_F(voodoo->verts[3].sW1);
                                         if (mask & CMDFIFO3_PC_MASK_S1_T1)
                                         {
-                                                voodoo->verts[3].sS1 = cmdfifo_get_f(voodoo);
-                                                voodoo->verts[3].sT1 = cmdfifo_get_f(voodoo);
+                                                CMDFIFO_GET_F(voodoo->verts[3].sS1);
+                                                CMDFIFO_GET_F(voodoo->verts[3].sT1);
                                         }
                                         if (v_num)
                                                 voodoo_reg_writel(SST_sDrawTriCMD, 0, voodoo);
@@ -412,7 +430,8 @@ int voodoo_fifo_thread(void *param)
                                 {
                                         if (mask & 1)
                                         {
-                                                uint32_t val = cmdfifo_get(voodoo);
+                                                uint32_t val;
+                                                CMDFIFO_GET(val);
 
                                                 if ((addr & (1 << 13)) && voodoo->type >= VOODOO_BANSHEE)
                                                 {
@@ -437,14 +456,15 @@ int voodoo_fifo_thread(void *param)
                                         mask >>= 1;
                                 }
                                 while (num--)
-                                        cmdfifo_get(voodoo);
+                                        CMDFIFO_SKIP();
                                 break;
 
                                 case 5:
 //                                if (header & 0x3fc00000)
 //                                        fatal("CMDFIFO packet 5 has byte disables set %08x\n", header);
                                 num = (header >> 3) & 0x7ffff;
-                                addr = cmdfifo_get(voodoo) & 0xffffff;
+                                CMDFIFO_GET(addr);
+                                addr &= 0xffffff;
                                 if (!num)
                                         num = 1;
 //                                pclog("CMDFIFO5 addr=%08x num=%i\n", addr, num);
@@ -463,7 +483,8 @@ int voodoo_fifo_thread(void *param)
                                         }
                                         while (num--)
                                         {
-                                                uint32_t val = cmdfifo_get(voodoo);
+                                                uint32_t val;
+                                                CMDFIFO_GET(val);
                                                 if (addr <= voodoo->fb_mask)
                                                         *(uint32_t *)&voodoo->fb_mem[addr] = val;
                                                 addr += 4;
@@ -472,7 +493,8 @@ int voodoo_fifo_thread(void *param)
                                         case 2: /*Framebuffer*/
                                         while (num--)
                                         {
-                                                uint32_t val = cmdfifo_get(voodoo);
+                                                uint32_t val;
+                                                CMDFIFO_GET(val);
                                                 voodoo_fb_writel(addr, val, voodoo);
                                                 addr += 4;
                                         }
@@ -480,7 +502,8 @@ int voodoo_fifo_thread(void *param)
                                         case 3: /*Texture*/
                                         while (num--)
                                         {
-                                                uint32_t val = cmdfifo_get(voodoo);
+                                                uint32_t val;
+                                                CMDFIFO_GET(val);
                                                 voodoo_tex_writel(addr, val, voodoo);
                                                 addr += 4;
                                         }
@@ -500,5 +523,10 @@ int voodoo_fifo_thread(void *param)
                 }
                 voodoo->voodoo_busy = 0;
         }
+fifo_thread_shutdown:
+#undef CMDFIFO_GET
+#undef CMDFIFO_GET_F
+#undef CMDFIFO_SKIP
+        voodoo->voodoo_busy = 0;
         return 0;
 }

--- a/src/pcem/vid_voodoo_render.cpp
+++ b/src/pcem/vid_voodoo_render.cpp
@@ -1578,11 +1578,13 @@ static int render_thread(void *param, int odd_even)
 {
         voodoo_t *voodoo = (voodoo_t *)param;
 
-        while (1)
+        while (voodoo->thread_run)
         {
                 thread_set_event(voodoo->render_not_full_event[odd_even]);
                 thread_wait_event(voodoo->wake_render_thread[odd_even], -1);
                 thread_reset_event(voodoo->wake_render_thread[odd_even]);
+                if (!voodoo->thread_run)
+                        break;
                 voodoo->render_voodoo_busy[odd_even] = 1;
 
                 while (!PARAM_EMPTY(odd_even))
@@ -1604,6 +1606,7 @@ static int render_thread(void *param, int odd_even)
 
                 voodoo->render_voodoo_busy[odd_even] = 0;
         }
+        voodoo->render_voodoo_busy[odd_even] = 0;
         return 0;
 }
 
@@ -1628,8 +1631,8 @@ void voodoo_queue_triangle(voodoo_t *voodoo, voodoo_params_t *params)
 {
         voodoo_params_t *params_new = &voodoo->params_buffer[voodoo->params_write_idx & PARAM_MASK];
 
-        while (PARAM_FULL(0) || (voodoo->render_threads >= 2 && PARAM_FULL(1)) ||
-                (voodoo->render_threads == 4 && (PARAM_FULL(2) || PARAM_FULL(3))))
+        while (voodoo->thread_run && (PARAM_FULL(0) || (voodoo->render_threads >= 2 && PARAM_FULL(1)) ||
+                (voodoo->render_threads == 4 && (PARAM_FULL(2) || PARAM_FULL(3)))))
         {
                 thread_reset_event(voodoo->render_not_full_event[0]);
                 if (voodoo->render_threads >= 2)
@@ -1648,6 +1651,8 @@ void voodoo_queue_triangle(voodoo_t *voodoo, voodoo_params_t *params)
                 if (voodoo->render_threads == 4 && PARAM_FULL(3))
                         thread_wait_event(voodoo->render_not_full_event[3], -1); /*Wait for room in ringbuffer*/
         }
+        if (!voodoo->thread_run)
+                return;
 
         voodoo_use_texture(voodoo, params, 0);
         if (voodoo->dual_tmus)

--- a/src/pcem/vid_voodoo_render.h
+++ b/src/pcem/vid_voodoo_render.h
@@ -320,10 +320,10 @@ static inline void voodoo_wake_render_thread(voodoo_t *voodoo)
 
 static inline void voodoo_wait_for_render_thread_idle(voodoo_t *voodoo)
 {
-        while (!PARAM_EMPTY(0) || (voodoo->render_threads >= 2 && !PARAM_EMPTY(1)) ||
+        while (voodoo->thread_run && (!PARAM_EMPTY(0) || (voodoo->render_threads >= 2 && !PARAM_EMPTY(1)) ||
                 (voodoo->render_threads == 4 && (!PARAM_EMPTY(2) || !PARAM_EMPTY(3))) ||
                 voodoo->render_voodoo_busy[0] || (voodoo->render_threads >= 2 && voodoo->render_voodoo_busy[1]) ||
-                (voodoo->render_threads == 4 && (voodoo->render_voodoo_busy[2] || voodoo->render_voodoo_busy[3])))
+                (voodoo->render_threads == 4 && (voodoo->render_voodoo_busy[2] || voodoo->render_voodoo_busy[3]))))
         {
                 voodoo_wake_render_thread(voodoo);
                 if (!PARAM_EMPTY(0) || voodoo->render_voodoo_busy[0])


### PR DESCRIPTION
## Summary
- add an explicit shutdown flag for Voodoo FIFO/render helper threads before joining them
- make nested Voodoo FIFO, command-FIFO, swap, and render-queue waits observe shutdown
- wake all Voodoo helper thread events during close, including render-not-full events and 4-thread render mode events
- document the Amiberry-local PCem shutdown delta next to the added Voodoo thread state
- harden uaenet pcap worker shutdown with a shared stop helper and pcap_breakloop()

## Context
Investigated from #2107. The Voodoo3/GREX log stops during reset after clipboard reset and before memory/PPC reset continues, which matches gfxboard teardown waiting on PCem Voodoo helper threads that previously had no exit condition.

This does not claim to fix the separate AGA/PIV OS4 black-screen/stall symptoms from the same issue.

## Testing
- git diff --check
- cmake --build build --parallel