### PR TITLE
Support derivative distro package setup

### DIFF
--- a/docs/linux-packages.md
+++ b/docs/linux-packages.md
@@ -21,7 +21,7 @@ After setup, install with `sudo apt install amiberry` (Debian/Ubuntu) or `sudo d
 
 ## Manual Installation — Ubuntu / Debian
 
-### Modern format (Ubuntu 24.04+, Debian 12+)
+### Modern format (Ubuntu 24.04+, Debian 13+)
 
 ```bash
 # Download GPG key
@@ -41,7 +41,7 @@ Signed-By: /usr/share/keyrings/amiberry-archive-keyring.gpg" \
 sudo apt update && sudo apt install amiberry
 ```
 
-### Legacy format (Ubuntu 22.04, or if DEB822 format is not supported)
+### Legacy format (Ubuntu 22.04, Debian 12, or if DEB822 format is not supported)
 
 ```bash
 # Download GPG key
@@ -89,16 +89,40 @@ sudo dnf update amiberry
 
 ## Supported Distributions
 
-| Distribution | Version | Architectures |
-|-------------|---------|---------------|
-| Ubuntu | 22.04 LTS (Jammy Jellyfish) | amd64 |
-| Ubuntu | 24.04 LTS (Noble Numbat) | amd64 |
-| Ubuntu | 25.10 (Plucky Puffin) | amd64, arm64 |
-| Debian | 12 (Bookworm) | amd64, arm64 |
-| Debian | 13 (Trixie) | amd64, arm64 |
-| Fedora | Latest | x86_64, aarch64 |
+| Distribution | Version | Repository suite | Architectures |
+|-------------|---------|------------------|---------------|
+| Ubuntu | 22.04 LTS (Jammy) | jammy | amd64 |
+| Ubuntu | 24.04 LTS (Noble) | noble | amd64 |
+| Ubuntu | 25.10 (Questing) | questing | amd64, arm64 |
+| Ubuntu | 26.04 LTS (Resolute) | resolute | amd64, arm64 |
+| Debian | 12 (Bookworm) | bookworm | amd64, arm64 |
+| Debian | 13 (Trixie) | trixie | amd64, arm64 |
+| Raspberry Pi OS | Bookworm, Trixie | bookworm, trixie | arm64 |
+| Fedora | 44 | rpm | x86_64, aarch64 |
 
-> **Note**: Raspberry Pi OS (64-bit) users can use the Debian Bookworm (arm64) package.
+The install script also maps compatible derivatives to the matching base suite:
+
+| Distribution | Version | Repository suite |
+|-------------|---------|------------------|
+| Linux Mint | 21.x | jammy |
+| Linux Mint | 22.x | noble |
+| LMDE | 6 | bookworm |
+| LMDE | 7 | trixie |
+| Elementary OS | 7 | jammy |
+| Elementary OS | 8 | noble |
+| Pop!_OS | 22.04 | jammy |
+| Pop!_OS | 24.04 | noble |
+| Zorin OS | 17 | jammy |
+| Zorin OS | 18 | noble |
+| Devuan | 5 | bookworm |
+| Devuan | 6 | trixie |
+| Parrot OS | 6 | bookworm |
+| Parrot OS | 7 | trixie |
+| SparkyLinux | 7 | bookworm |
+| SparkyLinux | 8 | trixie |
+
+For manual APT setup on derivatives, use the repository suite shown above instead
+of the derivative distribution codename.
 
 ---
 

--- a/packaging/repo/index.html
+++ b/packaging/repo/index.html
@@ -253,13 +253,18 @@
                         <td>apt</td>
                     </tr>
                     <tr>
-                        <td>Fedora</td>
-                        <td>42, 43, 44</td>
-                        <td>dnf</td>
+                        <td>Ubuntu derivatives</td>
+                        <td>Linux Mint 21.x/22.x, Elementary OS 7/8, Pop!_OS 22.04/24.04, Zorin OS 17/18</td>
+                        <td>apt</td>
                     </tr>
                     <tr>
-                        <td>RHEL / CentOS / Rocky / AlmaLinux</td>
-                        <td>8, 9</td>
+                        <td>Debian derivatives</td>
+                        <td>LMDE 6/7, Parrot OS 6/7, SparkyLinux 7/8, Devuan 5/6</td>
+                        <td>apt</td>
+                    </tr>
+                    <tr>
+                        <td>Fedora</td>
+                        <td>44</td>
                         <td>dnf</td>
                     </tr>
                 </tbody>
@@ -277,7 +282,7 @@
                             <code>sudo curl -fsSL https://packages.amiberry.com/gpg.key -o /usr/share/keyrings/amiberry-archive-keyring.gpg</code>
                         </div>
                     </li>
-                    <li>Add the repository to your sources (replace <code>jammy</code> with your release codename):
+                    <li>Add the repository to your sources (replace <code>jammy</code> with your supported repository suite):
                         <div class="code-block">
                             <code>echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/amiberry-archive-keyring.gpg] https://packages.amiberry.com/apt jammy main" | sudo tee /etc/apt/sources.list.d/amiberry.list</code>
                         </div>
@@ -292,7 +297,7 @@ sudo apt install amiberry</code>
             </div>
             
             <div class="manual-section">
-                <h3>Fedora / RHEL / CentOS / Rocky / AlmaLinux</h3>
+                <h3>Fedora</h3>
                 <ol>
                     <li>Download the repository configuration:
                         <div class="code-block">
@@ -329,7 +334,7 @@ sudo apt install amiberry</code>
         <section>
             <h2>Troubleshooting</h2>
             <div class="warning">
-                <strong>Repository not found?</strong> Make sure you've replaced the release codename (e.g., <code>jammy</code>, <code>bookworm</code>) with your actual distribution release. Run <code>lsb_release -cs</code> to find your codename.
+                <strong>Repository not found?</strong> Make sure you are using a supported repository suite (e.g., <code>jammy</code>, <code>noble</code>, <code>bookworm</code>, or <code>trixie</code>). Derivative distributions must use the matching Ubuntu or Debian base suite.
             </div>
             <div class="warning">
                 <strong>GPG signature verification failed?</strong> Ensure the GPG key was downloaded correctly and placed in <code>/usr/share/keyrings/amiberry-archive-keyring.gpg</code>.

--- a/packaging/repo/install.sh
+++ b/packaging/repo/install.sh
@@ -47,58 +47,70 @@ set_debian_suite() {
     esac
 }
 
-case "$ID" in
-    ubuntu)
-        set_ubuntu_suite "${VERSION_CODENAME:-}"
-        APT_VERSION_ID="${VERSION_ID:-$APT_VERSION_ID}"
-        ;;
-    debian|raspbian)
-        set_debian_suite "${VERSION_CODENAME:-}"
-        APT_VERSION_ID="${VERSION_ID:-$APT_VERSION_ID}"
-        ;;
-    devuan)
-        # Devuan is a Debian fork; map its codenames/version to the Debian
-        # equivalents so we can reuse the Debian repository suites.
-        case "${VERSION_CODENAME:-}" in
-            excalibur) set_debian_suite "trixie" ;;
-            daedalus)  set_debian_suite "bookworm" ;;
-            chimaera)  set_debian_suite "bullseye" ;;
-            *)         set_debian_suite "${VERSION_CODENAME:-}" ;;
+case " ${NAME:-} ${PRETTY_NAME:-} " in
+    *"Parrot"*)
+        case "${VERSION_ID:-}:${VERSION_CODENAME:-}" in
+            6*:*)  set_debian_suite "bookworm" ;;
+            7*:*)  set_debian_suite "trixie" ;;
+            *:lory) set_debian_suite "bookworm" ;;
         esac
         ;;
-    linuxmint)
-        if [ -n "${UBUNTU_CODENAME:-}" ]; then
-            set_ubuntu_suite "$UBUNTU_CODENAME"
-        else
+esac
+
+if [ -z "$APT_SUITE" ]; then
+    case "$ID" in
+        ubuntu)
+            set_ubuntu_suite "${VERSION_CODENAME:-}"
+            APT_VERSION_ID="${VERSION_ID:-$APT_VERSION_ID}"
+            ;;
+        debian|raspbian)
+            set_debian_suite "${VERSION_CODENAME:-}"
+            APT_VERSION_ID="${VERSION_ID:-$APT_VERSION_ID}"
+            ;;
+        devuan)
+            # Devuan is a Debian fork; map its codenames/version to the Debian
+            # equivalents so we can reuse the Debian repository suites.
+            case "${VERSION_CODENAME:-}" in
+                excalibur) set_debian_suite "trixie" ;;
+                daedalus)  set_debian_suite "bookworm" ;;
+                chimaera)  set_debian_suite "bullseye" ;;
+                *)         set_debian_suite "${VERSION_CODENAME:-}" ;;
+            esac
+            ;;
+        linuxmint)
+            if [ -n "${UBUNTU_CODENAME:-}" ]; then
+                set_ubuntu_suite "$UBUNTU_CODENAME"
+            else
+                case "${VERSION_ID:-}" in
+                    6*) set_debian_suite "bookworm" ;;
+                    7*) set_debian_suite "trixie" ;;
+                esac
+            fi
+            ;;
+        elementary|pop|zorin)
+            if [ -n "${UBUNTU_CODENAME:-}" ]; then
+                set_ubuntu_suite "$UBUNTU_CODENAME"
+            else
+                case "$ID:${VERSION_ID:-}" in
+                    elementary:7*|pop:22.04*|zorin:17*) set_ubuntu_suite "jammy" ;;
+                    elementary:8*|pop:24.04*|zorin:18*) set_ubuntu_suite "noble" ;;
+                esac
+            fi
+            ;;
+        parrot)
             case "${VERSION_ID:-}" in
                 6*) set_debian_suite "bookworm" ;;
                 7*) set_debian_suite "trixie" ;;
             esac
-        fi
-        ;;
-    elementary|pop|zorin)
-        if [ -n "${UBUNTU_CODENAME:-}" ]; then
-            set_ubuntu_suite "$UBUNTU_CODENAME"
-        else
-            case "$ID:${VERSION_ID:-}" in
-                elementary:7*|pop:22.04*|zorin:17*) set_ubuntu_suite "jammy" ;;
-                elementary:8*|pop:24.04*|zorin:18*) set_ubuntu_suite "noble" ;;
+            ;;
+        sparky)
+            case "${VERSION_ID:-}" in
+                7*) set_debian_suite "bookworm" ;;
+                8*) set_debian_suite "trixie" ;;
             esac
-        fi
-        ;;
-    parrot)
-        case "${VERSION_ID:-}" in
-            6*) set_debian_suite "bookworm" ;;
-            7*) set_debian_suite "trixie" ;;
-        esac
-        ;;
-    sparky)
-        case "${VERSION_ID:-}" in
-            7*) set_debian_suite "bookworm" ;;
-            8*) set_debian_suite "trixie" ;;
-        esac
-        ;;
-esac
+            ;;
+    esac
+fi
 
 if [ -z "$APT_SUITE" ] && [ -n "${UBUNTU_CODENAME:-}" ]; then
     set_ubuntu_suite "$UBUNTU_CODENAME"

--- a/packaging/repo/install.sh
+++ b/packaging/repo/install.sh
@@ -23,83 +23,169 @@ GPG_KEY_URL="${REPO_BASE}/gpg.key"
 GPG_ASC_URL="${REPO_BASE}/gpg.asc"
 GPG_KEYRING="/usr/share/keyrings/amiberry-archive-keyring.gpg"
 
-case "$ID" in
-    ubuntu|debian|raspbian|devuan)
-        echo "Detected ${PRETTY_NAME}"
+APT_FAMILY=""
+APT_SUITE=""
+APT_VERSION_ID="${VERSION_ID:-}"
 
-        # Devuan is a Debian fork; map its codenames/version to the Debian equivalents
-        # so we can reuse the Debian repository suites.
-        if [ "$ID" = "devuan" ]; then
-            case "$VERSION_CODENAME" in
-                excalibur) VERSION_CODENAME="trixie";  VERSION_ID="13" ;;
-                daedalus)  VERSION_CODENAME="bookworm"; VERSION_ID="12" ;;
-                chimaera)  VERSION_CODENAME="bullseye"; VERSION_ID="11" ;;
+set_ubuntu_suite() {
+    APT_FAMILY="ubuntu"
+    APT_SUITE="$1"
+    case "$APT_SUITE" in
+        jammy)    APT_VERSION_ID="22.04" ;;
+        noble)    APT_VERSION_ID="24.04" ;;
+        questing) APT_VERSION_ID="25.10" ;;
+        resolute) APT_VERSION_ID="26.04" ;;
+    esac
+}
+
+set_debian_suite() {
+    APT_FAMILY="debian"
+    APT_SUITE="$1"
+    case "$APT_SUITE" in
+        bookworm) APT_VERSION_ID="12" ;;
+        trixie)   APT_VERSION_ID="13" ;;
+    esac
+}
+
+case "$ID" in
+    ubuntu)
+        set_ubuntu_suite "${VERSION_CODENAME:-}"
+        APT_VERSION_ID="${VERSION_ID:-$APT_VERSION_ID}"
+        ;;
+    debian|raspbian)
+        set_debian_suite "${VERSION_CODENAME:-}"
+        APT_VERSION_ID="${VERSION_ID:-$APT_VERSION_ID}"
+        ;;
+    devuan)
+        # Devuan is a Debian fork; map its codenames/version to the Debian
+        # equivalents so we can reuse the Debian repository suites.
+        case "${VERSION_CODENAME:-}" in
+            excalibur) set_debian_suite "trixie" ;;
+            daedalus)  set_debian_suite "bookworm" ;;
+            chimaera)  set_debian_suite "bullseye" ;;
+            *)         set_debian_suite "${VERSION_CODENAME:-}" ;;
+        esac
+        ;;
+    linuxmint)
+        if [ -n "${UBUNTU_CODENAME:-}" ]; then
+            set_ubuntu_suite "$UBUNTU_CODENAME"
+        else
+            case "${VERSION_ID:-}" in
+                6*) set_debian_suite "bookworm" ;;
+                7*) set_debian_suite "trixie" ;;
             esac
         fi
-
-        # Check if codename is supported
-        case "$VERSION_CODENAME" in
-            jammy|noble|questing|resolute|bookworm|trixie)
-                ;;
-            *)
-                echo "Warning: ${VERSION_CODENAME} is not officially supported."
-                echo "You can still try to use the closest supported release."
-                ;;
-        esac
-        
-        # Install curl if not available
-        if ! command -v curl >/dev/null 2>&1; then
-            apt-get update -q && apt-get install -y -q curl
+        ;;
+    elementary|pop|zorin)
+        if [ -n "${UBUNTU_CODENAME:-}" ]; then
+            set_ubuntu_suite "$UBUNTU_CODENAME"
+        else
+            case "$ID:${VERSION_ID:-}" in
+                elementary:7*|pop:22.04*|zorin:17*) set_ubuntu_suite "jammy" ;;
+                elementary:8*|pop:24.04*|zorin:18*) set_ubuntu_suite "noble" ;;
+            esac
         fi
-        
-        # Download and install GPG key
-        echo "Installing GPG signing key..."
-        curl -fsSL "$GPG_KEY_URL" -o "$GPG_KEYRING"
-        chmod 644 "$GPG_KEYRING"
-        
-        # Get architecture
-        ARCH=$(dpkg --print-architecture)
-        
-        # Determine which sources format to use
-        # DEB822 (.sources) for Ubuntu 24.04+ and Debian 13+ (trixie), legacy (.list) for older
-        USE_DEB822=0
-        case "$ID" in
-            ubuntu)
-                MAJOR=$(echo "${VERSION_ID:-0}" | cut -d. -f1)
-                [ "${MAJOR:-0}" -ge 24 ] && USE_DEB822=1
-                ;;
-            debian|raspbian|devuan)
-                MAJOR=$(echo "${VERSION_ID:-0}" | cut -d. -f1)
-                [ "${MAJOR:-0}" -ge 13 ] && USE_DEB822=1
-                ;;
+        ;;
+    parrot)
+        case "${VERSION_ID:-}" in
+            6*) set_debian_suite "bookworm" ;;
+            7*) set_debian_suite "trixie" ;;
         esac
+        ;;
+    sparky)
+        case "${VERSION_ID:-}" in
+            7*) set_debian_suite "bookworm" ;;
+            8*) set_debian_suite "trixie" ;;
+        esac
+        ;;
+esac
+
+if [ -z "$APT_SUITE" ] && [ -n "${UBUNTU_CODENAME:-}" ]; then
+    set_ubuntu_suite "$UBUNTU_CODENAME"
+fi
+
+if [ -z "$APT_SUITE" ]; then
+    case "${VERSION_CODENAME:-}" in
+        jammy|noble|questing|resolute)
+            case " ${ID_LIKE:-} " in
+                *" ubuntu "*|*" debian "*) set_ubuntu_suite "$VERSION_CODENAME" ;;
+            esac
+            ;;
+        bookworm|trixie)
+            case " ${ID_LIKE:-} " in
+                *" debian "*|*" ubuntu "*) set_debian_suite "$VERSION_CODENAME" ;;
+            esac
+            ;;
+    esac
+fi
+
+if [ -n "$APT_SUITE" ]; then
+    echo "Detected ${PRETTY_NAME}"
+    echo "Using ${APT_SUITE} repository suite"
+
+    # Check if codename is supported
+    case "$APT_SUITE" in
+        jammy|noble|questing|resolute|bookworm|trixie)
+            ;;
+        *)
+            echo "Warning: ${APT_SUITE} is not officially supported."
+            echo "You can still try to use the closest supported release."
+            ;;
+    esac
         
-        if [ "$USE_DEB822" = "1" ]; then
-            # Modern DEB822 format
-            cat > /etc/apt/sources.list.d/amiberry.sources <<EOF
+    # Install curl if not available
+    if ! command -v curl >/dev/null 2>&1; then
+        apt-get update -q && apt-get install -y -q curl
+    fi
+        
+    # Download and install GPG key
+    echo "Installing GPG signing key..."
+    curl -fsSL "$GPG_KEY_URL" -o "$GPG_KEYRING"
+    chmod 644 "$GPG_KEYRING"
+        
+    # Get architecture
+    ARCH=$(dpkg --print-architecture)
+        
+    # Determine which sources format to use
+    # DEB822 (.sources) for Ubuntu 24.04+ and Debian 13+ (trixie), legacy (.list) for older
+    USE_DEB822=0
+    case "$APT_FAMILY" in
+        ubuntu)
+            MAJOR=$(echo "${APT_VERSION_ID:-0}" | cut -d. -f1)
+            [ "${MAJOR:-0}" -ge 24 ] && USE_DEB822=1
+            ;;
+        debian)
+            MAJOR=$(echo "${APT_VERSION_ID:-0}" | cut -d. -f1)
+            [ "${MAJOR:-0}" -ge 13 ] && USE_DEB822=1
+            ;;
+    esac
+        
+    if [ "$USE_DEB822" = "1" ]; then
+        # Modern DEB822 format
+        cat > /etc/apt/sources.list.d/amiberry.sources <<EOF
 Types: deb
 URIs: ${REPO_BASE}/apt
-Suites: ${VERSION_CODENAME}
+Suites: ${APT_SUITE}
 Components: main
 Architectures: ${ARCH}
 Signed-By: ${GPG_KEYRING}
 EOF
-            echo "Created /etc/apt/sources.list.d/amiberry.sources"
-        else
-            # Legacy one-line format
-            echo "deb [arch=${ARCH} signed-by=${GPG_KEYRING}] ${REPO_BASE}/apt ${VERSION_CODENAME} main" \
-                > /etc/apt/sources.list.d/amiberry.list
-            echo "Created /etc/apt/sources.list.d/amiberry.list"
-        fi
+        echo "Created /etc/apt/sources.list.d/amiberry.sources"
+    else
+        # Legacy one-line format
+        echo "deb [arch=${ARCH} signed-by=${GPG_KEYRING}] ${REPO_BASE}/apt ${APT_SUITE} main" \
+            > /etc/apt/sources.list.d/amiberry.list
+        echo "Created /etc/apt/sources.list.d/amiberry.list"
+    fi
         
-        # Update and install
-        echo "Updating package lists..."
-        apt-get update
-        echo ""
-        echo "Repository configured! Install Amiberry with:"
-        echo "  sudo apt install amiberry"
-        ;;
-    
+    # Update and install
+    echo "Updating package lists..."
+    apt-get update
+    echo ""
+    echo "Repository configured! Install Amiberry with:"
+    echo "  sudo apt install amiberry"
+else
+    case "$ID" in
     fedora|rhel|centos|rocky|almalinux)
         echo "Detected ${PRETTY_NAME}"
         
@@ -124,11 +210,14 @@ EOF
     *)
         echo "Error: Unsupported distribution: $ID"
         echo "Supported: Ubuntu (22.04+), Debian (12+), Devuan (5+), Fedora"
+        echo "Also supported through compatible suites: Linux Mint, LMDE,"
+        echo "Elementary OS, Pop!_OS, Zorin OS, Parrot OS, and SparkyLinux"
         echo ""
         echo "For manual installation, visit: https://packages.amiberry.com"
         exit 1
         ;;
-esac
+    esac
+fi
 
 echo ""
 echo "GPG key fingerprint: D74D52525340C442A4F8B657A12B57C04E1FE282"


### PR DESCRIPTION
## Summary
- map Ubuntu/Debian derivative distro IDs to existing supported repository suites in the install script
- document derivative suite mappings on the package repo page and Linux package docs
- narrow RPM-family docs to Fedora where the current package dependencies are known to work

Fixes #2110

## Testing
- sh -n packaging/repo/install.sh
- git diff --check
- resolver smoke tests for Mint, LMDE, Elementary OS, Pop!_OS, Zorin OS, Parrot OS, SparkyLinux, and Devuan mappings