### PR TITLE
Fix PPC QEMU JIT flush slowdown

### DIFF
--- a/src/include/uae/ppc.h
+++ b/src/include/uae/ppc.h
@@ -108,7 +108,6 @@ void PPCCALL ppc_cpu_stop(void);
 void PPCCALL ppc_cpu_atomic_raise_ext_exception(void);
 void PPCCALL ppc_cpu_atomic_cancel_ext_exception(void);
 void PPCCALL ppc_cpu_map_memory(PPCMemoryRegion *regions, int count);
-void PPCCALL ppc_cpu_flush_jit(void);
 void PPCCALL ppc_cpu_set_pc(int cpu, uint32_t value);
 void PPCCALL ppc_cpu_run_continuous(void);
 void PPCCALL ppc_cpu_run_single(int count);

--- a/src/ppc/ppc.cpp
+++ b/src/ppc/ppc.cpp
@@ -203,7 +203,6 @@ typedef void (PPCCALL *ppc_cpu_pause_function)(int pause);
 typedef bool (PPCCALL *ppc_cpu_check_state_function)(int state);
 typedef void (PPCCALL *ppc_cpu_set_state_function)(int state);
 typedef void (PPCCALL *ppc_cpu_reset_function)(void);
-typedef void (PPCCALL *ppc_cpu_flush_jit_function)(void);
 
 /* Function pointers to active PPC implementation */
 
@@ -229,7 +228,6 @@ static struct impl {
 	ppc_cpu_check_state_function check_state;
 	ppc_cpu_set_state_function set_state;
 	ppc_cpu_reset_function reset;
-	ppc_cpu_flush_jit_function flush_jit;
 	qemu_uae_ppc_in_cpu_thread_function in_cpu_thread;
 	qemu_uae_ppc_external_interrupt_function external_interrupt;
 	qemu_uae_lock_function lock;
@@ -311,10 +309,6 @@ static bool load_qemu_implementation(void)
 	}
 	//impl.free = (ppc_cpu_free_function) uae_dlsym(handle, "ppc_cpu_free");
 	//impl.stop = (ppc_cpu_stop_function) uae_dlsym(handle, "ppc_cpu_stop");
-	impl.flush_jit = (ppc_cpu_flush_jit_function) uae_dlsym(handle, "ppc_cpu_flush_jit");
-	if (impl.flush_jit) {
-		write_log("PPC: Imported optional ppc_cpu_flush_jit\n");
-	}
 
 	// FIXME: not needed, handled internally by uae_dlopen_plugin
 	// uae_dlopen_patch_common(handle);
@@ -698,9 +692,6 @@ static int ppc_thread(void *v)
 
 void uae_ppc_execute_check(void)
 {
-	if (using_qemu() && impl.flush_jit) {
-		impl.flush_jit();
-	}
 	if (ppc_spinlock_waiting) {
 		uae_ppc_spinlock_release();
 		uae_ppc_spinlock_get();
@@ -709,9 +700,6 @@ void uae_ppc_execute_check(void)
 
 void uae_ppc_execute_quick()
 {
-	if (using_qemu() && impl.flush_jit) {
-		impl.flush_jit();
-	}
 	uae_ppc_spinlock_release();
 	sleep_millis_main(1);
 	uae_ppc_spinlock_get();


### PR DESCRIPTION
## Summary

Removes Amiberry's host-side use of the optional QEMU PPC `ppc_cpu_flush_jit` hook.

The hook was being called from `uae_ppc_execute_check()` and `uae_ppc_execute_quick()`, which are hot handoff paths during PPC emulation. The QEMU-UAE plugin throttles the hook internally, but it can still force TCG translation block flushes up to once every 10ms. That repeatedly invalidates translated PPC code during OS4 boot and causes a large performance regression compared with WinUAE, which does not call this hook.

## Root cause

The hook was added recently to address PPC cache synchronization, but QEMU already handles guest cache invalidation through its normal mechanisms. Calling a host-side full JIT flush from the emulator handoff path is much broader than needed and dominates boot time.

The plugin side does still export `ppc_cpu_flush_jit` from `amiberry-qemu-uae` (`Export PPC JIT flush hook`), but this PR only removes Amiberry's import and hot-path use of it. Removing the unused plugin export can be handled separately in that repository.

Fixes #2103 

## Validation

Tested with the same FlowerPot OS4 config and QEMU-UAE plugin:

- Before: `SetSwitch() - Picasso96 1280x1024x32...` at `57.321s`
- After: `SetSwitch() - Picasso96 1280x1024x32...` at `15.363s`
- Before: `uaegfx.card 3.4 init` at `41.494s`
- After: `uaegfx.card 3.4 init` at `13.977s`

Local checks:

- `git diff --check`
- `cmake --build build --parallel --target amiberry`
