### PR TITLE
Bump QEMU-UAE plugin release tag

### DIFF
--- a/.github/scripts/download-qemu-uae-plugin.ps1
+++ b/.github/scripts/download-qemu-uae-plugin.ps1
@@ -15,7 +15,7 @@ if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
 }
 
 $repo = if ([string]::IsNullOrWhiteSpace($env:QEMU_UAE_RELEASE_REPO)) { "BlitterStudio/amiberry-qemu-uae" } else { $env:QEMU_UAE_RELEASE_REPO }
-$tag = if ([string]::IsNullOrWhiteSpace($env:QEMU_UAE_RELEASE_TAG)) { "v11.0.1-amiberry.5" } else { $env:QEMU_UAE_RELEASE_TAG }
+$tag = if ([string]::IsNullOrWhiteSpace($env:QEMU_UAE_RELEASE_TAG)) { "v11.0.1-amiberry.6" } else { $env:QEMU_UAE_RELEASE_TAG }
 $downloadDir = Join-Path $OutputDirectory "download"
 $extractDir = Join-Path $OutputDirectory "extract"
 

--- a/.github/scripts/download-qemu-uae-plugin.sh
+++ b/.github/scripts/download-qemu-uae-plugin.sh
@@ -8,7 +8,7 @@ fi
 
 asset="$1"
 repo="${QEMU_UAE_RELEASE_REPO:-BlitterStudio/amiberry-qemu-uae}"
-tag="${QEMU_UAE_RELEASE_TAG:-v11.0.1-amiberry.5}"
+tag="${QEMU_UAE_RELEASE_TAG:-v11.0.1-amiberry.6}"
 output_dir="${2:-${GITHUB_WORKSPACE:-$PWD}/.qemu-uae-plugin}"
 download_dir="$output_dir/download"
 extract_dir="$output_dir/extract"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   QEMU_UAE_RELEASE_REPO: BlitterStudio/amiberry-qemu-uae
-  QEMU_UAE_RELEASE_TAG: v11.0.1-amiberry.5
+  QEMU_UAE_RELEASE_TAG: v11.0.1-amiberry.6
   GH_TOKEN: ${{ github.token }}
 
 jobs:


### PR DESCRIPTION
## Summary

Updates Amiberry's QEMU-UAE plugin release pin from `v11.0.1-amiberry.5` to `v11.0.1-amiberry.6`.

The new plugin release removes the unused exported `ppc_cpu_flush_jit` hook from the QEMU-UAE patch deck. Amiberry no longer imports or calls this hook after the PPC boot performance fix, so the plugin export is now dead ABI surface.

Updated the aligned tag defaults in:

- `.github/workflows/c-cpp.yml`
- `.github/scripts/download-qemu-uae-plugin.sh`
- `.github/scripts/download-qemu-uae-plugin.ps1`

## Validation

Plugin repository release:

- `v11.0.1-amiberry.6` CI completed successfully across Linux, macOS, and Windows.
- GitHub Release was published with expected assets:
  - `qemu-uae-linux-aarch64.tar.xz`
  - `qemu-uae-linux-x86_64.tar.xz`
  - `qemu-uae-macos-universal.zip`
  - `qemu-uae-windows-arm64.zip`
  - `qemu-uae-windows-x64.zip`
  - `SHA256SUMS`

Local FlowerPot check before publishing the release:

- Built Amiberry against the updated local plugin artifact.
- Launched `FlowerPot.uae` with QEMU PPC enabled.
- QEMU-UAE loaded successfully.
- `ppc_cpu_flush_jit` was not imported or logged.
- RTG Workbench switch reached: `SetSwitch() - Picasso96 1280x1024x32...` at `15.356s`.

Downloader check after release publication:

- `.github/scripts/download-qemu-uae-plugin.sh qemu-uae-macos-universal.zip ...`
- SHA256 verification succeeded for the `.6` macOS universal asset.
- Downloaded dylib exports `qemu_uae_version`, `ppc_cpu_init`, `ppc_cpu_map_memory`, and `ppc_cpu_reset`.
- Downloaded dylib does not export `ppc_cpu_flush_jit`.

Other checks:

- `bash -n .github/scripts/download-qemu-uae-plugin.sh`
- `git diff --check`

PowerShell parser check was skipped locally because `pwsh` is not installed on this machine.
