### PR TITLE
Android: Integer Scaling toggle + Hard Drives in Storage settings

### DIFF
--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigGenerator.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigGenerator.kt
@@ -85,6 +85,8 @@ object ConfigGenerator {
 		sb.appendLine("gfx_height=${settings.gfxHeight}")
 		sb.appendLine("amiberry.gfx_correct_aspect=${settings.correctAspect.toCfg()}")
 		sb.appendLine("amiberry.gfx_auto_crop=${settings.autoCrop.toCfg()}")
+		sb.appendLine("scaling_method=${settings.scalingMethod}")
+		sb.appendLine("gfx_autoresolution=${settings.gfxAutoresolution}")
 
 		// Input
 		sb.appendLine("joyport0=${settings.joyport0}")

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigGenerator.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigGenerator.kt
@@ -75,6 +75,14 @@ object ConfigGenerator {
 			sb.appendLine("cdimage0=${settings.cdImage}")
 		}
 
+		// Hard drives (hardfiles on the UAE controller)
+		settings.hardDrives.forEachIndexed { index, hd ->
+			if (hd.path.isNotEmpty()) {
+				val access = if (hd.readOnly) "ro" else "rw"
+				sb.appendLine("hardfile2=$access,:${hd.path},0,0,0,512,${hd.bootPriority},,uae$index")
+			}
+		}
+
 		// Sound
 		sb.appendLine("sound_output=${settings.soundOutput}")
 		sb.appendLine("sound_frequency=${settings.soundFreq}")

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigParser.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigParser.kt
@@ -53,6 +53,11 @@ object ConfigParser {
 		val kvPairs = mutableMapOf<String, String>()
 		val unknownLines = mutableListOf<String>()
 		val hardDrives = mutableListOf<HardDrive>()
+		// UAE controller units of the simple hardfile2 lines we adopted into hardDrives.
+		val adoptedControllers = mutableSetOf<String>()
+		// uaehf=hdf lines, deferred until the whole file is scanned: a uaehf only duplicates
+		// a hardfile2 mount when we actually adopted a hardfile2 on the same controller.
+		val uaehfHdfLines = mutableListOf<Pair<String, String?>>()
 
 		for (line in lines) {
 			val trimmed = line.trim()
@@ -70,14 +75,24 @@ object ConfigParser {
 			when {
 				key == "hardfile2" -> {
 					val drive = parseHardfile2(value)
-					if (drive != null) hardDrives.add(drive)
-					else unknownLines.add(line)
+					if (drive != null) {
+						hardDrives.add(drive)
+						hardfile2Controller(value)?.let { adoptedControllers.add(it) }
+					} else {
+						unknownLines.add(line)
+					}
 				}
-				isRedundantUaehfHdf(key, value) -> {
-					// Redundant twin of hardfile2 for HDF mounts — drop to avoid double-mount.
-				}
+				isUaehfHdf(key, value) -> uaehfHdfLines.add(line to uaehfController(value))
 				key in knownKeys -> kvPairs[key] = value
 				else -> unknownLines.add(line)
+			}
+		}
+
+		// Drop a uaehf=hdf line only when it twins a hardfile2 we adopted (same controller);
+		// otherwise preserve it verbatim so standalone/legacy mounts survive a save.
+		for ((line, controller) in uaehfHdfLines) {
+			if (controller == null || controller !in adoptedControllers) {
+				unknownLines.add(line)
 			}
 		}
 
@@ -180,24 +195,41 @@ object ConfigParser {
 	}
 
 	private val uaehfKeyRegex = Regex("""uaehf[0-7]""")
+	private val uaeControllerRegex = Regex("""uae\d+""")
 
-	/** uaehf<n>=hdf,... duplicates a hardfile2 line; recognise so we can drop it. */
-	private fun isRedundantUaehfHdf(key: String, value: String): Boolean =
+	/** A uaehf<n>=hdf,... line (the twin native also writes for an HDF mount). */
+	private fun isUaehfHdf(key: String, value: String): Boolean =
 		uaehfKeyRegex.matches(key) && value.trimStart().startsWith("hdf,")
 
+	/** UAE controller unit (e.g. "uae0") of an adopted simple hardfile2 line. */
+	private fun hardfile2Controller(value: String): String? =
+		value.split(',').getOrNull(8)?.trim()?.takeIf { uaeControllerRegex.matches(it) }
+
+	/** UAE controller unit of a uaehf=hdf line: one of its fields holds a `uae<n>` token. */
+	private fun uaehfController(value: String): String? =
+		value.split(',').map { it.trim() }.firstOrNull { uaeControllerRegex.matches(it) }
+
 	/**
-	 * Parse a `hardfile2` value of the simple UAE-controller RDB form
-	 * `rw,:/path,0,0,0,512,0,,uae0`. Returns null for forms we don't manage
-	 * (non-UAE controller, missing path) so the caller preserves them verbatim.
+	 * Parse a `hardfile2` value ONLY when it is the exact simple UAE-controller RDB form
+	 * this app generates: `<ro|rw>,:<path>,0,0,0,512,<bootpri>,,uae<n>`. Any other form
+	 * (custom geometry/blocksize, an explicit filesystem, a device name, extra trailing
+	 * fields/flags, or a non-UAE controller) returns null so the caller preserves the line
+	 * verbatim — otherwise those mount parameters would be lost on a parse/save round trip.
 	 */
 	private fun parseHardfile2(value: String): HardDrive? {
 		val parts = value.split(',')
-		if (parts.size < 9) return null
-		if (!parts[8].trim().startsWith("uae")) return null
-		val path = parts[1].substringAfter(':', "").trim()
+		if (parts.size != 9) return null
+		val access = parts[0].trim()
+		if (!access.equals("ro", ignoreCase = true) && !access.equals("rw", ignoreCase = true)) return null
+		if (!parts[1].startsWith(":")) return null                       // empty device name only
+		if (parts[2].trim() != "0" || parts[3].trim() != "0" ||
+			parts[4].trim() != "0" || parts[5].trim() != "512") return null  // RDB / auto geometry
+		if (parts[7].trim().isNotEmpty()) return null                    // no explicit filesystem
+		if (!uaeControllerRegex.matches(parts[8].trim())) return null
+		val path = parts[1].substring(1).trim()
 		if (path.isEmpty()) return null
-		val readOnly = parts[0].trim().equals("ro", ignoreCase = true)
-		val bootPriority = parts[6].trim().toIntOrNull() ?: 0
+		val bootPriority = parts[6].trim().toIntOrNull() ?: return null
+		val readOnly = access.equals("ro", ignoreCase = true)
 		return HardDrive(path = path, readOnly = readOnly, bootPriority = bootPriority)
 	}
 

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigParser.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigParser.kt
@@ -3,6 +3,7 @@ package com.blitterstudio.amiberry.data
 import android.util.Log
 import com.blitterstudio.amiberry.data.model.AmigaModel
 import com.blitterstudio.amiberry.data.model.EmulatorSettings
+import com.blitterstudio.amiberry.data.model.HardDrive
 import java.io.File
 import java.io.IOException
 
@@ -51,6 +52,7 @@ object ConfigParser {
 		}
 		val kvPairs = mutableMapOf<String, String>()
 		val unknownLines = mutableListOf<String>()
+		val hardDrives = mutableListOf<HardDrive>()
 
 		for (line in lines) {
 			val trimmed = line.trim()
@@ -65,20 +67,27 @@ object ConfigParser {
 			val key = trimmed.substring(0, eqIndex).trim()
 			val value = trimmed.substring(eqIndex + 1).trim()
 
-			if (key in knownKeys) {
-				kvPairs[key] = value
-			} else {
-				unknownLines.add(line)
+			when {
+				key == "hardfile2" -> {
+					val drive = parseHardfile2(value)
+					if (drive != null) hardDrives.add(drive)
+					else unknownLines.add(line)
+				}
+				isRedundantUaehfHdf(key, value) -> {
+					// Redundant twin of hardfile2 for HDF mounts — drop to avoid double-mount.
+				}
+				key in knownKeys -> kvPairs[key] = value
+				else -> unknownLines.add(line)
 			}
 		}
 
-		val settings = buildSettings(kvPairs)
+		val settings = buildSettings(kvPairs, hardDrives)
 		val description = kvPairs["config_description"] ?: ""
 
 		return ParsedConfig(settings, unknownLines, description)
 	}
 
-	private fun buildSettings(kv: Map<String, String>): EmulatorSettings {
+	private fun buildSettings(kv: Map<String, String>, hardDrives: List<HardDrive>): EmulatorSettings {
 		return EmulatorSettings(
 			baseModel = guessModel(kv),
 			cpuModel = kv["cpu_model"]?.toIntOrNull() ?: 68000,
@@ -113,6 +122,7 @@ object ConfigParser {
 			floppy3Type = kv["floppy3type"]?.toIntOrNull() ?: -1,
 
 			cdImage = kv["cdimage0"] ?: "",
+			hardDrives = hardDrives,
 
 			soundOutput = kv["sound_output"] ?: "exact",
 			soundFreq = kv["sound_frequency"]?.toIntOrNull() ?: 44100,
@@ -167,6 +177,28 @@ object ConfigParser {
 			// OCS with 512KB chip + 512KB slow = A500 (or A2000), default A500
 			else -> AmigaModel.A500
 		}
+	}
+
+	private val uaehfKeyRegex = Regex("""uaehf[0-7]""")
+
+	/** uaehf<n>=hdf,... duplicates a hardfile2 line; recognise so we can drop it. */
+	private fun isRedundantUaehfHdf(key: String, value: String): Boolean =
+		uaehfKeyRegex.matches(key) && value.trimStart().startsWith("hdf,")
+
+	/**
+	 * Parse a `hardfile2` value of the simple UAE-controller RDB form
+	 * `rw,:/path,0,0,0,512,0,,uae0`. Returns null for forms we don't manage
+	 * (non-UAE controller, missing path) so the caller preserves them verbatim.
+	 */
+	private fun parseHardfile2(value: String): HardDrive? {
+		val parts = value.split(',')
+		if (parts.size < 9) return null
+		if (!parts[8].trim().startsWith("uae")) return null
+		val path = parts[1].substringAfter(':', "").trim()
+		if (path.isEmpty()) return null
+		val readOnly = parts[0].trim().equals("ro", ignoreCase = true)
+		val bootPriority = parts[6].trim().toIntOrNull() ?: 0
+		return HardDrive(path = path, readOnly = readOnly, bootPriority = bootPriority)
 	}
 
 	private fun String?.toBool(default: Boolean): Boolean {

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigParser.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigParser.kt
@@ -31,6 +31,7 @@ object ConfigParser {
 		"sound_output", "sound_frequency", "sound_channels",
 		"gfx_width", "gfx_height", "gfx_correct_aspect", "gfx_auto_crop",
 		"amiberry.gfx_correct_aspect", "amiberry.gfx_auto_crop",
+		"scaling_method", "gfx_autoresolution",
 		"joyport0", "joyport1",
 		"amiberry.onscreen_joystick", "amiberry.vkbd_enabled", "input.default_osk",
 		"amiberry.android_joyport1",
@@ -121,6 +122,8 @@ object ConfigParser {
 			gfxHeight = kv["gfx_height"]?.toIntOrNull() ?: 568,
 			correctAspect = (kv["amiberry.gfx_correct_aspect"] ?: kv["gfx_correct_aspect"]).toBool(true),
 			autoCrop = (kv["amiberry.gfx_auto_crop"] ?: kv["gfx_auto_crop"]).toBool(false),
+			scalingMethod = kv["scaling_method"]?.toIntOrNull() ?: -1,
+			gfxAutoresolution = kv["gfx_autoresolution"]?.toIntOrNull() ?: 0,
 
 			joyport0 = kv["joyport0"] ?: "mouse",
 			// Round-trip: prefer the explicit Android joyport1 key if present,

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettings.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettings.kt
@@ -57,6 +57,8 @@ data class EmulatorSettings(
 	val gfxHeight: Int = 568,
 	val correctAspect: Boolean = true,
 	val autoCrop: Boolean = false,
+	val scalingMethod: Int = -1,        // -1 Auto, 0 Nearest, 1 Linear, 2 Integer
+	val gfxAutoresolution: Int = 0,     // 0 Disabled, 1 Always On
 
 	// Input
 	val joyport0: String = "mouse",

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettings.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettings.kt
@@ -61,7 +61,7 @@ data class EmulatorSettings(
 	val correctAspect: Boolean = true,
 	val autoCrop: Boolean = false,
 	val scalingMethod: Int = -1,        // -1 Auto, 0 Nearest, 1 Linear, 2 Integer
-	val gfxAutoresolution: Int = 0,     // 0 Disabled, 1 Always On
+	val gfxAutoresolution: Int = 0,     // 0 Disabled, 1 Always On, 10/33/66 = % (raw native value)
 
 	// Input
 	val joyport0: String = "mouse",

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettings.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettings.kt
@@ -47,6 +47,9 @@ data class EmulatorSettings(
 	// CD
 	val cdImage: String = "",
 
+	// Hard drives (hardfiles)
+	val hardDrives: List<HardDrive> = emptyList(),
+
 	// Sound
 	val soundOutput: String = "exact",  // none, interrupts, normal, exact
 	val soundFreq: Int = 44100,

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/HardDrive.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/HardDrive.kt
@@ -1,0 +1,11 @@
+package com.blitterstudio.amiberry.data.model
+
+/**
+ * A hardfile (.hdf/.hdi/.vhd) mounted as an Amiga hard drive on the UAE
+ * controller. Maps to a `hardfile2=` line in the .uae config.
+ */
+data class HardDrive(
+	val path: String,
+	val readOnly: Boolean = false,
+	val bootPriority: Int = 0
+)

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/DisplayTab.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/DisplayTab.kt
@@ -112,6 +112,17 @@ fun DisplayTab(viewModel: SettingsViewModel) {
 					viewModel.updateSettings { s -> s.copy(autoCrop = it) }
 				}
 			)
+			SwitchRow(
+				label = stringResource(R.string.settings_display_integer_scaling),
+				checked = settings.scalingMethod == 2 && settings.gfxAutoresolution == 1,
+				onCheckedChange = { on ->
+					viewModel.updateSettings { s ->
+						if (on) s.copy(scalingMethod = 2, gfxAutoresolution = 1)
+						else s.copy(scalingMethod = -1, gfxAutoresolution = 0)
+					}
+				},
+				supportingText = stringResource(R.string.settings_display_integer_scaling_desc)
+			)
 			}
 		}
 

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/StorageTab.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/StorageTab.kt
@@ -13,11 +13,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Album
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Eject
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.SaveAlt
+import androidx.compose.material.icons.filled.Storage
+import androidx.compose.ui.text.input.KeyboardType
+import com.blitterstudio.amiberry.data.model.HardDrive
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
@@ -68,6 +74,7 @@ fun StorageTab(
 	val roms by viewModel.availableRoms.collectAsState()
 	val floppies by viewModel.availableFloppies.collectAsState()
 	val cds by viewModel.availableCds.collectAsState()
+	val hardDrives by viewModel.availableHardDrives.collectAsState()
 	val importGuard = rememberImportInFlightGuard()
 	val importInProgress = importGuard.isImporting
 
@@ -208,6 +215,59 @@ fun StorageTab(
 						onSelect = { viewModel.updateSettings { s -> s.copy(cdImage = it) } },
 						onClear = { viewModel.updateSettings { s -> s.copy(cdImage = "") } }
 					)
+				}
+			}
+		}
+
+		// Hard drives
+		OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+			Column(modifier = Modifier.padding(16.dp)) {
+				Row(verticalAlignment = Alignment.CenterVertically) {
+					Icon(Icons.Default.Storage, contentDescription = null, modifier = Modifier.size(20.dp))
+					Spacer(modifier = Modifier.width(8.dp))
+					Text(stringResource(R.string.settings_storage_hard_drives_title), style = MaterialTheme.typography.titleMedium)
+				}
+				Spacer(modifier = Modifier.height(8.dp))
+
+				settings.hardDrives.forEachIndexed { index, drive ->
+					HardDriveRow(
+						index = index,
+						drive = drive,
+						files = hardDrives,
+						onPathChange = { newPath ->
+							viewModel.updateSettings { s ->
+								s.copy(hardDrives = s.hardDrives.updatedAt(index) { it.copy(path = newPath) })
+							}
+						},
+						onReadOnlyChange = { ro ->
+							viewModel.updateSettings { s ->
+								s.copy(hardDrives = s.hardDrives.updatedAt(index) { it.copy(readOnly = ro) })
+							}
+						},
+						onBootPriorityChange = { bp ->
+							viewModel.updateSettings { s ->
+								s.copy(hardDrives = s.hardDrives.updatedAt(index) { it.copy(bootPriority = bp) })
+							}
+						},
+						onRemove = {
+							viewModel.updateSettings { s ->
+								s.copy(hardDrives = s.hardDrives.removedAt(index))
+							}
+						},
+						context = context,
+						importGuard = importGuard,
+						importInProgress = importInProgress,
+						onImportResult = onImportResult
+					)
+					Spacer(modifier = Modifier.height(8.dp))
+				}
+
+				TextButton(onClick = {
+					viewModel.updateSettings { s -> s.copy(hardDrives = s.hardDrives + HardDrive(path = "")) }
+				}) {
+					Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+					Spacer(modifier = Modifier.width(4.dp))
+					Text(stringResource(R.string.settings_storage_add_hard_drive))
 				}
 			}
 		}
@@ -385,5 +445,101 @@ private fun FloppyDriveRow(
 				)
 			}
 		}
+	}
+}
+
+private fun List<HardDrive>.updatedAt(index: Int, transform: (HardDrive) -> HardDrive): List<HardDrive> =
+	mapIndexed { i, hd -> if (i == index) transform(hd) else hd }
+
+private fun List<HardDrive>.removedAt(index: Int): List<HardDrive> =
+	filterIndexed { i, _ -> i != index }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HardDriveRow(
+	index: Int,
+	drive: HardDrive,
+	files: List<AmigaFile>,
+	onPathChange: (String) -> Unit,
+	onReadOnlyChange: (Boolean) -> Unit,
+	onBootPriorityChange: (Int) -> Unit,
+	onRemove: () -> Unit,
+	context: android.content.Context,
+	importGuard: ImportInFlightGuard,
+	importInProgress: Boolean,
+	onImportResult: (FileManager.ImportResult) -> Unit
+) {
+	val scope = rememberCoroutineScope()
+
+	Column(modifier = Modifier.fillMaxWidth()) {
+		Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+			Text(
+				stringResource(R.string.settings_storage_hard_drive_label, index),
+				style = MaterialTheme.typography.labelMedium,
+				modifier = Modifier.weight(1f)
+			)
+			IconButton(onClick = onRemove) {
+				Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.settings_storage_remove_hard_drive))
+			}
+		}
+
+		FileDropdown(
+			label = stringResource(R.string.settings_storage_hardfile_label),
+			files = files,
+			selectedPath = drive.path,
+			onSelect = onPathChange,
+			onClear = { onPathChange("") }
+		)
+
+		val importLauncher = rememberLauncherForActivityResult(
+			ActivityResultContracts.OpenDocument()
+		) { uri ->
+			uri?.let {
+				scope.launchImportGuarded(importGuard) {
+					val result = withContext(Dispatchers.IO) {
+						FileManager.importFileWithResult(context, it, FileCategory.HARD_DRIVES).also { importResult ->
+							if (importResult is FileManager.ImportResult.Imported) {
+								FileRepository.getInstance(context).rescanCategory(FileCategory.HARD_DRIVES)
+							}
+						}
+					}
+					if (result is FileManager.ImportResult.Imported) onPathChange(result.path)
+					onImportResult(result)
+				}
+			}
+		}
+		TextButton(
+			onClick = { importLauncher.launch(FilePickerFilters.mimeTypesFor(FileCategory.HARD_DRIVES)) },
+			enabled = !importInProgress
+		) {
+			if (importInProgress) {
+				CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+				Spacer(modifier = Modifier.width(4.dp))
+			}
+			Text(
+				stringResource(
+					if (importInProgress) R.string.action_importing else R.string.settings_storage_import_hardfile
+				)
+			)
+		}
+
+		SwitchRow(
+			label = stringResource(R.string.settings_storage_hard_drive_read_only),
+			checked = drive.readOnly,
+			onCheckedChange = onReadOnlyChange
+		)
+
+		var bootText by remember(drive.bootPriority) { mutableStateOf(drive.bootPriority.toString()) }
+		OutlinedTextField(
+			value = bootText,
+			onValueChange = { input ->
+				bootText = input
+				input.toIntOrNull()?.let { onBootPriorityChange(it) }
+			},
+			label = { Text(stringResource(R.string.settings_storage_boot_priority)) },
+			singleLine = true,
+			keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+			modifier = Modifier.fillMaxWidth()
+		)
 	}
 }

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
@@ -32,6 +32,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 	val availableRoms: StateFlow<List<AmigaFile>> = repository.roms
 	val availableFloppies: StateFlow<List<AmigaFile>> = repository.floppies
 	val availableCds: StateFlow<List<AmigaFile>> = repository.cdImages
+	val availableHardDrives: StateFlow<List<AmigaFile>> = repository.hardDrives
 
 	init {
 		restoreLastSession()

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -258,6 +258,14 @@
     <string name="settings_storage_type_label">Type</string>
     <string name="settings_storage_disk_label">Disk</string>
     <string name="settings_storage_import_disk_image">Import disk image...</string>
+    <string name="settings_storage_hard_drives_title">Hard Drives</string>
+    <string name="settings_storage_hard_drive_label">Hard drive %1$d</string>
+    <string name="settings_storage_hardfile_label">HDF image</string>
+    <string name="settings_storage_import_hardfile">Import HDF image...</string>
+    <string name="settings_storage_add_hard_drive">Add hard drive</string>
+    <string name="settings_storage_remove_hard_drive">Remove hard drive</string>
+    <string name="settings_storage_hard_drive_read_only">Read-only</string>
+    <string name="settings_storage_boot_priority">Boot priority</string>
 
     <string name="clipboard_label_path">path</string>
     <string name="placeholder_none">(none)</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -204,6 +204,8 @@
     <string name="settings_display_theme_light">Light</string>
     <string name="settings_display_theme_dark">Dark</string>
     <string name="settings_display_dynamic_color">Use Material You colors</string>
+    <string name="settings_display_integer_scaling">Integer Scaling</string>
+    <string name="settings_display_integer_scaling_desc">Pixel-perfect scaling. Sets the scaling method to Integer and turns Resolution Autoswitch to Always On.</string>
 
     <string name="settings_sound_title">Sound Settings</string>
     <string name="settings_sound_output_label">Sound Output</string>

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
@@ -377,6 +377,24 @@ class ConfigGeneratorTest {
 		assertEquals("onscreen_joy", parsed.settings.joyport1)
 	}
 
+	// --- Integer scaling ---
+
+	@Test
+	fun `generate emits default scaling keys`() {
+		val output = ConfigGenerator.generate(EmulatorSettings())
+		assertContains(output, "scaling_method=-1")
+		assertContains(output, "gfx_autoresolution=0")
+	}
+
+	@Test
+	fun `generate emits integer scaling when enabled`() {
+		val output = ConfigGenerator.generate(
+			EmulatorSettings(scalingMethod = 2, gfxAutoresolution = 1)
+		)
+		assertContains(output, "scaling_method=2")
+		assertContains(output, "gfx_autoresolution=1")
+	}
+
 	// --- Helpers ---
 
 	private fun assertContains(text: String, substring: String) {

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
@@ -409,6 +409,23 @@ class ConfigGeneratorTest {
 		assertEquals("onscreen_joy", parsed.settings.joyport1)
 	}
 
+	// --- Hard drive round-trip ---
+
+	@Test
+	fun `round-trip preserves hard drives`() {
+		val original = EmulatorSettings(
+			hardDrives = listOf(
+				HardDrive(path = "/hd/system.hdf", readOnly = false, bootPriority = 0),
+				HardDrive(path = "/hd/work.hdf", readOnly = true, bootPriority = 2)
+			)
+		)
+		val file = tempDir.newFile("roundtrip_hd.uae")
+		file.writeText(ConfigGenerator.generate(original))
+		val result = ConfigParser.parse(file).settings
+
+		assertEquals(original.hardDrives, result.hardDrives)
+	}
+
 	// --- Integer scaling ---
 
 	@Test

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
@@ -3,6 +3,7 @@ package com.blitterstudio.amiberry.data
 import com.blitterstudio.amiberry.data.model.AmigaModel
 import com.blitterstudio.amiberry.data.model.EmulatorSettings
 import com.blitterstudio.amiberry.data.model.EmulatorSettingsConstraints
+import com.blitterstudio.amiberry.data.model.HardDrive
 import com.blitterstudio.amiberry.data.model.StoragePaths
 import org.junit.Assert.*
 import org.junit.Rule
@@ -112,6 +113,37 @@ class ConfigGeneratorTest {
 	fun `generate includes cdimage when nonempty`() {
 		val output = ConfigGenerator.generate(EmulatorSettings(cdImage = "/path/game.iso"))
 		assertContains(output, "cdimage0=/path/game.iso")
+	}
+
+	// --- Hard drives ---
+
+	@Test
+	fun `generate omits hardfile lines when no hard drives`() {
+		val output = ConfigGenerator.generate(EmulatorSettings())
+		assertNotContains(output, "hardfile2=")
+	}
+
+	@Test
+	fun `generate emits hardfile2 line per drive with controller index`() {
+		val output = ConfigGenerator.generate(
+			EmulatorSettings(
+				hardDrives = listOf(
+					HardDrive(path = "/hd/system.hdf", readOnly = false, bootPriority = 0),
+					HardDrive(path = "/hd/work.hdf", readOnly = true, bootPriority = -1)
+				)
+			)
+		)
+		val lines = output.lines()
+		assertContainsLine(lines, "hardfile2=rw,:/hd/system.hdf,0,0,0,512,0,,uae0")
+		assertContainsLine(lines, "hardfile2=ro,:/hd/work.hdf,0,0,0,512,-1,,uae1")
+	}
+
+	@Test
+	fun `generate skips hard drive with empty path`() {
+		val output = ConfigGenerator.generate(
+			EmulatorSettings(hardDrives = listOf(HardDrive(path = "")))
+		)
+		assertNotContains(output, "hardfile2=")
 	}
 
 	// --- Joystick port 1 special handling ---

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
@@ -1,6 +1,7 @@
 package com.blitterstudio.amiberry.data
 
 import com.blitterstudio.amiberry.data.model.AmigaModel
+import com.blitterstudio.amiberry.data.model.HardDrive
 import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
@@ -478,5 +479,64 @@ class ConfigParserTest {
 
 		assertEquals(68020, result.settings.cpuModel)
 		assertEquals("aga", result.settings.chipset)
+	}
+
+	// --- Hard drives ---
+
+	@Test
+	fun `parse multiple hardfile2 lines into hard drives`() {
+		val file = writeConfig("""
+			hardfile2=rw,:/hd/system.hdf,0,0,0,512,0,,uae0
+			hardfile2=ro,:/hd/work.hdf,0,0,0,512,-1,,uae1
+		""".trimIndent())
+		val result = ConfigParser.parse(file)
+		val drives = result.settings.hardDrives
+
+		assertEquals(2, drives.size)
+		assertEquals("/hd/system.hdf", drives[0].path)
+		assertFalse(drives[0].readOnly)
+		assertEquals(0, drives[0].bootPriority)
+		assertEquals("/hd/work.hdf", drives[1].path)
+		assertTrue(drives[1].readOnly)
+		assertEquals(-1, drives[1].bootPriority)
+		assertTrue(result.unknownLines.isEmpty())
+	}
+
+	@Test
+	fun `parse drops redundant uaehf hdf lines`() {
+		val file = writeConfig("""
+			hardfile2=rw,:/hd/system.hdf,0,0,0,512,0,,uae0
+			uaehf0=hdf,rw,:/hd/system.hdf,0,0,0,512,0,,uae0
+		""".trimIndent())
+		val result = ConfigParser.parse(file)
+
+		assertEquals(1, result.settings.hardDrives.size)
+		assertTrue(result.unknownLines.none { it.startsWith("uaehf0=") })
+	}
+
+	@Test
+	fun `parse preserves directory mounts and cd uaehf lines`() {
+		val file = writeConfig("""
+			filesystem2=rw,DH0:Work:/host/dir,0
+			uaehf1=dir,rw,DH0:Work:/host/dir,0
+			uaehf2=cd0,rw,:/host/disc.iso
+		""".trimIndent())
+		val result = ConfigParser.parse(file)
+
+		assertTrue(result.settings.hardDrives.isEmpty())
+		assertTrue(result.unknownLines.any { it.startsWith("filesystem2=") })
+		assertTrue(result.unknownLines.any { it.startsWith("uaehf1=dir") })
+		assertTrue(result.unknownLines.any { it.startsWith("uaehf2=cd0") })
+	}
+
+	@Test
+	fun `parse preserves non-uae controller hardfile2`() {
+		val file = writeConfig(
+			"hardfile2=rw,DH0:/hd/scsi.hdf,0,0,0,512,0,,scsi0"
+		)
+		val result = ConfigParser.parse(file)
+
+		assertTrue(result.settings.hardDrives.isEmpty())
+		assertTrue(result.unknownLines.any { it.startsWith("hardfile2=") })
 	}
 }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
@@ -453,11 +453,11 @@ class ConfigParserTest {
 			scaling_method=2
 			gfx_autoresolution=1
 		""".trimIndent())
-		val s = ConfigParser.parse(file).settings
+		val result = ConfigParser.parse(file)
 
-		assertEquals(2, s.scalingMethod)
-		assertEquals(1, s.gfxAutoresolution)
-		assertTrue(ConfigParser.parse(file).unknownLines.isEmpty())
+		assertEquals(2, result.settings.scalingMethod)
+		assertEquals(1, result.settings.gfxAutoresolution)
+		assertTrue(result.unknownLines.isEmpty())
 	}
 
 	@Test
@@ -511,6 +511,9 @@ class ConfigParserTest {
 		val result = ConfigParser.parse(file)
 
 		assertEquals(1, result.settings.hardDrives.size)
+		assertEquals("/hd/system.hdf", result.settings.hardDrives[0].path)
+		assertFalse(result.settings.hardDrives[0].readOnly)
+		assertEquals(0, result.settings.hardDrives[0].bootPriority)
 		assertTrue(result.unknownLines.none { it.startsWith("uaehf0=") })
 	}
 
@@ -534,6 +537,15 @@ class ConfigParserTest {
 		val file = writeConfig(
 			"hardfile2=rw,DH0:/hd/scsi.hdf,0,0,0,512,0,,scsi0"
 		)
+		val result = ConfigParser.parse(file)
+
+		assertTrue(result.settings.hardDrives.isEmpty())
+		assertTrue(result.unknownLines.any { it.startsWith("hardfile2=") })
+	}
+
+	@Test
+	fun `parse preserves malformed short hardfile2 line`() {
+		val file = writeConfig("hardfile2=rw,:/hd/x.hdf,0")
 		val result = ConfigParser.parse(file)
 
 		assertTrue(result.settings.hardDrives.isEmpty())

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
@@ -444,6 +444,28 @@ class ConfigParserTest {
 		assertEquals(AmigaModel.A600, result.settings.baseModel)
 	}
 
+	// --- Integer scaling ---
+
+	@Test
+	fun `parse scaling and autoresolution`() {
+		val file = writeConfig("""
+			scaling_method=2
+			gfx_autoresolution=1
+		""".trimIndent())
+		val s = ConfigParser.parse(file).settings
+
+		assertEquals(2, s.scalingMethod)
+		assertEquals(1, s.gfxAutoresolution)
+		assertTrue(ConfigParser.parse(file).unknownLines.isEmpty())
+	}
+
+	@Test
+	fun `parse scaling defaults when absent`() {
+		val s = ConfigParser.parse(writeConfig("cpu_model=68000")).settings
+		assertEquals(-1, s.scalingMethod)
+		assertEquals(0, s.gfxAutoresolution)
+	}
+
 	// --- Whitespace handling ---
 
 	@Test

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
@@ -551,4 +551,58 @@ class ConfigParserTest {
 		assertTrue(result.settings.hardDrives.isEmpty())
 		assertTrue(result.unknownLines.any { it.startsWith("hardfile2=") })
 	}
+
+	@Test
+	fun `parse preserves standalone uaehf hdf without matching hardfile2`() {
+		// Legacy/native seed configs ship a uaehf with no hardfile2 twin
+		// (see src/osdep/amiberry.cpp). Dropping it would delete the drive on save.
+		val file = writeConfig("uaehf0=hdf,rw,DH0:/hd/system.hdf,0,0,0,512,0,,uae0")
+		val result = ConfigParser.parse(file)
+
+		assertTrue(result.settings.hardDrives.isEmpty())
+		assertTrue(result.unknownLines.any { it.startsWith("uaehf0=") })
+	}
+
+	@Test
+	fun `parse preserves uaehf hdf whose controller has no matching hardfile2`() {
+		val file = writeConfig("""
+			hardfile2=rw,:/hd/system.hdf,0,0,0,512,0,,uae0
+			uaehf1=hdf,rw,DH1:/hd/extra.hdf,0,0,0,512,0,,uae1
+		""".trimIndent())
+		val result = ConfigParser.parse(file)
+
+		// Only the uae0 hardfile2 is adopted; the uae1 twin has no matching hardfile2.
+		assertEquals(1, result.settings.hardDrives.size)
+		assertEquals("/hd/system.hdf", result.settings.hardDrives[0].path)
+		assertTrue(result.unknownLines.any { it.startsWith("uaehf1=") })
+	}
+
+	@Test
+	fun `parse preserves hardfile2 with custom geometry`() {
+		// UAE controller but non-RDB geometry must not be flattened to 0,0,0,512.
+		val file = writeConfig("hardfile2=rw,:/hd/custom.hdf,63,16,2,512,0,,uae0")
+		val result = ConfigParser.parse(file)
+
+		assertTrue(result.settings.hardDrives.isEmpty())
+		assertTrue(result.unknownLines.any { it.startsWith("hardfile2=") })
+	}
+
+	@Test
+	fun `parse preserves hardfile2 with device name and filesystem`() {
+		val file = writeConfig("hardfile2=rw,DH0:/hd/x.hdf,0,0,0,512,0,myfs,uae0")
+		val result = ConfigParser.parse(file)
+
+		assertTrue(result.settings.hardDrives.isEmpty())
+		assertTrue(result.unknownLines.any { it.startsWith("hardfile2=") })
+	}
+
+	@Test
+	fun `parse preserves hardfile2 with extra trailing fields`() {
+		// highcyl / physical geometry / flags appended after the controller.
+		val file = writeConfig("hardfile2=rw,:/hd/x.hdf,0,0,0,512,0,,uae0,1024,1024/16/63")
+		val result = ConfigParser.parse(file)
+
+		assertTrue(result.settings.hardDrives.isEmpty())
+		assertTrue(result.unknownLines.any { it.startsWith("hardfile2=") })
+	}
 }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/EmulatorSettingsTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/EmulatorSettingsTest.kt
@@ -318,6 +318,15 @@ class EmulatorSettingsTest {
 		assertEquals("stereo", constrained.soundChannels)
 	}
 
+	// --- Integer scaling defaults ---
+
+	@Test
+	fun `default settings have integer scaling off`() {
+		val s = EmulatorSettings()
+		assertEquals(-1, s.scalingMethod)
+		assertEquals(0, s.gfxAutoresolution)
+	}
+
 	@Test
 	fun `constraints normalize floppy drive types and hidden disk paths`() {
 		val constrained = EmulatorSettingsConstraints.apply(

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/EmulatorSettingsTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/EmulatorSettingsTest.kt
@@ -3,6 +3,7 @@ package com.blitterstudio.amiberry.data
 import com.blitterstudio.amiberry.data.model.AmigaModel
 import com.blitterstudio.amiberry.data.model.EmulatorSettings
 import com.blitterstudio.amiberry.data.model.EmulatorSettingsConstraints
+import com.blitterstudio.amiberry.data.model.HardDrive
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -316,6 +317,13 @@ class EmulatorSettingsTest {
 		assertEquals("exact", constrained.soundOutput)
 		assertEquals(44100, constrained.soundFreq)
 		assertEquals("stereo", constrained.soundChannels)
+	}
+
+	// --- Hard drives ---
+
+	@Test
+	fun `default settings have no hard drives`() {
+		assertTrue(EmulatorSettings().hardDrives.isEmpty())
 	}
 
 	// --- Integer scaling defaults ---


### PR DESCRIPTION
## Summary

Two improvements to the Android Kotlin/Compose UI:

### 1. Integer Scaling toggle (Display settings)
A single **Integer Scaling** switch that, when enabled, sets the native scaling method to *Integer* **and** Resolution Autoswitch to *Always On* together.
- Persists the native keys `scaling_method` (`-1` Auto / `0` Nearest / `1` Linear / `2` Integer) and `gfx_autoresolution` (`0` Disabled / `1` Always On).
- Stores the raw native values on `EmulatorSettings` (not just a boolean), so configs created in the ImGui GUI round-trip without data loss.
- Toggle ON → `(2, 1)`; OFF → `(-1, 0)`. Old configs lacking the keys default to OFF.

### 2. Hard Drives (Storage settings)
A multi-drive hardfile mounter — add/remove `.hdf`/`.hdi`/`.vhd` images as Amiga hard drives.
- New `HardDrive(path, readOnly, bootPriority)` type and `EmulatorSettings.hardDrives` list.
- Per drive: HDF dropdown (from the existing Hard Drives folder) + per-slot import, read-only toggle, and boot-priority field. "Add hard drive" appends a slot.
- `ConfigGenerator` emits one `hardfile2=<ro|rw>,:<path>,0,0,0,512,<bootpri>,,uae<index>` line per drive (RDB form on the UAE controller, no `uaehf` lines).
- `ConfigParser` reads those lines back into the list, drops the redundant `uaehf<n>=hdf` twin (avoids a double-mount), and preserves all other mount lines (`filesystem2`, `uaehf=dir/cd`, non-UAE `hardfile2`) so externally-created configs are not clobbered.

## Scope / limitations (by design)
- Directory (host-folder) mounts are out of scope — Android scoped storage gives `content://` URIs the native side can't open as POSIX directories.
- Hardfiles on non-UAE controllers (IDE/SCSI) from foreign configs are preserved but not shown/editable in the Android UI.

## Testing
- **352 unit tests pass** (`:app:testDebugUnitTest`); new coverage in `EmulatorSettingsTest`, `ConfigGeneratorTest`, `ConfigParserTest` including generator/parser round-trip, redundant-`uaehf` drop, foreign-line preservation, and malformed-line handling.
- `:app:assembleDebug` BUILD SUCCESSFUL.
- Native mount/dedup verified by tracing `cfgfile.cpp` → `cfgfile_parse_newfilesys` / `add_filesys_config`: a `hardfile2`-only config mounts each drive once on `uae0`/`uae1` with no collision.

## Still to verify manually
On-device/emulator smoke test: confirm the Integer Scaling toggle persists and that an RDB `.hdf` mounts and boots.
