### PR TITLE
Fix collapsed group box hiding sibling column; more collapsible panels

### DIFF
--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -1023,7 +1023,7 @@ void AmigaCircularBevel(const ImVec2 center, const float radius, const bool rece
 static bool g_groupbox_collapsed = false;
 static bool g_groupbox_collapsible = false;
 
-bool BeginGroupBox(const char* name, bool collapsible)
+bool BeginGroupBox(const char* name, bool collapsible, bool default_open)
 {
 	// Add breathing room between consecutive group boxes.
 	// Skip the extra spacing when we are near the top of the panel
@@ -1040,7 +1040,7 @@ bool BeginGroupBox(const char* name, bool collapsible)
 	if (collapsible) {
 		ImGuiID id = ImGui::GetID("##collapse");
 		ImGuiStorage* storage = ImGui::GetStateStorage();
-		bool open = storage->GetBool(id, true);
+		bool open = storage->GetBool(id, default_open);
 		const char* arrow = open ? ICON_FA_CHEVRON_DOWN : ICON_FA_CHEVRON_RIGHT;
 		std::string toggle_label = std::string(arrow) + " " + name;
 		if (ImGui::Selectable(toggle_label.c_str(), false, 0, ImVec2(0, ImGui::GetTextLineHeightWithSpacing()))) {
@@ -1048,6 +1048,14 @@ bool BeginGroupBox(const char* name, bool collapsible)
 			storage->SetBool(id, open);
 		}
 		if (!open) {
+			// When collapsed the header Selectable is the group's only/last item.
+			// A Selectable sizes its render/click rect to the full available width
+			// (WorkRect.Max.x), and ImGui::EndGroup() folds the last item's rect
+			// into the group's bounding box. That full-width rect would otherwise
+			// leak into the enclosing layout and push a side-by-side column off
+			// screen (issue #2118). Submit a zero-size item so the collapsed group
+			// reports a sane width based on the header label only.
+			ImGui::Dummy(ImVec2(0.0f, 0.0f));
 			g_groupbox_collapsed = true;
 			return false;
 		}

--- a/src/osdep/imgui/cpu.cpp
+++ b/src/osdep/imgui/cpu.cpp
@@ -138,34 +138,40 @@ void render_panel_cpu() {
 
     ImGui::BeginGroup(); // Left Column
     {
-        BeginGroupBox("CPU");
+        const float left_group_min_width = BUTTON_WIDTH * 2.0f;
+
+        if (BeginGroupBox("CPU", true)) {
 
         int old_cpu_model = changed_prefs.cpu_model;
-        if (AmigaRadioButton("68000", &changed_prefs.cpu_model, 68000))
-            settings_changed = true;
-        ShowHelpMarker("Original Amiga 500/1000/2000 CPU.");
-        
-        if (AmigaRadioButton("68010", &changed_prefs.cpu_model, 68010))
-            settings_changed = true;
-        ShowHelpMarker("Slightly faster version of 68000, used in some accelerators.");
 
-        if (AmigaRadioButton("68020", &changed_prefs.cpu_model, 68020))
+        static const int cpu_models[] = { 68000, 68010, 68020, 68030, 68040, 68060 };
+        static const char* const cpu_model_labels[] = {
+            "68000 (A500/A1000/A2000)",
+            "68010",
+            "68020 (A1200)",
+            "68030 (A3000/A4000)",
+            "68040",
+            "68060"
+        };
+        int cpu_model_idx = 0;
+        for (int i = 0; i < IM_ARRAYSIZE(cpu_models); i++) {
+            if (cpu_models[i] == changed_prefs.cpu_model) {
+                cpu_model_idx = i;
+                break;
+            }
+        }
+        // Size the closed combo to the longest descriptive label so it isn't
+        // clipped; the dropdown list auto-sizes regardless.
+        const float cpu_combo_width = ImGui::CalcTextSize("68000 (A500/A1000/A2000)").x +
+            ImGui::GetFrameHeight() + ImGui::GetStyle().FramePadding.x * 2.0f;
+        ImGui::SetNextItemWidth(cpu_combo_width);
+        if (ImGui::Combo("##CPUModel", &cpu_model_idx, cpu_model_labels, IM_ARRAYSIZE(cpu_model_labels))) {
+            changed_prefs.cpu_model = cpu_models[cpu_model_idx];
             settings_changed = true;
-        ShowHelpMarker("Amiga 1200 CPU. 32-bit.");
+        }
+        AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActive());
+        ShowHelpMarker("CPU model. 68020+ are 32-bit; 68040/68060 include FPU and MMU. Higher models are faster.");
 
-        if (AmigaRadioButton("68030", &changed_prefs.cpu_model, 68030))
-            settings_changed = true;
-        ShowHelpMarker("Amiga 3000/4000 CPU. Includes MMU.");
-
-        if (AmigaRadioButton("68040", &changed_prefs.cpu_model, 68040))
-            settings_changed = true;
-        ShowHelpMarker("Faster 32-bit CPU with integrated FPU and MMU.");
-
-        if (AmigaRadioButton("68060", &changed_prefs.cpu_model, 68060))
-            settings_changed = true;
-        ShowHelpMarker("Fastest Amiga CPU.");
-
-        const float left_group_min_width = BUTTON_WIDTH * 2.0f;
         ImGui::Dummy(ImVec2(left_group_min_width, 0.0f));
 
         if (settings_changed && old_cpu_model != changed_prefs.cpu_model) {
@@ -297,6 +303,7 @@ void render_panel_cpu() {
         ShowHelpMarker("Just-In-Time compilation. Greatly speeds up CPU emulation but reduces compatibility.");
         ImGui::EndDisabled();
         ImGui::Spacing();
+        }
         EndGroupBox("CPU");
 
         if (BeginGroupBox("MMU", true)) {
@@ -321,7 +328,7 @@ void render_panel_cpu() {
         }
         EndGroupBox("MMU");
 
-        BeginGroupBox("FPU");
+        if (BeginGroupBox("FPU", true)) {
         int current_fpu_sel = 0;
         if (changed_prefs.fpu_model == 68881)
             current_fpu_sel = 1;
@@ -375,6 +382,7 @@ void render_panel_cpu() {
         ShowHelpMarker("Emulate unimplemented FPU instructions in software.");
         ImGui::EndDisabled();
         ImGui::Dummy(ImVec2(left_group_min_width, 0.0f));
+        }
         EndGroupBox("FPU");
     }
     ImGui::EndGroup();
@@ -385,7 +393,9 @@ void render_panel_cpu() {
 
     ImGui::BeginGroup(); // Right Column
     {
-        BeginGroupBox("CPU Speed");
+        const float right_group_min_width = BUTTON_WIDTH * 5.0f;
+
+        if (BeginGroupBox("CPU Speed", true)) {
         // Logic: WinUAE sets m68k_speed to -1 for "Fastest Possible", 0 for "Cycle Exact/Approx"
         // Also updates throttle.
         int speed_mode = changed_prefs.m68k_speed < 0 ? -1 : 0;
@@ -433,11 +443,11 @@ void render_panel_cpu() {
         AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
         ImGui::EndDisabled();
 
-        float right_group_min_width = BUTTON_WIDTH * 5.0f;
         ImGui::Dummy(ImVec2(right_group_min_width, 0.0f));
+        }
         EndGroupBox("CPU Speed");
 
-        BeginGroupBox("Cycle-Exact CPU Emulation Speed");
+        if (BeginGroupBox("Cycle-Exact CPU Emulation Speed", true)) {
         const char *freq_items[] = {"1x", "2x (A500)", "4x (A1200)", "8x", "16x"};
         ImGui::AlignTextToFramePadding();
         ImGui::Text("CPU Frequency");
@@ -484,10 +494,11 @@ void render_panel_cpu() {
         ImGui::EndDisabled();
         
         ImGui::Dummy(ImVec2(right_group_min_width, 0.0f));
+        }
         EndGroupBox("Cycle-Exact CPU Emulation Speed");
 
 #ifdef WITH_PPC
-        if (BeginGroupBox("PowerPC CPU Options", true)) {
+        if (BeginGroupBox("PowerPC CPU Options", true, false)) {
         ImGui::BeginDisabled(!enable_ppc);
         bool ppc_bool = changed_prefs.ppc_mode != 0;
         if (AmigaCheckbox("PPC CPU emulation", &ppc_bool)) {
@@ -539,7 +550,7 @@ void render_panel_cpu() {
         EndGroupBox("PowerPC CPU Options");
 #endif
 
-        if (BeginGroupBox("x86 Bridgeboard CPU options", true)) {
+        if (BeginGroupBox("x86 Bridgeboard CPU options", true, false)) {
         ImGui::BeginDisabled(!enable_x86_group);
         ImGui::AlignTextToFramePadding();
         ImGui::Text("CPU Speed");

--- a/src/osdep/imgui/floppy.cpp
+++ b/src/osdep/imgui/floppy.cpp
@@ -253,7 +253,7 @@ static void RenderDriveSlot(const int i)
 #ifdef FLOPPYBRIDGE
 static void RenderDrawBridge()
 {
-    BeginGroupBox("DrawBridge (FloppyBridge)");
+    if (BeginGroupBox("DrawBridge (FloppyBridge)", true, false)) {
 
     // --- Driver Selection ---
     ImGui::AlignTextToFramePadding();
@@ -399,6 +399,7 @@ static void RenderDrawBridge()
     ShowHelpMarker("Select drive cable type: IBM PC (A/B) or SHUGART (0-3) standard");
     ImGui::EndDisabled();
     ImGui::Spacing();
+    }
     EndGroupBox("DrawBridge (FloppyBridge)");
 }
 #endif

--- a/src/osdep/imgui/imgui_panels.h
+++ b/src/osdep/imgui/imgui_panels.h
@@ -20,7 +20,7 @@ struct SDL_Surface;
 ImTextureID gui_create_texture(SDL_Surface* surface, int* out_w, int* out_h);
 void gui_destroy_texture(ImTextureID tex);
 
-bool BeginGroupBox(const char* name, bool collapsible = false);
+bool BeginGroupBox(const char* name, bool collapsible = false, bool default_open = true);
 void EndGroupBox(const char* name);
 
 void AmigaBevel(ImVec2 min, ImVec2 max, bool recessed);

--- a/src/osdep/imgui/input.cpp
+++ b/src/osdep/imgui/input.cpp
@@ -389,7 +389,7 @@ void render_panel_input() {
     static const int digital_joymousespeed_values[] = {2, 5, 10, 15, 20};
     static const int analog_joymousespeed_values[] = {5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 75, 100, 125, 150};
 
-    if (BeginGroupBox("Game Controller Settings", true)) {
+    if (BeginGroupBox("Game Controller Settings", true, false)) {
     // Joystick Dead Zone
     ImGui::AlignTextToFramePadding();
     ImGui::Text("Joystick dead zone:");
@@ -479,7 +479,7 @@ void render_panel_input() {
     }
     EndGroupBox("Game Controller Settings");
 
-    if (BeginGroupBox("Mouse extra settings", true)) {
+    if (BeginGroupBox("Mouse extra settings", true, false)) {
 
     if (ImGui::BeginTable("MouseExtrasTable", 2, ImGuiTableFlags_None)) {
         // Row 1

--- a/src/osdep/imgui/ram.cpp
+++ b/src/osdep/imgui/ram.cpp
@@ -354,7 +354,7 @@ void render_panel_ram() {
 
     EndGroupBox("Memory Settings");
 
-    if (BeginGroupBox("Advanced Memory Settings", true)) {
+    if (BeginGroupBox("Advanced Memory Settings", true, false)) {
 
     // WinUAE sync: Validate current selection is still valid (e.g., after switching to 24-bit mode)
     if (!z3_enabled && current_advanced_ram_idx >= ADVANCED_RAM_Z3_BASE) {


### PR DESCRIPTION
The custom BeginGroupBox/EndGroupBox helper left a full-width header Selectable as the collapsed group's last item. ImGui::EndGroup() folds the last item's rect into the group bounding box, so the full window width leaked into the enclosing layout and pushed side-by-side columns off screen (e.g. collapsing "MMU" hid the entire right column of the CPU & FPU panel).

- Submit a zero-size item in the collapsed branch so the group reports a sane width based on the header label only.
- Add an optional default_open parameter to BeginGroupBox.
- CPU & FPU panel: make CPU, FPU, CPU Speed and Cycle-Exact CPU Emulation Speed groups collapsible; replace the CPU model radio buttons with a combo to save vertical space.
- Collapse by default: PowerPC CPU Options, x86 Bridgeboard CPU options, Advanced Memory Settings, DrawBridge (FloppyBridge, now collapsible), Game Controller Settings and Mouse extra settings.

Fixes #2118