### PR TITLE
Fix editing device/controller in CD & Tape Drive Settings (#2119)

### DIFF
--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -1606,7 +1606,12 @@ void addhdcontroller(const struct expansionromtype* erc, int firstid, int flags)
 void inithdcontroller(int ctype, int ctype_unit, int devtype, bool media)
 {
 	controller.clear();
-	controller.push_back({ HD_CONTROLLER_TYPE_UAE, _T("UAE (uaehf.device)") });
+	// A CD-ROM cannot be attached to the UAE (uaehf.device) controller as a
+	// mountconfig entry: add_filesys_config() rejects it (UAE CDs are handled
+	// via the uaescsi.device/cdslot mechanism instead). Offering it here would
+	// let the user pick a controller that silently fails to apply.
+	if (devtype != UAEDEV_CD)
+		controller.push_back({ HD_CONTROLLER_TYPE_UAE, _T("UAE (uaehf.device)") });
 	controller.push_back({ HD_CONTROLLER_TYPE_IDE_AUTO, _T("IDE (Auto)") });
 
 	for (auto i = 0; expansionroms[i].name; i++) {

--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -1519,6 +1519,7 @@ void new_cddrive(int entry)
 	struct uaedev_config_info ci{};
 	ci.device_emu_unit = 0;
 	ci.controller_type = current_cddlg.ci.controller_type;
+	ci.controller_type_unit = current_cddlg.ci.controller_type_unit;
 	ci.controller_unit = current_cddlg.ci.controller_unit;
 #ifdef AMIBERRY
 	_tcscpy(ci.rootdir, current_cddlg.ci.rootdir);
@@ -1534,6 +1535,7 @@ void new_tapedrive(int entry)
 	struct uaedev_config_data* uci;
 	struct uaedev_config_info ci{};
 	ci.controller_type = current_tapedlg.ci.controller_type;
+	ci.controller_type_unit = current_tapedlg.ci.controller_type_unit;
 	ci.controller_unit = current_tapedlg.ci.controller_unit;
 	ci.readonly = current_tapedlg.ci.readonly;
 	_tcscpy(ci.rootdir, current_tapedlg.ci.rootdir);

--- a/src/osdep/imgui/hd.cpp
+++ b/src/osdep/imgui/hd.cpp
@@ -1330,7 +1330,7 @@ static void ShowEditCDDriveModal()
                     AddToMruCdList(path_buf);
             }
 
-            new_cddrive(-1);
+            new_cddrive(edit_entry_index);
             invalidate_hdf_cache();
             gui_force_rtarea_hdchange(); 
             ImGui::CloseCurrentPopup();
@@ -1456,7 +1456,7 @@ static void ShowEditTapeDriveModal()
                 
                 inithdcontroller(current_tapedlg.ci.controller_type, current_tapedlg.ci.controller_type_unit, UAEDEV_TAPE, path_buf[0] != 0);
 
-                new_tapedrive(-1);
+                new_tapedrive(edit_entry_index);
                 invalidate_hdf_cache();
                 gui_force_rtarea_hdchange(); 
                 ImGui::CloseCurrentPopup();
@@ -1570,7 +1570,8 @@ void render_panel_hd()
                 is_board_enabled(&changed_prefs, ROMTYPE_GVPS2, 0) || is_board_enabled(&changed_prefs, ROMTYPE_A4091, 0) ||
                 (changed_prefs.cs_mbdmac & 3)) ? HD_CONTROLLER_TYPE_SCSI_AUTO : HD_CONTROLLER_TYPE_IDE_AUTO;
         inithdcontroller(current_cddlg.ci.controller_type, current_cddlg.ci.controller_type_unit, UAEDEV_CD, current_cddlg.ci.rootdir[0] != 0);
-        
+
+        edit_entry_index = -1;
         ImGui::OpenPopup("CD Drive Settings");
         show_cd_modal = true;
         current_hd_dialog_mode = HDDialogMode::None;
@@ -1581,6 +1582,7 @@ void render_panel_hd()
         default_tapedlg(&current_tapedlg);
         inithdcontroller(current_tapedlg.ci.controller_type, current_tapedlg.ci.controller_type_unit, UAEDEV_TAPE, current_tapedlg.ci.rootdir[0] != 0);
 
+        edit_entry_index = -1;
         ImGui::OpenPopup("Tape Drive Settings");
         show_tape_modal = true;
         current_hd_dialog_mode = HDDialogMode::None;
@@ -1595,11 +1597,13 @@ void render_panel_hd()
          
          if (uci->type == UAEDEV_CD) {
              memcpy(&current_cddlg.ci, uci, sizeof(struct uaedev_config_info));
+             inithdcontroller(current_cddlg.ci.controller_type, current_cddlg.ci.controller_type_unit, UAEDEV_CD, current_cddlg.ci.rootdir[0] != 0);
              ImGui::OpenPopup("CD Drive Settings");
              show_cd_modal = true;
          }
          else if (uci->type == UAEDEV_TAPE) {
              memcpy(&current_tapedlg.ci, uci, sizeof(struct uaedev_config_info));
+             inithdcontroller(current_tapedlg.ci.controller_type, current_tapedlg.ci.controller_type_unit, UAEDEV_TAPE, current_tapedlg.ci.rootdir[0] != 0);
              ImGui::OpenPopup("Tape Drive Settings");
              show_tape_modal = true;
          }


### PR DESCRIPTION
Fixes #2119.

The CD/Tape **Properties** (edit) flow in the ImGui Hard Drives panel diverged from the working **Add** flow, causing three defects:

### 1. Controller dropdown empty when editing
`inithdcontroller()` rebuilds the shared `controller` list and was called on the Add path and the hardfile-edit path, but **not** on the CD/Tape edit dispatch. Editing an existing CD/Tape therefore showed an empty/stale dropdown ("none of the available controllers shows up… the drop-down works fine when creating a new CD-ROM").

**Fix:** call `inithdcontroller()` in the `UAEDEV_CD` and `UAEDEV_TAPE` branches of the edit dispatch.

### 2. Device column not updated after OK
The OK handlers always called `new_cddrive(-1)` / `new_tapedrive(-1)`. With `entry == -1`, `add_filesys_config()` treats it as an *add* and the `device_emu_unit` duplicate check returns `NULL`, so the existing mountconfig entry was never modified — the change didn't apply.

**Fix:** pass `edit_entry_index` when saving, and reset `edit_entry_index = -1` on the Add CD/Add Tape paths so adding still allocates a fresh entry.

### 3. Selecting the "UAE" controller for a CD did nothing
The CD controller dropdown offered "UAE (uaehf.device)", but `add_filesys_config()` rejects a `UAEDEV_CD` on the UAE controller (UAE-side CDs use the `uaescsi.device`/cdslot mechanism, not a mountconfig hardfile entry). Picking it silently no-op'd, while every other controller worked. The Add path already encodes this by auto-converting UAE → IDE/SCSI.

**Fix:** omit the UAE entry from the controller list when `devtype == UAEDEV_CD`.

### Note on the unit-4 / uaescsi.device:0 observation
The reporter also noted the CD set to A4091 SCSI ID 4 appears on `uaescsi.device:0`. This is **expected**, not a regression: with `scsi=true` the built-in `uaescsi.device` always presents an in-use `cdslot` as a SCSI unit, independently of the A4091 binding (which also works — the cdslot open is reference-counted). No code change for that here.

### Testing
- Built with the `windows-debug` CMake preset (Ninja/mingw); compiles and links cleanly.
- Manual: F12 → Hard Drives → select a CD/Tape → Properties → controller list is populated, changing it updates the Device column, and UAE is no longer offered for CDs.