### PR TITLE
Fix macOS crash when bsdsocket library closes from a trap thread (#2115)

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -3390,20 +3390,23 @@ void update_clipboard()
 	osdep_platform_update_clipboard();
 }
 
-extern bool uae_self_is_ppc(void);
-
 int handle_msgpump(bool vblank)
 {
 	if (!osdep_platform_use_event_pump())
 		return 0;
-	/* SDL/Cocoa event pumping must never run on the qemu-uae PPC CPU thread.
-	 * That thread can reach here through a CIA register read
-	 * (uae_ppc_io_mem_read -> ReadCIAA -> handle_joystick_buttons ->
-	 * handle_msgpump); on macOS, calling the Cocoa event loop off the main
-	 * thread aborts the process ("nextEventMatchingMask should only be called
-	 * from the Main Thread!"). The host event loop is pumped by the emulation
-	 * thread every frame, so skipping it here is safe. */
-	if (uae_self_is_ppc())
+	/* SDL/Cocoa event pumping must only ever run on the main thread.
+	 * Several worker threads can reach here while the main thread is blocked
+	 * waiting on them, e.g.:
+	 *   - the qemu-uae PPC CPU thread, via a CIA register read
+	 *     (uae_ppc_io_mem_read -> ReadCIAA -> handle_joystick_buttons);
+	 *   - a bsdsocket/uaeserial extended-trap thread, which advances the
+	 *     cycle-exact chipset clock from trap_Call68k -> fill_prefetch and so
+	 *     reaches the hsync handler (inputdevice_hsync -> handle_msgpump).
+	 * On macOS, calling the Cocoa event loop off the main thread aborts the
+	 * process ("nextEventMatchingMask should only be called from the Main
+	 * Thread!"). The host event loop is pumped by the main emulation thread
+	 * every frame, so skipping it on any other thread is safe. */
+	if (!is_mainthread())
 		return 0;
 	lctrl_pressed = rctrl_pressed = lalt_pressed = ralt_pressed = lshift_pressed = rshift_pressed = lgui_pressed = rgui_pressed = false;
 	auto got_event = 0;


### PR DESCRIPTION
Fixes #2115.

## Problem

On macOS, Amiberry aborts during `bsdsocket` emulation use:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
    reason: 'nextEventMatchingMask should only be called from the Main Thread!'
...
 8  handle_msgpump
 9  inputdevice_hsync
10  hsync_handler_post
...
13  do_cycles_ce020
17  trap_Call68k
18  trap_call_lib
19  bsdsocklib_Close
20  extended_trap_thread     <- bsdsocket worker thread, not main
```

## Root cause

All `bsdsocket.library` functions are registered with `TRAPFLAG_EXTRA_STACK`, so they run as *extended traps* on the reusable `extended-trap` worker thread rather than the main thread.

When `bsdsocklib_Close` calls back into 68k (FreeMem) via `trap_call_lib` → `trap_Call68k`, the `fill_prefetch()` in `trap_Call68k` advances the **cycle-exact chipset clock on that worker thread**. Landing on an hsync boundary reaches `inputdevice_hsync` → `handle_msgpump()` → `SDL_PollEvent`, which on macOS dispatches to Cocoa's `nextEventMatchingMask` — a **main-thread-only** API — and aborts the process.

`handle_msgpump()` already guarded the *identical* failure mode for the qemu PPC CPU thread with `uae_self_is_ppc()`; the bsdsocket/uaeserial trap threads simply weren't covered.

## Fix

Generalize the guard in `handle_msgpump()` from the PPC-specific check to `!is_mainthread()`. This:

- **subsumes** the previous `uae_self_is_ppc()` case (the PPC thread is never the main thread);
- **covers** the bsdsocket/uaeserial extended-trap worker threads;
- is **safe** — the legitimate event pump always runs on the main emulation thread. Even with `cpu_thread` enabled, the chipset stays on the main thread (the CPU thread defers register access via `cpu_thread_queue_register_op`), so no real pump is lost. The host event loop is pumped by the main thread every frame, so skipping it on any other thread loses nothing.

`is_mainthread()` (from `uae.h`) is already used codebase-wide for exactly this kind of main-thread gating.

## Notes / scope

- This is a host-side (macOS/SDL/Cocoa) constraint; the change only affects `src/osdep/amiberry.cpp`.
- Not addressed here (much rarer, unreported): a trap thread's `fill_prefetch` could in principle cross a *vsync* and reach rendering off the main thread. That is ~300x rarer than the per-line hsync path and would require a broader guard; left as a possible follow-up.

## Testing

Reasoning verified across `traps.cpp`, `custom.cpp`, `inputdevice.cpp`, and `ppc.cpp`. I do not have a macOS host to reproduce the original abort; maintainer verification on macOS with a bsdsocket-heavy workload (e.g. the reporter's micropython socket open/close cycles) would be appreciated.