### PR TITLE
Redirect debugger I/O via shell stdin/stdout (#2117)

### DIFF
--- a/src/osdep/writelog.cpp
+++ b/src/osdep/writelog.cpp
@@ -22,6 +22,7 @@
 #include <termios.h>
 #include <sys/ioctl.h>
 #include <poll.h>
+#include <sys/stat.h>
 #endif
 
 #if defined(__ANDROID__)
@@ -63,6 +64,39 @@ static SDL_Window* previousactivewindow;
 static uae_sem_t log_sem;
 static int log_sem_init;
 
+#ifndef _WIN32
+// Returns true when the fd is a redirected regular file or pipe — i.e. the
+// debugger's stream is connected to `<file` / `>file` / a `| pipe`, not a TTY
+// and not /dev/null / a character device / a closed fd. Used to route the
+// interactive debugger to the launching shell's stdin/stdout (issue #2117)
+// instead of the ImGui/Cocoa debugger window.
+static bool fd_is_redirected(int fd)
+{
+	struct stat st{};
+	if (fstat(fd, &st) != 0)
+		return false;
+	return S_ISREG(st.st_mode) || S_ISFIFO(st.st_mode);
+}
+
+// fd types are stable for the process lifetime, so cache the result.
+static bool debugger_stdin_redirected()
+{
+	static const bool v = fd_is_redirected(STDIN_FILENO);
+	return v;
+}
+
+static bool debugger_stdout_redirected()
+{
+	static const bool v = fd_is_redirected(STDOUT_FILENO);
+	return v;
+}
+
+static bool debugger_stdio_redirected()
+{
+	return debugger_stdin_redirected() || debugger_stdout_redirected();
+}
+#endif
+
 #if defined(AMIBERRY_MACOS) || (!defined(__ANDROID__) && !defined(AMIBERRY_IOS))
 static constexpr int CONSOLEOPEN_DEBUGGER_WINDOW = 2;
 
@@ -71,7 +105,8 @@ static bool console_debugger_available()
 #if defined(_WIN32)
 	return true;
 #else
-	return console_logging && isatty(STDIN_FILENO) && isatty(STDOUT_FILENO);
+	return (console_logging && isatty(STDIN_FILENO) && isatty(STDOUT_FILENO))
+		|| debugger_stdio_redirected();
 #endif
 }
 

--- a/src/osdep/writelog.cpp
+++ b/src/osdep/writelog.cpp
@@ -686,6 +686,11 @@ bool console_isch ()
 	if (consoleopen == CONSOLEOPEN_DEBUGGER_WINDOW)
 		return debugger_window_has_input();
 #endif
+	// A redirected command stream has no async "abort key": its bytes belong to
+	// console_get(), and poll() on a regular file is always ready. Report no input
+	// so iscancel() never fires and console_getch() can't steal command bytes.
+	if (debugger_stdin_redirected())
+		return false;
 	struct pollfd fds;
 	fds.fd = STDIN_FILENO;
 	fds.events = POLLIN;

--- a/src/osdep/writelog.cpp
+++ b/src/osdep/writelog.cpp
@@ -539,7 +539,12 @@ static void writeconsole_2 (const TCHAR *buffer)
 #ifdef _WIN32
 		fprintf(stdout, "%s", buffer);
 #else
-		SDL_Log("%s", buffer);
+		if (debugger_stdio_redirected()) {
+			fprintf(stdout, "%s", buffer);
+			fflush(stdout);
+		} else {
+			SDL_Log("%s", buffer);
+		}
 #endif
 	}
 	else if (realconsole) {


### PR DESCRIPTION
## Summary

Closes #2117.

Lets the interactive debugger (Fn+Shift+F12) use the launching shell's redirected
`stdin`/`stdout` instead of the ImGui/Cocoa debugger window, so debugger commands can
be scripted from a file and output captured to a file — matching FS-UAE's behavior:

```
.../Amiberry.app/Contents/MacOS/Amiberry config.uae <dbg-i.txt >dbg-o.txt
```

This makes long-running traces (`f`, `g`, `t`) easy to review offline. Detection is
fully automatic — no new flags or config.

## Why it didn't work before

All debugger console I/O lives in `src/osdep/writelog.cpp`:

- `console_debugger_available()` gated console mode on `isatty(stdin) && isatty(stdout)`,
  so any redirected file/pipe failed the check and the debugger fell back to the GUI window.
- Even in console mode, non-Windows debugger output went through `SDL_Log()` (→ stderr with
  an `INFO:` prefix), so `>out` (stdout) captured nothing. The plain-stdout path
  (`realconsole`) is dead code on Amiberry.
- `console_isch()` polled `STDIN_FILENO`; a redirected **regular file always reports ready**,
  so `iscancel()` (debug.cpp) would abort long dumps/traces immediately and `console_getch()`
  would steal bytes from the command stream.

## What this changes (all in `src/osdep/writelog.cpp`)

1. **Detect redirected streams** via `fstat()` — `S_ISREG` or `S_ISFIFO` only. `/dev/null`,
   character devices, and closed fds are *not* treated as redirected, so Finder/double-click
   (macOS) and `.desktop` (Linux) launches keep today's window debugger. Results are cached.
2. **Select console mode** when redirected, by extending `console_debugger_available()`.
3. **Route debugger output to real `stdout`** (`fprintf` + `fflush`) when redirected, instead
   of `SDL_Log()`.
4. **Disable async cancel** for a redirected (non-interactive) stdin: `console_isch()` returns
   false so the scripted command stream is consumed only by `console_get()`.

On EOF (script exhausted) the debugger resumes emulation, as today.

## Scope

- macOS + desktop Linux (the shared non-Windows console path). Windows is unchanged (it
  already writes console output to stdout); the new detection is POSIX-only and behaviorally
  inert on Android/iOS.
- No new CLI flags, config keys, or source files. Three small, self-contained commits.

## Interaction with `--log`

- Without `--log` (typical): only debugger output reaches stdout — clean trace logs.
- With `--log`: emulator `write_log` output also interleaves on stdout (it shares the same
  console sink) — the user's explicit choice.

## Testing

> Note: developed on a Windows host where these `#ifndef _WIN32` paths don't compile —
> needs a macOS/Linux build to verify (CI covers this).

Create `dbg-i.txt`:

```
r
m 0 20
t
t
g
```

Run `.../Amiberry config.uae <dbg-i.txt >dbg-o.txt`, trigger the debugger. Expect `dbg-o.txt`
to contain the register dump (`r`), memory dump (`m 0 20`), two single-steps (`t`), then `g`
resumes emulation — no `INFO:` prefixes, nothing sent to a window.

Regression checks:
- Finder/double-click (macOS) and `.desktop` (Linux) launches still open the **window** debugger.
- Plain terminal launch with no redirection is unchanged.
- A long `m`/`t` dump ending in `g` is captured in full (verifies the `iscancel`/`console_isch` fix).
- Output-only (`>out`), input-only (`<in`), and pipe (`cat dbg-i.txt | Amiberry ...`) all behave.
