### PR TITLE
Android: document-style config edit/save UX (Save / Save As, dirty tracking, unsaved-changes guard)

### DIFF
--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigFiles.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigFiles.kt
@@ -73,6 +73,9 @@ object ConfigFiles {
 	fun isUserConfigFileName(name: String): Boolean =
 		!name.startsWith(".") && name.substringAfterLast('.', "").equals("uae", ignoreCase = true)
 
+	/** Resolve a stored absolute [path] to its File only if it is a user config inside [confDir]. */
+	fun userConfigFile(confDir: File, path: String): File? = userConfigFileFromPath(confDir, path)
+
 	private fun normalizedBaseName(name: String): String? {
 		val trimmed = name.trim()
 		if (trimmed.isBlank()) return null

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigRepository.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigRepository.kt
@@ -85,6 +85,22 @@ class ConfigRepository(private val context: Context) {
 		return writeConfigFile(target, settings, unknownLines, description)
 	}
 
+	/**
+	 * Overwrite the exact config file at [path], preserving its original filename and
+	 * extension case — used when re-saving the config the user opened. Returns InvalidName
+	 * if [path] is not a user config inside the configurations directory.
+	 */
+	fun overwriteConfigAtPath(
+		path: String,
+		settings: EmulatorSettings,
+		unknownLines: List<String> = emptyList(),
+		description: String = ""
+	): ConfigurationSaveActions.SaveResult {
+		val target = ConfigFiles.userConfigFile(confDir, path)
+			?: return ConfigurationSaveActions.SaveResult.InvalidName
+		return writeConfigFile(target, settings, unknownLines, description)
+	}
+
 	private fun writeConfigFile(
 		target: File,
 		settings: EmulatorSettings,
@@ -92,15 +108,15 @@ class ConfigRepository(private val context: Context) {
 		description: String
 	): ConfigurationSaveActions.SaveResult {
 		return try {
-			val file = ConfigGenerator.writeConfig(context, settings, target.name)
+			target.writeText(ConfigGenerator.generate(settings))
 			if (description.isNotBlank()) {
-				file.appendText("config_description=$description\n")
+				target.appendText("config_description=$description\n")
 			}
 			if (unknownLines.isNotEmpty()) {
-				file.appendText("\n; Preserved settings from original config\n")
-				unknownLines.forEach { file.appendText("$it\n") }
+				target.appendText("\n; Preserved settings from original config\n")
+				unknownLines.forEach { target.appendText("$it\n") }
 			}
-			ConfigurationSaveActions.SaveResult.Saved(file)
+			ConfigurationSaveActions.SaveResult.Saved(target)
 		} catch (_: IOException) {
 			ConfigurationSaveActions.SaveResult.Failed
 		}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigRepository.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigRepository.kt
@@ -58,21 +58,48 @@ class ConfigRepository(private val context: Context) {
 			ConfigurationSaveActions.SaveTarget.InvalidName -> return ConfigurationSaveActions.SaveResult.InvalidName
 			ConfigurationSaveActions.SaveTarget.AlreadyExists -> return ConfigurationSaveActions.SaveResult.AlreadyExists
 		}
+		return writeConfigFile(target, settings, unknownLines, description)
+	}
 
+	/**
+	 * Save honoring the config currently being edited: silently overwrites the open
+	 * config, writes brand-new names, and only reports AlreadyExists when the name
+	 * collides with a *different* existing config and [allowOverwrite] is false.
+	 */
+	fun saveResolved(
+		settings: EmulatorSettings,
+		requestedName: String,
+		currentConfigName: String?,
+		unknownLines: List<String> = emptyList(),
+		description: String = "",
+		allowOverwrite: Boolean = false
+	): ConfigurationSaveActions.SaveResult {
+		val target = when (val resolution = ConfigSaveResolver.resolve(confDir, requestedName, currentConfigName)) {
+			ConfigSaveResolver.Resolution.InvalidName -> return ConfigurationSaveActions.SaveResult.InvalidName
+			is ConfigSaveResolver.Resolution.WriteNew -> resolution.file
+			is ConfigSaveResolver.Resolution.OverwriteTracked -> resolution.file
+			is ConfigSaveResolver.Resolution.CollisionWithOther ->
+				if (allowOverwrite) resolution.file
+				else return ConfigurationSaveActions.SaveResult.AlreadyExists
+		}
+		return writeConfigFile(target, settings, unknownLines, description)
+	}
+
+	private fun writeConfigFile(
+		target: File,
+		settings: EmulatorSettings,
+		unknownLines: List<String>,
+		description: String
+	): ConfigurationSaveActions.SaveResult {
 		return try {
 			val file = ConfigGenerator.writeConfig(context, settings, target.name)
-
-			// Append description if provided
 			if (description.isNotBlank()) {
 				file.appendText("config_description=$description\n")
 			}
-
-			// Append preserved unknown lines from original config
 			if (unknownLines.isNotEmpty()) {
 				file.appendText("\n; Preserved settings from original config\n")
 				unknownLines.forEach { file.appendText("$it\n") }
 			}
-
 			ConfigurationSaveActions.SaveResult.Saved(file)
 		} catch (_: IOException) {
 			ConfigurationSaveActions.SaveResult.Failed

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigSaveResolver.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigSaveResolver.kt
@@ -1,0 +1,32 @@
+package com.blitterstudio.amiberry.data
+
+import java.io.File
+
+/**
+ * Classifies a save request against the config currently being edited.
+ * Pure: no Android types, no IO beyond canonical-path resolution via ConfigFiles.
+ */
+object ConfigSaveResolver {
+
+	sealed interface Resolution {
+		/** The requested name cannot be used as a config filename. */
+		data object InvalidName : Resolution
+		/** No config with this name exists yet — write a brand new file. */
+		data class WriteNew(val file: File) : Resolution
+		/** The name resolves to the config currently open — overwrite it silently. */
+		data class OverwriteTracked(val file: File) : Resolution
+		/** The name collides with a *different* existing config — confirm before overwriting. */
+		data class CollisionWithOther(val file: File) : Resolution
+	}
+
+	fun resolve(confDir: File, requestedName: String, currentConfigName: String?): Resolution {
+		val target = ConfigFiles.targetFileForName(confDir, requestedName)
+			?: return Resolution.InvalidName
+		val trackedTarget = currentConfigName?.let { ConfigFiles.targetFileForName(confDir, it) }
+		return when {
+			trackedTarget != null && target == trackedTarget -> Resolution.OverwriteTracked(target)
+			target.exists() -> Resolution.CollisionWithOther(target)
+			else -> Resolution.WriteNew(target)
+		}
+	}
+}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/AmiberryApp.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/AmiberryApp.kt
@@ -1,6 +1,7 @@
 package com.blitterstudio.amiberry.ui
 
 import android.content.res.Configuration
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Column
@@ -57,7 +58,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun AmiberryApp() {
 	val navController = rememberNavController()
-	val activity = LocalContext.current.findActivity() as? MainActivity
+	val context = LocalContext.current
+	val activity = context.findActivity() as? MainActivity
 	val crashDetected = activity?.emulatorCrashDetected == true
 	val assetExtractionFailed = activity?.assetExtractionFailed == true
 	val visibleGlobalDialog = GlobalDialogState.visibleDialog(
@@ -167,8 +169,8 @@ fun AmiberryApp() {
 
 	val onSettingsRoute = currentDestination?.hierarchy?.any { it.route == Screen.Settings.route } == true
 
-	fun guardedNavigate(action: () -> Unit) {
-		if (onSettingsRoute && settingsViewModel.isDirty) {
+	fun guardedNavigate(targetRoute: String, action: () -> Unit) {
+		if (targetRoute != Screen.Settings.route && onSettingsRoute && settingsViewModel.isDirty) {
 			pendingNavigation = action
 		} else {
 			action()
@@ -202,6 +204,13 @@ fun AmiberryApp() {
 						if (result is ConfigurationSaveActions.SaveResult.Saved) {
 							pendingNavigation = null
 							proceed()
+						} else {
+							pendingNavigation = null
+							Toast.makeText(
+								context,
+								context.getString(R.string.msg_failed_save_config),
+								Toast.LENGTH_SHORT
+							).show()
 						}
 					}
 				}) {
@@ -234,7 +243,7 @@ fun AmiberryApp() {
 							icon = { Icon(screen.icon, contentDescription = title) },
 							label = { Text(title) },
 							selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
-						onClick = { guardedNavigate { navigateToRoute(screen.route) } }
+						onClick = { guardedNavigate(screen.route) { navigateToRoute(screen.route) } }
 					)
 				}
 			}
@@ -252,7 +261,7 @@ fun AmiberryApp() {
 							icon = { Icon(screen.icon, contentDescription = title) },
 							label = { Text(title) },
 							selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
-							onClick = { guardedNavigate { navigateToRoute(screen.route) } }
+							onClick = { guardedNavigate(screen.route) { navigateToRoute(screen.route) } }
 						)
 					}
 				}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/AmiberryApp.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/AmiberryApp.kt
@@ -44,6 +44,15 @@ import com.blitterstudio.amiberry.ui.screens.ConfigurationsScreen
 import com.blitterstudio.amiberry.ui.screens.FileManagerScreen
 import com.blitterstudio.amiberry.ui.screens.QuickStartScreen
 import com.blitterstudio.amiberry.ui.screens.settings.SettingsScreen
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.blitterstudio.amiberry.data.ConfigurationSaveActions
+import com.blitterstudio.amiberry.ui.viewmodel.SettingsViewModel
+import kotlinx.coroutines.launch
 
 @Composable
 fun AmiberryApp() {
@@ -143,6 +152,29 @@ fun AmiberryApp() {
 	val navBackStackEntry by navController.currentBackStackEntryAsState()
 	val currentDestination = navBackStackEntry?.destination
 
+	val settingsViewModel: SettingsViewModel =
+		viewModel(LocalContext.current.findActivity() as ComponentActivity)
+	val navScope = rememberCoroutineScope()
+	var pendingNavigation by remember { mutableStateOf<(() -> Unit)?>(null) }
+
+	fun navigateToRoute(route: String) {
+		navController.navigate(route) {
+			popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+			launchSingleTop = true
+			restoreState = true
+		}
+	}
+
+	val onSettingsRoute = currentDestination?.hierarchy?.any { it.route == Screen.Settings.route } == true
+
+	fun guardedNavigate(action: () -> Unit) {
+		if (onSettingsRoute && settingsViewModel.isDirty) {
+			pendingNavigation = action
+		} else {
+			action()
+		}
+	}
+
 	BackHandler(
 		enabled = shouldMoveTaskToBack(
 			route = currentDestination?.route,
@@ -151,6 +183,46 @@ fun AmiberryApp() {
 		)
 	) {
 		activity?.moveTaskToBack(true)
+	}
+
+	BackHandler(enabled = onSettingsRoute && settingsViewModel.isDirty) {
+		pendingNavigation = { activity?.moveTaskToBack(true) }
+	}
+
+	pendingNavigation?.let { proceed ->
+		val configName = settingsViewModel.currentConfigName.orEmpty()
+		AlertDialog(
+			onDismissRequest = { pendingNavigation = null },
+			title = { Text(stringResource(R.string.dialog_unsaved_changes_title)) },
+			text = { Text(stringResource(R.string.dialog_unsaved_changes_message, configName)) },
+			confirmButton = {
+				TextButton(onClick = {
+					navScope.launch {
+						val result = settingsViewModel.saveTracked()
+						if (result is ConfigurationSaveActions.SaveResult.Saved) {
+							pendingNavigation = null
+							proceed()
+						}
+					}
+				}) {
+					Text(stringResource(R.string.action_save))
+				}
+			},
+			dismissButton = {
+				Row {
+					TextButton(onClick = {
+						settingsViewModel.discardChanges()
+						pendingNavigation = null
+						proceed()
+					}) {
+						Text(stringResource(R.string.action_discard))
+					}
+					TextButton(onClick = { pendingNavigation = null }) {
+						Text(stringResource(R.string.action_cancel))
+					}
+				}
+			}
+		)
 	}
 
 	if (useNavRail) {
@@ -162,15 +234,7 @@ fun AmiberryApp() {
 							icon = { Icon(screen.icon, contentDescription = title) },
 							label = { Text(title) },
 							selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
-						onClick = {
-							navController.navigate(screen.route) {
-								popUpTo(navController.graph.findStartDestination().id) {
-									saveState = true
-								}
-								launchSingleTop = true
-								restoreState = true
-							}
-						}
+						onClick = { guardedNavigate { navigateToRoute(screen.route) } }
 					)
 				}
 			}
@@ -188,15 +252,7 @@ fun AmiberryApp() {
 							icon = { Icon(screen.icon, contentDescription = title) },
 							label = { Text(title) },
 							selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true,
-							onClick = {
-								navController.navigate(screen.route) {
-									popUpTo(navController.graph.findStartDestination().id) {
-										saveState = true
-									}
-									launchSingleTop = true
-									restoreState = true
-								}
-							}
+							onClick = { guardedNavigate { navigateToRoute(screen.route) } }
 						)
 					}
 				}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/ConfigurationsScreen.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/ConfigurationsScreen.kt
@@ -158,7 +158,7 @@ fun ConfigurationsScreen(
 							scope.launch {
 								when (val result = ConfigurationActions.load(runCatching { viewModel.loadConfig(config.path) })) {
 									is ConfigurationActions.LoadResult.Loaded -> {
-										settingsViewModel.loadConfig(result.value, config.name)
+										settingsViewModel.loadConfig(result.value, config.name, config.path)
 										navController.switchToTab(Screen.Settings.route)
 									}
 									is ConfigurationActions.LoadResult.Failed -> {

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/ConfigurationsScreen.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/ConfigurationsScreen.kt
@@ -148,7 +148,7 @@ fun ConfigurationsScreen(
 							scope.launch {
 								when (val result = ConfigurationActions.load(runCatching { viewModel.loadConfig(config.path) })) {
 									is ConfigurationActions.LoadResult.Loaded -> {
-										settingsViewModel.loadConfig(result.value)
+										settingsViewModel.loadConfig(result.value, config.name)
 										navController.navigate(Screen.Settings.route) {
 											popUpTo(Screen.Configurations.route) { inclusive = false }
 										}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/ConfigurationsScreen.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/ConfigurationsScreen.kt
@@ -66,6 +66,8 @@ import com.blitterstudio.amiberry.data.EmulatorLauncher
 import com.blitterstudio.amiberry.ui.dpadFocusIndicator
 import com.blitterstudio.amiberry.ui.findActivity
 import com.blitterstudio.amiberry.ui.launchGuarded
+import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import com.blitterstudio.amiberry.ui.navigation.Screen
 import com.blitterstudio.amiberry.ui.rememberLaunchInFlightGuard
 import com.blitterstudio.amiberry.ui.viewmodel.ConfigurationsViewModel
@@ -74,6 +76,14 @@ import kotlinx.coroutines.launch
 import java.text.DateFormat
 import java.util.Date
 import java.util.Locale
+
+private fun NavController.switchToTab(route: String) {
+	navigate(route) {
+		popUpTo(graph.findStartDestination().id) { saveState = true }
+		launchSingleTop = true
+		restoreState = true
+	}
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -130,7 +140,7 @@ fun ConfigurationsScreen(
 							color = MaterialTheme.colorScheme.onSurfaceVariant
 						)
 						Spacer(modifier = Modifier.height(24.dp))
-						Button(onClick = { navController.navigate(Screen.Settings.route) }) {
+						Button(onClick = { navController.switchToTab(Screen.Settings.route) }) {
 							Text(stringResource(R.string.configurations_empty_cta))
 						}
 				}
@@ -149,9 +159,7 @@ fun ConfigurationsScreen(
 								when (val result = ConfigurationActions.load(runCatching { viewModel.loadConfig(config.path) })) {
 									is ConfigurationActions.LoadResult.Loaded -> {
 										settingsViewModel.loadConfig(result.value, config.name)
-										navController.navigate(Screen.Settings.route) {
-											popUpTo(Screen.Configurations.route) { inclusive = false }
-										}
+										navController.switchToTab(Screen.Settings.route)
 									}
 									is ConfigurationActions.LoadResult.Failed -> {
 										snackbarHostState.showSnackbar(actionMessage(result.message))

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsScreen.kt
@@ -87,7 +87,8 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel(LocalContext.current
 	val importGuard = rememberImportInFlightGuard()
 	val importInProgress = importGuard.isImporting
 	var selectedTab by rememberSaveable { mutableIntStateOf(0) }
-	var showSaveDialog by remember { mutableStateOf(false) }
+	var showSaveAsDialog by remember { mutableStateOf(false) }
+	var overwriteRequest by remember { mutableStateOf<OverwriteRequest?>(null) }
 	var showTopBarMenu by remember { mutableStateOf(false) }
 	val availableRoms by viewModel.availableRoms.collectAsState()
 	val canStart = viewModel.settings.romFile.isNotBlank() || availableRoms.isNotEmpty()
@@ -132,8 +133,34 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel(LocalContext.current
 		snackbarHost = { SnackbarHost(snackbarHostState) },
 		topBar = {
 			TopAppBar(
-				title = { Text(stringResource(R.string.settings_title)) },
+				title = {
+					Column {
+						Text(viewModel.currentConfigName ?: stringResource(R.string.settings_new_configuration))
+						if (viewModel.isDirty) {
+							Text(
+								text = stringResource(R.string.settings_unsaved_changes),
+								style = MaterialTheme.typography.labelSmall,
+								color = MaterialTheme.colorScheme.onSurfaceVariant
+							)
+						}
+					}
+				},
 				actions = {
+					TextButton(
+						onClick = {
+							if (viewModel.currentConfigName == null) {
+								showSaveAsDialog = true
+							} else {
+								scope.launch {
+									val result = viewModel.saveTracked()
+									snackbarHostState.showSnackbar(saveMessage(result))
+								}
+							}
+						},
+						enabled = viewModel.currentConfigName == null || viewModel.isDirty
+					) {
+						Text(stringResource(R.string.action_save))
+					}
 					IconButton(onClick = { showTopBarMenu = true }) {
 						Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.more_options))
 					}
@@ -142,11 +169,11 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel(LocalContext.current
 						onDismissRequest = { showTopBarMenu = false }
 					) {
 						DropdownMenuItem(
-							text = { Text(stringResource(R.string.action_save_configuration)) },
+							text = { Text(stringResource(R.string.action_save_as)) },
 							leadingIcon = { Icon(Icons.Default.Save, contentDescription = null) },
 							onClick = {
 								showTopBarMenu = false
-								showSaveDialog = true
+								showSaveAsDialog = true
 							}
 						)
 						DropdownMenuItem(
@@ -337,39 +364,67 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel(LocalContext.current
 			}
 		}
 
-		if (showSaveDialog) {
-			SaveConfigDialog(
-				onDismiss = { showSaveDialog = false },
-				onSave = { name, description ->
-					val repo = ConfigRepository.getInstance(context)
-					val safeName = name.trim()
-					scope.launch {
-						val result = withContext(Dispatchers.IO) {
-							repo.saveConfigResult(
-								viewModel.settings,
-								safeName,
-								viewModel.currentUnknownLines,
-								description
-							)
+		if (showSaveAsDialog) {
+				SaveConfigDialog(
+					initialName = viewModel.currentConfigName.orEmpty(),
+					initialDescription = viewModel.currentConfigDescription,
+					onDismiss = { showSaveAsDialog = false },
+					onSave = { name, description ->
+						scope.launch {
+							when (val result = viewModel.saveAs(name, description, allowOverwrite = false)) {
+								is ConfigurationSaveActions.SaveResult.Saved -> {
+									showSaveAsDialog = false
+									snackbarHostState.showSnackbar(saveMessage(result))
+								}
+								ConfigurationSaveActions.SaveResult.AlreadyExists ->
+									overwriteRequest = OverwriteRequest(name, description)
+								else -> snackbarHostState.showSnackbar(saveMessage(result))
+							}
 						}
-						if (result is ConfigurationSaveActions.SaveResult.Saved) {
-							showSaveDialog = false
-						}
-						snackbarHostState.showSnackbar(saveMessage(result))
 					}
-				}
-			)
-		}
+				)
+			}
+
+			overwriteRequest?.let { request ->
+				AlertDialog(
+					onDismissRequest = { overwriteRequest = null },
+					title = { Text(stringResource(R.string.dialog_overwrite_config_title)) },
+					text = { Text(stringResource(R.string.dialog_overwrite_config_message, request.name)) },
+					confirmButton = {
+						TextButton(onClick = {
+							scope.launch {
+								val result = viewModel.saveAs(request.name, request.description, allowOverwrite = true)
+								overwriteRequest = null
+								if (result is ConfigurationSaveActions.SaveResult.Saved) {
+									showSaveAsDialog = false
+								}
+								snackbarHostState.showSnackbar(saveMessage(result))
+							}
+						}) {
+							Text(stringResource(R.string.action_overwrite))
+						}
+					},
+					dismissButton = {
+						TextButton(onClick = { overwriteRequest = null }) {
+							Text(stringResource(R.string.action_cancel))
+						}
+					}
+				)
+			}
 	}
 }
 
+private data class OverwriteRequest(val name: String, val description: String)
+
 @Composable
 fun SaveConfigDialog(
+	initialName: String,
+	initialDescription: String,
 	onDismiss: () -> Unit,
 	onSave: (String, String) -> Unit
 ) {
-	var name by remember { mutableStateOf("") }
-	var description by remember { mutableStateOf("") }
+	var name by remember { mutableStateOf(initialName) }
+	var description by remember { mutableStateOf(initialDescription) }
 
 	AlertDialog(
 		onDismissRequest = onDismiss,

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
@@ -15,19 +15,39 @@ import com.blitterstudio.amiberry.data.model.EmulatorSettings
 import com.blitterstudio.amiberry.data.model.EmulatorSettingsConstraints
 import com.blitterstudio.amiberry.data.model.ModelRomAvailability
 import com.blitterstudio.amiberry.data.ConfigParser
+import com.blitterstudio.amiberry.data.ConfigRepository
+import com.blitterstudio.amiberry.data.ConfigurationSaveActions
 import com.blitterstudio.amiberry.ui.hasTouchScreen
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
 
 	private val repository = FileRepository.getInstance(application)
+	private val configRepository = ConfigRepository.getInstance(application)
 
 	var settings by mutableStateOf(EmulatorSettings())
 		private set
 
 	var currentUnknownLines by mutableStateOf<List<String>>(emptyList())
 		private set
+
+	var currentConfigName by mutableStateOf<String?>(null)
+		private set
+
+	var currentConfigDescription by mutableStateOf("")
+		private set
+
+	// State-backed so updating the baseline (on save/load, when `settings` itself does not
+	// change) still triggers recomposition of anything observing isDirty.
+	private var baselineSettings by mutableStateOf(EmulatorSettings())
+	private var baselineUnknownLines by mutableStateOf<List<String>>(emptyList())
+
+	val isDirty: Boolean
+		get() = currentConfigName != null &&
+			(settings != baselineSettings || currentUnknownLines != baselineUnknownLines)
 
 	val availableRoms: StateFlow<List<AmigaFile>> = repository.roms
 	val availableFloppies: StateFlow<List<AmigaFile>> = repository.floppies
@@ -81,11 +101,58 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 		saveLastSession()
 	}
 
-	fun loadConfig(parsed: ConfigParser.ParsedConfig) {
+	fun loadConfig(parsed: ConfigParser.ParsedConfig, name: String) {
 		settings = applyConstraints(parsed.settings)
 		currentUnknownLines = parsed.unknownLines
+		currentConfigName = name
+		currentConfigDescription = parsed.description
 		autoSelectDefaultRomIfNeeded(availableRoms.value)
+		baselineSettings = settings
+		baselineUnknownLines = currentUnknownLines
 		saveLastSession()
+	}
+
+	/** Overwrite the config currently being edited. Requires an open config. */
+	suspend fun saveTracked(): ConfigurationSaveActions.SaveResult {
+		val name = currentConfigName ?: return ConfigurationSaveActions.SaveResult.InvalidName
+		return saveAs(name, currentConfigDescription, allowOverwrite = true)
+	}
+
+	/**
+	 * Save under [name]. With [allowOverwrite] false, a collision with a *different*
+	 * existing config returns AlreadyExists so the UI can confirm. On success the saved
+	 * config becomes the tracked config and the dirty baseline is reset.
+	 */
+	suspend fun saveAs(
+		name: String,
+		description: String,
+		allowOverwrite: Boolean
+	): ConfigurationSaveActions.SaveResult {
+		val savedSettings = settings
+		val savedUnknownLines = currentUnknownLines
+		val result = withContext(Dispatchers.IO) {
+			configRepository.saveResolved(
+				settings = savedSettings,
+				requestedName = name,
+				currentConfigName = currentConfigName,
+				unknownLines = savedUnknownLines,
+				description = description,
+				allowOverwrite = allowOverwrite
+			)
+		}
+		if (result is ConfigurationSaveActions.SaveResult.Saved) {
+			currentConfigName = result.file.nameWithoutExtension
+			currentConfigDescription = description
+			baselineSettings = savedSettings
+			baselineUnknownLines = savedUnknownLines
+		}
+		return result
+	}
+
+	/** Revert in-memory edits back to the last saved/loaded values of the open config. */
+	fun discardChanges() {
+		settings = baselineSettings
+		currentUnknownLines = baselineUnknownLines
 	}
 
 	private fun autoSelectDefaultRomIfNeeded(roms: List<AmigaFile>) {

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
@@ -153,6 +153,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 	fun discardChanges() {
 		settings = baselineSettings
 		currentUnknownLines = baselineUnknownLines
+		saveLastSession()
 	}
 
 	private fun autoSelectDefaultRomIfNeeded(roms: List<AmigaFile>) {

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
@@ -40,6 +40,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 	var currentConfigDescription by mutableStateOf("")
 		private set
 
+	var currentConfigPath by mutableStateOf<String?>(null)
+		private set
+
 	// State-backed so updating the baseline (on save/load, when `settings` itself does not
 	// change) still triggers recomposition of anything observing isDirty.
 	private var baselineSettings by mutableStateOf(EmulatorSettings())
@@ -101,21 +104,43 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 		saveLastSession()
 	}
 
-	fun loadConfig(parsed: ConfigParser.ParsedConfig, name: String) {
+	fun loadConfig(parsed: ConfigParser.ParsedConfig, name: String, path: String) {
 		settings = applyConstraints(parsed.settings)
 		currentUnknownLines = parsed.unknownLines
 		currentConfigName = name
 		currentConfigDescription = parsed.description
+		currentConfigPath = path
 		autoSelectDefaultRomIfNeeded(availableRoms.value)
 		baselineSettings = settings
 		baselineUnknownLines = currentUnknownLines
 		saveLastSession()
 	}
 
-	/** Overwrite the config currently being edited. Requires an open config. */
+	/** Overwrite the exact config file currently being edited. Requires an open config. */
 	suspend fun saveTracked(): ConfigurationSaveActions.SaveResult {
-		val name = currentConfigName ?: return ConfigurationSaveActions.SaveResult.InvalidName
-		return saveAs(name, currentConfigDescription, allowOverwrite = true)
+		val path = currentConfigPath
+		if (path == null) {
+			// No exact path tracked — fall back to name-based save.
+			val name = currentConfigName ?: return ConfigurationSaveActions.SaveResult.InvalidName
+			return saveAs(name, currentConfigDescription, allowOverwrite = true)
+		}
+		val savedSettings = settings
+		val savedUnknownLines = currentUnknownLines
+		val result = withContext(Dispatchers.IO) {
+			configRepository.overwriteConfigAtPath(
+				path = path,
+				settings = savedSettings,
+				unknownLines = savedUnknownLines,
+				description = currentConfigDescription
+			)
+		}
+		if (result is ConfigurationSaveActions.SaveResult.Saved) {
+			currentConfigName = result.file.nameWithoutExtension
+			currentConfigPath = result.file.absolutePath
+			baselineSettings = savedSettings
+			baselineUnknownLines = savedUnknownLines
+		}
+		return result
 	}
 
 	/**
@@ -142,6 +167,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 		}
 		if (result is ConfigurationSaveActions.SaveResult.Saved) {
 			currentConfigName = result.file.nameWithoutExtension
+			currentConfigPath = result.file.absolutePath
 			currentConfigDescription = description
 			baselineSettings = savedSettings
 			baselineUnknownLines = savedUnknownLines

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -56,6 +56,9 @@
     <string name="dialog_overwrite_config_title">Overwrite configuration?</string>
     <string name="dialog_overwrite_config_message">A configuration named \"%1$s\" already exists. Overwrite it?</string>
     <string name="action_overwrite">Overwrite</string>
+    <string name="action_discard">Discard</string>
+    <string name="dialog_unsaved_changes_title">Unsaved changes</string>
+    <string name="dialog_unsaved_changes_message">Save your changes to \"%1$s\" before leaving?</string>
     <string name="dialog_delete_config_title">Delete Configuration</string>
     <string name="dialog_delete_config_message">Delete "%1$s"? This cannot be undone.</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="action_edit_config">Edit Config</string>
     <string name="action_save_configuration">Save Configuration</string>
     <string name="action_advanced">Advanced</string>
+    <string name="action_save_as">Save As…</string>
     <string name="action_edit_advanced_imgui">Edit in Advanced mode (ImGui)</string>
     <string name="action_eject">Eject</string>
     <string name="action_share">Share</string>
@@ -50,6 +51,11 @@
     <string name="label_configuration_description">Description (optional)</string>
     <string name="dialog_save_config_title">Save Configuration</string>
     <string name="dialog_save_config_message">Enter a name for this configuration.</string>
+    <string name="settings_new_configuration">New configuration</string>
+    <string name="settings_unsaved_changes">Unsaved changes</string>
+    <string name="dialog_overwrite_config_title">Overwrite configuration?</string>
+    <string name="dialog_overwrite_config_message">A configuration named \"%1$s\" already exists. Overwrite it?</string>
+    <string name="action_overwrite">Overwrite</string>
     <string name="dialog_delete_config_title">Delete Configuration</string>
     <string name="dialog_delete_config_message">Delete "%1$s"? This cannot be undone.</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -34,7 +34,6 @@
     <string name="action_duplicate">Duplicate</string>
     <string name="action_launch">Launch</string>
     <string name="action_edit_config">Edit Config</string>
-    <string name="action_save_configuration">Save Configuration</string>
     <string name="action_advanced">Advanced</string>
     <string name="action_save_as">Save As…</string>
     <string name="action_edit_advanced_imgui">Edit in Advanced mode (ImGui)</string>

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigFilesTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigFilesTest.kt
@@ -2,6 +2,7 @@ package com.blitterstudio.amiberry.data
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -101,6 +102,29 @@ class ConfigFilesTest {
 		assertNull(ConfigFiles.targetFileForName(confDir, ".hidden"))
 		assertNull(ConfigFiles.targetFileForName(confDir, "a/b"))
 		assertNull(ConfigFiles.targetFileForName(confDir, "a\\b"))
+	}
+
+	@Test
+	fun `userConfigFile preserves the exact filename and extension case`() {
+		val confDir = tempDir.newFolder("Configurations")
+		// Capture the name-based filename BEFORE the file exists so canonical resolution
+		// cannot fold Workbench.uae → Workbench.UAE on case-insensitive filesystems (Windows).
+		val nameBasedName = ConfigFiles.targetFileForName(confDir, "Workbench")!!.name
+		val upper = File(confDir, "Workbench.UAE")
+		upper.writeText("cpu_model=68000\n")
+
+		val resolved = ConfigFiles.userConfigFile(confDir, upper.absolutePath)
+
+		assertEquals(upper.canonicalFile, resolved)
+		// A name-based target would have forced a different lowercase-extension file:
+		assertNotEquals(resolved!!.name, nameBasedName)
+	}
+
+	@Test
+	fun `userConfigFile rejects a path outside the configurations dir`() {
+		val confDir = tempDir.newFolder("Configurations")
+		val outside = tempDir.newFile("Outside.uae")
+		assertNull(ConfigFiles.userConfigFile(confDir, outside.absolutePath))
 	}
 
 	private fun configFile(confDir: File, name: String, text: String): File =

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigRepositoryTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigRepositoryTest.kt
@@ -128,6 +128,26 @@ class ConfigRepositoryTest {
 		assertTrue(existing.readText().contains("68020"))
 	}
 
+	@Test
+	fun `saveResolved gates a different-config collision behind allowOverwrite`() {
+		val source = File("src/main/java/com/blitterstudio/amiberry/data/ConfigRepository.kt").readText()
+
+		assertTrue(
+			"ConfigRepository should expose saveResolved(...) with currentConfigName and allowOverwrite.",
+			Regex("""fun saveResolved\([\s\S]*currentConfigName[\s\S]*allowOverwrite""")
+				.containsMatchIn(source)
+		)
+		assertTrue(
+			"saveResolved should resolve the request through ConfigSaveResolver.",
+			source.contains("ConfigSaveResolver.resolve(")
+		)
+		assertTrue(
+			"A collision with a different config must return AlreadyExists unless allowOverwrite is set.",
+			Regex("""CollisionWithOther[\s\S]*if \(allowOverwrite\)[\s\S]*else return[\s\S]*AlreadyExists""")
+				.containsMatchIn(source)
+		)
+	}
+
 	/**
 	 * Mirror of ConfigRepository.isValidConfigName for testing without Context.
 	 */

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigRepositoryTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigRepositoryTest.kt
@@ -148,6 +148,13 @@ class ConfigRepositoryTest {
 		)
 	}
 
+	@Test
+	fun `overwriteConfigAtPath writes the exact user config file`() {
+		val source = File("src/main/java/com/blitterstudio/amiberry/data/ConfigRepository.kt").readText()
+		assertTrue(source.contains("fun overwriteConfigAtPath("))
+		assertTrue(source.contains("ConfigFiles.userConfigFile(confDir, path)"))
+	}
+
 	/**
 	 * Mirror of ConfigRepository.isValidConfigName for testing without Context.
 	 */

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigSaveResolverTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigSaveResolverTest.kt
@@ -1,0 +1,73 @@
+package com.blitterstudio.amiberry.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ConfigSaveResolverTest {
+
+	@get:Rule
+	val tempDir = TemporaryFolder()
+
+	private fun confDir(): File = tempDir.newFolder("Configurations")
+
+	@Test
+	fun `invalid name resolves to InvalidName`() {
+		val resolution = ConfigSaveResolver.resolve(confDir(), "../bad", currentConfigName = null)
+		assertTrue(resolution is ConfigSaveResolver.Resolution.InvalidName)
+	}
+
+	@Test
+	fun `new name with no open config resolves to WriteNew`() {
+		val dir = confDir()
+		val resolution = ConfigSaveResolver.resolve(dir, "Workbench", currentConfigName = null)
+		assertEquals(
+			ConfigSaveResolver.Resolution.WriteNew(File(dir, "Workbench.uae").canonicalFile),
+			resolution
+		)
+	}
+
+	@Test
+	fun `saving to the open config resolves to OverwriteTracked even though the file exists`() {
+		val dir = confDir()
+		File(dir, "Workbench.uae").writeText("cpu_model=68000\n")
+		val resolution = ConfigSaveResolver.resolve(dir, "Workbench", currentConfigName = "Workbench")
+		assertEquals(
+			ConfigSaveResolver.Resolution.OverwriteTracked(File(dir, "Workbench.uae").canonicalFile),
+			resolution
+		)
+	}
+
+	@Test
+	fun `open config name with uae suffix still resolves to OverwriteTracked`() {
+		val dir = confDir()
+		File(dir, "Workbench.uae").writeText("cpu_model=68000\n")
+		val resolution = ConfigSaveResolver.resolve(dir, "Workbench.uae", currentConfigName = "Workbench")
+		assertTrue(resolution is ConfigSaveResolver.Resolution.OverwriteTracked)
+	}
+
+	@Test
+	fun `name of a different existing config resolves to CollisionWithOther`() {
+		val dir = confDir()
+		File(dir, "Games.uae").writeText("cpu_model=68020\n")
+		val resolution = ConfigSaveResolver.resolve(dir, "Games", currentConfigName = "Workbench")
+		assertEquals(
+			ConfigSaveResolver.Resolution.CollisionWithOther(File(dir, "Games.uae").canonicalFile),
+			resolution
+		)
+	}
+
+	@Test
+	fun `third new name while a config is open resolves to WriteNew`() {
+		val dir = confDir()
+		File(dir, "Workbench.uae").writeText("cpu_model=68000\n")
+		val resolution = ConfigSaveResolver.resolve(dir, "Demos", currentConfigName = "Workbench")
+		assertEquals(
+			ConfigSaveResolver.Resolution.WriteNew(File(dir, "Demos.uae").canonicalFile),
+			resolution
+		)
+	}
+}

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/AppShellUnsavedChangesArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/AppShellUnsavedChangesArchitectureTest.kt
@@ -34,4 +34,16 @@ class AppShellUnsavedChangesArchitectureTest {
 		assertTrue(source.contains("settingsViewModel.discardChanges()"))
 		assertTrue(source.contains("R.string.action_discard"))
 	}
+
+	@Test
+	fun `guard does not fire when re-selecting the current Settings tab`() {
+		assertTrue(source.contains("targetRoute != Screen.Settings.route"))
+		assertTrue(source.contains("guardedNavigate(screen.route)"))
+	}
+
+	@Test
+	fun `guard save failure surfaces feedback instead of getting stuck`() {
+		assertTrue(source.contains("Toast"))
+		assertTrue(source.contains("R.string.msg_failed_save_config"))
+	}
 }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/AppShellUnsavedChangesArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/AppShellUnsavedChangesArchitectureTest.kt
@@ -1,0 +1,37 @@
+package com.blitterstudio.amiberry.ui
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class AppShellUnsavedChangesArchitectureTest {
+
+	private val source =
+		File("src/main/java/com/blitterstudio/amiberry/ui/AmiberryApp.kt").readText()
+
+	@Test
+	fun `app shell observes the shared settings view model`() {
+		assertTrue(source.contains("SettingsViewModel"))
+		assertTrue(source.contains("settingsViewModel.isDirty"))
+	}
+
+	@Test
+	fun `navigation away from a dirty Settings screen is guarded`() {
+		// Bottom-nav/rail clicks route through a guard rather than navigating directly.
+		assertTrue(source.contains("guardedNavigate("))
+		assertTrue(
+			Regex("""Screen\.Settings\.route[\s\S]*settingsViewModel\.isDirty""")
+				.containsMatchIn(source) ||
+			Regex("""settingsViewModel\.isDirty[\s\S]*Screen\.Settings\.route""")
+				.containsMatchIn(source)
+		)
+	}
+
+	@Test
+	fun `shows an unsaved-changes dialog with save and discard`() {
+		assertTrue(source.contains("R.string.dialog_unsaved_changes_title"))
+		assertTrue(source.contains("settingsViewModel.saveTracked()"))
+		assertTrue(source.contains("settingsViewModel.discardChanges()"))
+		assertTrue(source.contains("R.string.action_discard"))
+	}
+}

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/ConfigurationsScreenArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/ConfigurationsScreenArchitectureTest.kt
@@ -1,5 +1,6 @@
 package com.blitterstudio.amiberry.ui
 
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -32,6 +33,20 @@ class ConfigurationsScreenArchitectureTest {
 		assertTrue(
 			"Edit should hand the config name to the Settings editor so Save can overwrite it.",
 			source.contains("settingsViewModel.loadConfig(result.value, config.name)")
+		)
+	}
+
+	@Test
+	fun `editing a config switches to the Settings tab so other tabs stay reachable`() {
+		val source = File("src/main/java/com/blitterstudio/amiberry/ui/screens/ConfigurationsScreen.kt").readText()
+		assertTrue(
+			"Navigation to Settings must use the standard tab-switch options (saveState + restoreState), not stack Settings on the Configs entry.",
+			source.contains("popUpTo(graph.findStartDestination().id) { saveState = true }") &&
+				source.contains("restoreState = true")
+		)
+		assertFalse(
+			"Edit must not push Settings on top of the Configurations entry — that breaks returning to the Configs tab.",
+			source.contains("popUpTo(Screen.Configurations.route)")
 		)
 	}
 }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/ConfigurationsScreenArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/ConfigurationsScreenArchitectureTest.kt
@@ -24,4 +24,14 @@ class ConfigurationsScreenArchitectureTest {
 			source.contains("R.string.configurations_refresh")
 		)
 	}
+
+	@Test
+	fun `editing a config passes its name so the editor can save it back`() {
+		val source = File("src/main/java/com/blitterstudio/amiberry/ui/screens/ConfigurationsScreen.kt").readText()
+
+		assertTrue(
+			"Edit should hand the config name to the Settings editor so Save can overwrite it.",
+			source.contains("settingsViewModel.loadConfig(result.value, config.name)")
+		)
+	}
 }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/ConfigurationsScreenArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/ConfigurationsScreenArchitectureTest.kt
@@ -32,7 +32,7 @@ class ConfigurationsScreenArchitectureTest {
 
 		assertTrue(
 			"Edit should hand the config name to the Settings editor so Save can overwrite it.",
-			source.contains("settingsViewModel.loadConfig(result.value, config.name)")
+			source.contains("settingsViewModel.loadConfig(result.value, config.name, config.path)")
 		)
 	}
 

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsScreenSaveArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsScreenSaveArchitectureTest.kt
@@ -1,0 +1,50 @@
+package com.blitterstudio.amiberry.ui.screens.settings
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class SettingsScreenSaveArchitectureTest {
+
+	private val source =
+		File("src/main/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsScreen.kt").readText()
+
+	@Test
+	fun `title shows the open config name or a new-configuration label`() {
+		assertTrue(source.contains("viewModel.currentConfigName"))
+		assertTrue(source.contains("R.string.settings_new_configuration"))
+	}
+
+	@Test
+	fun `shows an unsaved-changes indicator driven by isDirty`() {
+		assertTrue(source.contains("viewModel.isDirty"))
+		assertTrue(source.contains("R.string.settings_unsaved_changes"))
+	}
+
+	@Test
+	fun `top bar has a Save action that saves the tracked config`() {
+		assertTrue(
+			Regex("""actions = \{[\s\S]*viewModel\.saveTracked\(\)""").containsMatchIn(source)
+		)
+	}
+
+	@Test
+	fun `overflow offers Save As`() {
+		assertTrue(source.contains("R.string.action_save_as"))
+	}
+
+	@Test
+	fun `a different-config collision triggers an overwrite confirmation`() {
+		assertTrue(source.contains("R.string.dialog_overwrite_config_title"))
+		assertTrue(source.contains("allowOverwrite = true"))
+		assertTrue(source.contains("ConfigurationSaveActions.SaveResult.AlreadyExists"))
+	}
+
+	@Test
+	fun `save dialog is seeded with the current name and description`() {
+		assertTrue(
+			Regex("""SaveConfigDialog\([\s\S]*initialName[\s\S]*initialDescription""")
+				.containsMatchIn(source)
+		)
+	}
+}

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsViewModelArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsViewModelArchitectureTest.kt
@@ -1,0 +1,43 @@
+package com.blitterstudio.amiberry.ui.screens.settings
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class SettingsViewModelArchitectureTest {
+
+	private val source =
+		File("src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt").readText()
+
+	@Test
+	fun `tracks the open config name and description`() {
+		assertTrue(source.contains("var currentConfigName"))
+		assertTrue(source.contains("var currentConfigDescription"))
+	}
+
+	@Test
+	fun `exposes dirty state derived from a baseline snapshot`() {
+		assertTrue(source.contains("baselineSettings"))
+		assertTrue(source.contains("baselineUnknownLines"))
+		assertTrue(
+			Regex("""val isDirty[\s\S]*currentConfigName != null[\s\S]*settings != baselineSettings""")
+				.containsMatchIn(source)
+		)
+	}
+
+	@Test
+	fun `loadConfig takes the config name`() {
+		assertTrue(
+			Regex("""fun loadConfig\(\s*parsed: ConfigParser\.ParsedConfig,\s*name: String""")
+				.containsMatchIn(source)
+		)
+	}
+
+	@Test
+	fun `exposes save and discard operations`() {
+		assertTrue(source.contains("suspend fun saveTracked()"))
+		assertTrue(source.contains("suspend fun saveAs("))
+		assertTrue(source.contains("fun discardChanges()"))
+		assertTrue(source.contains("configRepository.saveResolved("))
+	}
+}

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsViewModelArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsViewModelArchitectureTest.kt
@@ -40,4 +40,11 @@ class SettingsViewModelArchitectureTest {
 		assertTrue(source.contains("fun discardChanges()"))
 		assertTrue(source.contains("configRepository.saveResolved("))
 	}
+
+	@Test
+	fun `tracks the exact config path and overwrites it on save`() {
+		assertTrue(source.contains("var currentConfigPath"))
+		assertTrue(source.contains("configRepository.overwriteConfigAtPath("))
+		assertTrue(Regex("""fun loadConfig\([\s\S]*name: String,\s*path: String""").containsMatchIn(source))
+	}
 }


### PR DESCRIPTION
## Problem

Editing a saved config on Android was confusing. The reported flow: go to **Configs → Edit**, which drops you on the shared **Settings** screen with no obvious way to save your changes back. The only Save lived behind the `⋯` overflow and always asked for a name — re-typing the same name returned *"config already exists"* with no way to overwrite, and there was no clear way back to the Configs list.

Root cause: the Settings screen is a shared live editor, and opening a config via Edit loaded its settings but **discarded the config's identity**, so "Save" could only ever create a new file.

## What changed

A document-editor model for config editing:

- **Save** overwrites the config you're editing, silently, with a toast — no prompt.
- **Save As…** creates a new named config; a name collision with a *different* config shows an **Overwrite?** confirmation.
- The title shows **which** config is open (or "New configuration") and an **Unsaved changes** indicator when edits diverge from the saved values.
- Leaving the Settings screen with unsaved edits (bottom nav / nav rail / system back) prompts **Save / Discard / Cancel**.
- **Edit** now carries the config's name into the editor so Save knows what to overwrite.
- Fixed a pre-existing navigation bug where the **Configs tab became unreachable** after editing a config (Settings was being stacked on top of the Configs back-stack entry; both Settings navigations now use the standard tab-switch options).

## Implementation

- `ConfigSaveResolver` — pure classifier: new / overwrite-tracked / collide-with-different / invalid.
- `ConfigRepository.saveResolved(...)` — overwrite-aware save; the existing `saveConfigResult(...)` is untouched.
- `SettingsViewModel` — tracks the open config + a state-backed baseline for `isDirty`; `loadConfig(parsed, name)`, `saveTracked()`, `saveAs(...)`, `discardChanges()`.
- `SettingsScreen` — name/dirty title, Save button, Save As, overwrite-confirm dialog.
- `AmiberryApp` — the unsaved-changes navigation guard.

## Testing

- 384 JVM unit tests pass (pure logic + the project's source-level "architecture" tests; no Robolectric in this module).
- Manually verified on-device: dirty indicator, silent Save + toast, Save As, overwrite confirm, discard guard, and the Configs-tab navigation fix.

## Review

Built task-by-task with per-task reviews plus a final whole-branch review. The final review's two Important findings were fixed in `8a05bd7c`:
- the guard no longer fires when you re-tap the Settings tab you're already on (which previously exposed a Discard-wipes-edits path);
- the guard's Save now surfaces a Toast and closes instead of getting stuck if the write fails.

## Known follow-up (not in this PR)

QuickStart's `applyModel` / media-pruning mutate the same activity-scoped `SettingsViewModel`. After editing a tracked config and visiting QuickStart, if its model/media became unavailable the working set can diverge from baseline and show "Unsaved changes" the user didn't make. Pre-existing behavior that only now has a visible consequence; worth a separate, scoped fix.
