### PR TITLE
capsimage: fix IPF/CT-Raw images failing to lock with 5.2 library

### DIFF
--- a/external/capsimage/CAPSImg/DiskImage.cpp
+++ b/external/capsimage/CAPSImg/DiskImage.cpp
@@ -39,7 +39,11 @@ int CDiskImage::Lock(std::unique_ptr<CBaseFile> pf)
 // release file
 int CDiskImage::Unlock()
 {
-	return imgeUnsupported;
+	// the base class is only used as an empty placeholder container, so there
+	// is nothing locked to release; report success. CAPSLockImage[Memory] now
+	// calls Unlock() before (re)locking and aborts on any non-imgeOk result, so
+	// returning an error here would make the first lock of every image fail.
+	return imgeOk;
 }
 
 // load image file and test for erros


### PR DESCRIPTION
## Problem

After updating to the CAPSimg 5.2 library (#2120), inserting an `.ipf` disk no longer boots. Opening the GUI shows the misleading **"Old version of capsimg found"** popup — even though the log confirms the library loaded and reported its version correctly:

```
CAPS: library version 5.2 (flags=00007FFF)
caps: CAPSLockImageMemory() returned 1
```

`return 1` is `imgeUnsupported`. Amiberry shows `NUMSG_OLDCAPS` for any `imgeUnsupported`/`imgeIncompatible` result from `CAPSLockImageMemory()`, so the message is not a real version check.

## Root cause

The 5.2 import added an `img[id]->Unlock()` precheck to `CAPSLockImage`/`CAPSLockImageMemory` that aborts on any non-`imgeOk` result:

```cpp
int res = img[id]->Unlock();
if (res != imgeOk)
    return res;            // imgeUnsupported = 1
```

`CAPSAddImage()` fills every drive container with a base `CDiskImage` placeholder, and `CDiskImage::Unlock()` returned `imgeUnsupported`. So the **first lock of every image** aborts before type detection ever runs. The previous library never called `Unlock()` here, which is why IPFs worked before.

## Fix

Make the base `CDiskImage::Unlock()` return `imgeOk` — an empty placeholder container has nothing locked to release. This also fixes:
- CT-Raw re-locking (`CCapsImage` inherits the base `Unlock`)
- `CAPSUnlockImage()` on a never-locked container

This is an upstream-side fix, to be forwarded to the CAPSimg authors alongside the other 5.2 adaptations.

## Testing

Rebuilt the plugin and confirmed `4d_sports_driving.uae` (an `.ipf` config) now boots, with no "old capsimg" popup.