### PR TITLE
Fix Host Only cursor handling

### DIFF
--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -4424,8 +4424,9 @@ static void cursorsprite(struct sprite *s)
 		sprite_0_colors[3] = amiberry_cursor_rgb12_to_rgb24(agnus_colors.color_regs_ecs[19]);
 	}
 	sprite_0_width = sprite_width;
-	if (currprefs.input_tablet && (currprefs.input_mouse_untrap & MOUSEUNTRAP_MAGIC) &&
-		currprefs.input_magic_mouse_cursor == MAGICMOUSE_HOST_ONLY && mousehack_alive()) {
+	if (amiberry_cursor_host_only_enabled(currprefs.input_tablet,
+		currprefs.input_mouse_untrap, MOUSEUNTRAP_MAGIC,
+		currprefs.input_magic_mouse_cursor, MAGICMOUSE_HOST_ONLY) && mousehack_alive()) {
 		magic_sprite_mask &= ~SPRITE_RENDER_MASK(0);
 	} else {
 		magic_sprite_mask |= SPRITE_RENDER_MASK(0);

--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -30,6 +30,7 @@
 #include "blitter.h"
 #include "xwin.h"
 #include "inputdevice.h"
+#include "amiberry_cursor.h"
 #ifdef SERIAL_PORT
 #include "serial.h"
 #endif
@@ -693,11 +694,13 @@ static struct sprite spr[MAX_SPRITES];
 uaecptr sprite_0;
 int sprite_0_width, sprite_0_height, sprite_0_doubled;
 uae_u32 sprite_0_colors[4];
-static uae_u8 magic_sprite_mask = 0xff;
+uae_u32 magic_sprite_mask = 0xffffffff;
 
 static int sprite_width;
 static int sprite_sprctlmask;
 int sprite_buffer_res;
+
+#define SPRITE_RENDER_MASK(num) ((3u << ((num) * 2)) | (1u << ((num) + 16)))
 
 static uae_s16 bpl1mod, bpl2mod;
 static uaecptr bplpt[MAX_PLANES];
@@ -4416,17 +4419,16 @@ static void cursorsprite(struct sprite *s)
 		sprite_0_colors[2] = agnus_colors.color_regs_aga[sbasecol + 2] & 0xffffff;
 		sprite_0_colors[3] = agnus_colors.color_regs_aga[sbasecol + 3] & 0xffffff;
 	} else {
-		sprite_0_colors[1] = xcolors[agnus_colors.color_regs_ecs[17] & 0xfff];
-		sprite_0_colors[2] = xcolors[agnus_colors.color_regs_ecs[18] & 0xfff];
-		sprite_0_colors[3] = xcolors[agnus_colors.color_regs_ecs[19] & 0xfff];
+		sprite_0_colors[1] = amiberry_cursor_rgb12_to_rgb24(agnus_colors.color_regs_ecs[17]);
+		sprite_0_colors[2] = amiberry_cursor_rgb12_to_rgb24(agnus_colors.color_regs_ecs[18]);
+		sprite_0_colors[3] = amiberry_cursor_rgb12_to_rgb24(agnus_colors.color_regs_ecs[19]);
 	}
 	sprite_0_width = sprite_width;
-	if (currprefs.input_tablet && (currprefs.input_mouse_untrap & MOUSEUNTRAP_MAGIC)) {
-		if (currprefs.input_magic_mouse_cursor == MAGICMOUSE_HOST_ONLY && mousehack_alive()) {
-			magic_sprite_mask &= ~1;
-		} else {
-			magic_sprite_mask |= 1;
-		}
+	if (currprefs.input_tablet && (currprefs.input_mouse_untrap & MOUSEUNTRAP_MAGIC) &&
+		currprefs.input_magic_mouse_cursor == MAGICMOUSE_HOST_ONLY && mousehack_alive()) {
+		magic_sprite_mask &= ~SPRITE_RENDER_MASK(0);
+	} else {
+		magic_sprite_mask |= SPRITE_RENDER_MASK(0);
 	}
 }
 

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -4525,6 +4525,7 @@ static uae_u32 decode_pixel(uint8_t pix)
 
 static void denise_collide_sprites(uae_u8 apixel, uae_u32 vs)
 {
+	vs &= magic_sprite_mask;
 	uae_u8 c = vs >> 16;
 	uae_u16 v = (uae_u16)vs;
 	if (currprefs.collision_level) {
@@ -4553,6 +4554,7 @@ static void denise_collide_sprites(uae_u8 apixel, uae_u32 vs)
 
 static uae_u8 denise_render_sprites2(uae_u8 apixel, uae_u32 vs)
 {
+	vs &= magic_sprite_mask;
 	uae_u8 c = vs >> 16;
 	uae_u16 v = (uae_u16)vs;
 	if (currprefs.collision_level) {

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -4525,7 +4525,6 @@ static uae_u32 decode_pixel(uint8_t pix)
 
 static void denise_collide_sprites(uae_u8 apixel, uae_u32 vs)
 {
-	vs &= magic_sprite_mask;
 	uae_u8 c = vs >> 16;
 	uae_u16 v = (uae_u16)vs;
 	if (currprefs.collision_level) {
@@ -4554,12 +4553,12 @@ static void denise_collide_sprites(uae_u8 apixel, uae_u32 vs)
 
 static uae_u8 denise_render_sprites2(uae_u8 apixel, uae_u32 vs)
 {
-	vs &= magic_sprite_mask;
-	uae_u8 c = vs >> 16;
-	uae_u16 v = (uae_u16)vs;
 	if (currprefs.collision_level) {
 		denise_collide_sprites(apixel, vs);
 	}
+	vs &= magic_sprite_mask;
+	uae_u8 c = vs >> 16;
+	uae_u16 v = (uae_u16)vs;
 	int *shift_lookup = bpldualpf ? (bpldualpfpri ? dblpf_ms2 : dblpf_ms1) : dblpf_ms;
 	int maskshift, plfmask;
 	maskshift = shift_lookup[apixel];

--- a/src/include/amiberry_cursor.h
+++ b/src/include/amiberry_cursor.h
@@ -26,9 +26,11 @@ static inline std::uint32_t amiberry_cursor_rgba32_from_rgb24(std::uint32_t rgb)
 }
 
 static inline bool amiberry_cursor_host_only_enabled(int input_tablet,
+	int input_mouse_untrap, int magic_mouse_untrap_value,
 	int input_magic_mouse_cursor, int host_only_cursor_value)
 {
 	return input_tablet > 0
+		&& (input_mouse_untrap & magic_mouse_untrap_value) != 0
 		&& input_magic_mouse_cursor == host_only_cursor_value;
 }
 

--- a/src/include/amiberry_cursor.h
+++ b/src/include/amiberry_cursor.h
@@ -1,0 +1,45 @@
+#ifndef AMIBERRY_CURSOR_H
+#define AMIBERRY_CURSOR_H
+
+#include <cstdint>
+
+static inline std::uint32_t amiberry_cursor_rgb12_to_rgb24(std::uint16_t color)
+{
+	const std::uint32_t r = (color >> 8) & 0x0f;
+	const std::uint32_t g = (color >> 4) & 0x0f;
+	const std::uint32_t b = color & 0x0f;
+
+	return ((r << 20) | (r << 16) | (g << 12) | (g << 8) | (b << 4) | b);
+}
+
+static inline std::uint32_t amiberry_cursor_rgba32_from_rgb24(std::uint32_t rgb)
+{
+	const std::uint32_t r = (rgb >> 16) & 0xff;
+	const std::uint32_t g = (rgb >> 8) & 0xff;
+	const std::uint32_t b = rgb & 0xff;
+
+#ifdef WORDS_BIGENDIAN
+	return (r << 24) | (g << 16) | (b << 8) | 0xff;
+#else
+	return 0xff000000 | (b << 16) | (g << 8) | r;
+#endif
+}
+
+static inline bool amiberry_cursor_host_only_enabled(int input_tablet,
+	int input_magic_mouse_cursor, int host_only_cursor_value)
+{
+	return input_tablet > 0
+		&& input_magic_mouse_cursor == host_only_cursor_value;
+}
+
+static inline bool amiberry_cursor_rtg_needs_separate_sprite(bool rtg_hardware_sprite, bool host_only_cursor)
+{
+	return rtg_hardware_sprite || host_only_cursor;
+}
+
+static inline std::uint16_t amiberry_cursor_rtg_softsprite_fallback_mask()
+{
+	return 0;
+}
+
+#endif

--- a/src/include/custom.h
+++ b/src/include/custom.h
@@ -328,6 +328,7 @@ bool check_rga_free_slot_in(void);
 struct rgabuf *read_rga(int slot);
 struct rgabuf *write_rga(int slot, int type, uae_u16 v, uae_u32 *p);
 extern uae_u16 clxdat;
+extern uae_u32 magic_sprite_mask;
 
 void custom_end_drawing(void);
 void resetfulllinestate(void);

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -258,6 +258,7 @@ static uaecptr oldscr = 0;
 static bool magic_mouse_host_only_enabled()
 {
 	return amiberry_cursor_host_only_enabled(currprefs.input_tablet,
+		currprefs.input_mouse_untrap, MOUSEUNTRAP_MAGIC,
 		currprefs.input_magic_mouse_cursor, MAGICMOUSE_HOST_ONLY);
 }
 

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -969,6 +969,9 @@ static void setupcursor()
 		return;
 
 	if (magic_mouse_host_only_enabled()) {
+		if (cursordata && cursorwidth && cursorheight) {
+			createwindowscursor(rbc->monitor_id, 1, 0);
+		}
 		setupcursor_needed = 0;
 		return;
 	}

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -57,6 +57,7 @@
 
 #include "options.h"
 #ifdef AMIBERRY
+#include "amiberry_cursor.h"
 #include "amiberry_gfx.h"
 #include "gfx_colors.h"
 #include "gfx_window.h"
@@ -181,17 +182,6 @@ static int newcursor_x, newcursor_y;
 static int cursorwidth, cursorheight, cursorok;
 static uae_u8 *cursordata;
 static uae_u32 cursorrgb[4], cursorrgbn[4];
-#ifdef AMIBERRY
-// Truecolor sprite (P96 >=3.x alpha-capable hardware pointer). When the
-// Amiga-side P96 advertises a truecolor RGBFormat in SetSprite(), sprite
-// image data is ARGB32 instead of 2-bit planar. IconLib uploads alpha-
-// blended drag icons through this path. cursor_argb holds host-endian
-// 0xAARRGGBB pixels; empty if current sprite is classic 2-bit planar.
-static uae_u32 *cursor_argb = nullptr;
-// RGBFormat most recently passed to SetSprite(). RGBFB_CLUT (=0) means
-// classic planar; any truecolor value triggers the ARGB path.
-static RGBFTYPE sprite_rgbformat = RGBFB_CLUT;
-#endif
 static int cursordeactivate, setupcursor_needed;
 static bool cursorvisible;
 #if defined(_WIN32) && !defined(AMIBERRY)
@@ -263,6 +253,19 @@ static uae_u32 p2ctab[256][2];
 static int set_gc_called = 0, init_picasso_screen_called = 0;
 //fastscreen
 static uaecptr oldscr = 0;
+
+#ifdef AMIBERRY
+static bool magic_mouse_host_only_enabled()
+{
+	return amiberry_cursor_host_only_enabled(currprefs.input_tablet,
+		currprefs.input_magic_mouse_cursor, MAGICMOUSE_HOST_ONLY);
+}
+
+static bool p96_needs_separate_cursor_sprite()
+{
+	return amiberry_cursor_rtg_needs_separate_sprite(currprefs.rtg_hardwaresprite, magic_mouse_host_only_enabled());
+}
+#endif
 
 extern addrbank gfxmem_bank;
 extern addrbank *gfxmem_banks[MAX_RTG_BOARDS];
@@ -866,12 +869,8 @@ bool p96_uses_software_cursor()
 	if (!hwsprite || !cursorvisible)
 		return false;
 		
-	// If in Absolute Mouse mode (Tablet enabled), check Magic Mouse preferences
-	if (currprefs.input_tablet > 0) {
-		// If user wants Host Only cursor, do not draw the software overlay
-		if (currprefs.input_magic_mouse_cursor == MAGICMOUSE_HOST_ONLY)
-			return false;
-	}
+	if (magic_mouse_host_only_enabled())
+		return false;
 	
 	return true;
 }
@@ -895,28 +894,19 @@ static void update_cursor_overlay_surface()
 {
 	if (!cursorwidth || !cursorheight || !hwsprite)
 		return;
-	// Need at least one data source — classic 2-bit or truecolor ARGB.
-	if (!cursordata && !cursor_argb)
+	if (!cursordata)
 		return;
-
-	// Surface pixel format depends on sprite source: classic 2-bit uses
-	// RGBA32 (authored by updatesprcolors with R/B swapped for LE); truecolor
-	// sprite uses ARGB8888 where each uint32 pixel is packed 0xAARRGGBB in
-	// host order — the form our cursor_argb buffer carries.
-	const SDL_PixelFormat want_fmt = cursor_argb
-		? SDL_PIXELFORMAT_ARGB8888
-		: SDL_PIXELFORMAT_RGBA32;
 
 	// (Re)create surface if dimensions or format changed
 	if (!cursor_overlay_surface ||
 		cursor_overlay_surface->w != cursorwidth ||
 		cursor_overlay_surface->h != cursorheight ||
-		cursor_overlay_surface->format != want_fmt) {
+		cursor_overlay_surface->format != SDL_PIXELFORMAT_RGBA32) {
 
 		if (cursor_overlay_surface) {
 			SDL_DestroySurface(cursor_overlay_surface);
 		}
-		cursor_overlay_surface = SDL_CreateSurface(cursorwidth, cursorheight, want_fmt);
+		cursor_overlay_surface = SDL_CreateSurface(cursorwidth, cursorheight, SDL_PIXELFORMAT_RGBA32);
 		if (!cursor_overlay_surface)
 			return;
 		// Zero any pitch padding once at create time. The per-row copies
@@ -926,30 +916,19 @@ static void update_cursor_overlay_surface()
 		SDL_FillSurfaceRect(cursor_overlay_surface, nullptr, 0);
 	}
 
-	if (cursor_argb) {
-		// Truecolor path: packed uint32 copy, one row at a time (pitch may
-		// exceed cursorwidth*4 if SDL aligned the surface).
-		for (int y = 0; y < cursorheight; y++) {
-			const uae_u32 *src = cursor_argb + cursorwidth * y;
-			auto *dst = reinterpret_cast<uae_u32*>(
-				static_cast<uint8_t*>(cursor_overlay_surface->pixels) +
-				cursor_overlay_surface->pitch * y);
-			memcpy(dst, src, cursorwidth * 4);
-		}
-	} else {
-		// Classic 2-bit path unchanged.
-		for (int y = 0; y < cursorheight; y++) {
-			uae_u8 *p1 = cursordata + cursorwidth * y;
-			auto *p2 = reinterpret_cast<uae_u32*>(
-				static_cast<uint8_t*>(cursor_overlay_surface->pixels) +
-				cursor_overlay_surface->pitch * y);
-			for (int x = 0; x < cursorwidth; x++) {
-				uae_u8 c = *p1++;
-				if (c < 4) {
-					*p2 = cursorrgbn[c];
-				}
-				p2++;
+	// Keep this independent of the RTG framebuffer pixel format. This
+	// surface is always RGBA32 and uses raw RGB cursor palette entries.
+	for (int y = 0; y < cursorheight; y++) {
+		uae_u8 *p1 = cursordata + cursorwidth * y;
+		auto *p2 = reinterpret_cast<uae_u32*>(
+			static_cast<uint8_t*>(cursor_overlay_surface->pixels) +
+			cursor_overlay_surface->pitch * y);
+		for (int x = 0; x < cursorwidth; x++) {
+			uae_u8 c = *p1++;
+			if (c < 4) {
+				*p2 = c ? amiberry_cursor_rgba32_from_rgb24(cursorrgb[c]) : 0;
 			}
+			p2++;
 		}
 	}
 
@@ -977,12 +956,6 @@ void p96_cleanup_cursor_overlay()
 		SDL_DestroySurface(cursor_overlay_surface);
 		cursor_overlay_surface = nullptr;
 	}
-	// Release the truecolor sprite pixel buffer symmetric with allocation
-	// in setspriteimage. picasso_reset2 also handles warm reboots; this
-	// path covers emulator shutdown and config teardown.
-	xfree(cursor_argb);
-	cursor_argb = nullptr;
-	sprite_rgbformat = RGBFB_CLUT;
 	// Note: texture cleanup is handled by the renderer in amiberry_gfx.cpp
 }
 #endif
@@ -995,8 +968,13 @@ static void setupcursor()
 	if (rbc->rtgmem_type >= GFXBOARD_HARDWARE)
 		return;
 
+	if (magic_mouse_host_only_enabled()) {
+		setupcursor_needed = 0;
+		return;
+	}
+
 	setupcursor_needed = 1;
-	if ((cursordata || cursor_argb) && cursorwidth && cursorheight) {
+	if (cursordata && cursorwidth && cursorheight) {
 		// Always update the overlay surface (used in software cursor mode)
 		// We use a software overlay for RTG cursors to ensure consistency
 		// across different mouse modes (relative/absolute) and drivers.
@@ -2177,7 +2155,7 @@ static void putmousepixel(const SDL_Surface* cursor_surface, const int x, const 
 	if (c == 0) {
 		*target_pixel = 0;
 	} else {
-		*target_pixel = ct[c];
+		*target_pixel = amiberry_cursor_rgba32_from_rgb24(ct[c]);
 	}
 }
 #else
@@ -2210,26 +2188,16 @@ static int createwindowscursor(int monid, int set, int chipset)
 	int ret = 0;
 	bool isdata = false;
 	SDL_Cursor* old_cursor = p96_cursor;
-	uae_u32 *ct;
+	uae_u32 *ct = nullptr;
 	TrapContext *ctx = nullptr;
 	int w, h;
-	uae_u8 *image;
+	uae_u8 *image = nullptr;
 	uae_u8 tmp_sprite[CURSORMAXWIDTH * CURSORMAXHEIGHT];
 	int datasize;
 
 	wincursor_shown = 0;
 
-	if (isfullscreen() > 0 || currprefs.input_tablet == 0 || !(currprefs.input_mouse_untrap & MOUSEUNTRAP_MAGIC)) {
-		goto exit;
-	}
-	if (currprefs.input_magic_mouse_cursor != MAGICMOUSE_HOST_ONLY) {
-		goto exit;
-	}
-
-	// Truecolor RTG sprite: SDL_Cursor path (2-bit index + palette expansion)
-	// can't represent per-pixel alpha, so skip and let the software overlay
-	// path (update_cursor_overlay_surface) render the pointer instead.
-	if (!chipset && cursor_argb) {
+	if (isfullscreen() > 0 || !magic_mouse_host_only_enabled()) {
 		goto exit;
 	}
 
@@ -2283,7 +2251,7 @@ static int createwindowscursor(int monid, int set, int chipset)
 	} else {
 		w = cursorwidth;
 		h = cursorheight;
-		ct = cursorrgbn;
+		ct = cursorrgb;
 		image = cursordata;
 	}
 
@@ -2562,24 +2530,6 @@ int picasso_setwincursor(int monid)
 	return 0;
 }
 
-#ifdef AMIBERRY
-// Returns true when the current sprite RGBFormat selects a truecolor path
-// (ARGB32 pixel data, per-pixel alpha). RGBFB_CLUT and RGBFB_NONE keep the
-// classic 2-bit planar decode path that this function has always used.
-static bool is_truecolor_sprite()
-{
-	switch (sprite_rgbformat) {
-	case RGBFB_A8R8G8B8:
-	case RGBFB_A8B8G8R8:
-	case RGBFB_R8G8B8A8:
-	case RGBFB_B8G8R8A8:
-		return true;
-	default:
-		return false;
-	}
-}
-#endif
-
 static uae_u32 setspriteimage(TrapContext *ctx, uaecptr bi)
 {
 	uae_u32 flags;
@@ -2593,10 +2543,6 @@ static uae_u32 setspriteimage(TrapContext *ctx, uaecptr bi)
 		return 0;
 	xfree (cursordata);
 	cursordata = nullptr;
-#ifdef AMIBERRY
-	xfree(cursor_argb);
-	cursor_argb = nullptr;
-#endif
 	bpp = 4;
 	w = trap_get_byte(ctx, bi + PSSO_BoardInfo_MouseWidth);
 	h = trap_get_byte(ctx, bi + PSSO_BoardInfo_MouseHeight);
@@ -2614,78 +2560,6 @@ static uae_u32 setspriteimage(TrapContext *ctx, uaecptr bi)
 		hiressprite - 1, doubledsprite, bi + PSSO_BoardInfo_MouseImage));
 
 	const uaecptr iptr = trap_get_long(ctx, bi + PSSO_BoardInfo_MouseImage);
-
-#ifdef AMIBERRY
-	if (is_truecolor_sprite()) {
-		// Truecolor sprite: pixel data is w*h packed 4-byte pixels in
-		// sprite_rgbformat byte order. No planar header, no hires/big
-		// scaling (those flags are 2-bit-sprite only). Target layout is
-		// packed uint32 0xAARRGGBB (SDL_PIXELFORMAT_ARGB8888), built from
-		// the per-format byte order so host endianness doesn't matter.
-		const int tc_datasize = w * h * 4;
-		if (!w || !h || iptr == 0 || !valid_address(iptr, tc_datasize)) {
-			cursordeactivate = 1;
-			ret = 1;
-			goto end;
-		}
-		auto *raw = xmalloc(uae_u8, tc_datasize);
-		cursor_argb = xmalloc(uae_u32, w * h);
-		if (!raw || !cursor_argb) {
-			xfree(raw);
-			xfree(cursor_argb);
-			cursor_argb = nullptr;
-			cursordeactivate = 1;
-			ret = 1;
-			goto end;
-		}
-		// One batched Amiga→host memory read instead of w*h trap_get_long
-		// calls (~2K traps for a 48x46 icon — measurable overhead on every
-		// SetSpriteImage when IconLib re-uploads the drag icon).
-		trap_get_bytes(ctx, raw, iptr, tc_datasize);
-
-		// No default case: is_truecolor_sprite() gates entry to this block
-		// and only returns true for these four 32-bit-with-alpha formats.
-		// If you add a new truecolor format there, also add a case here —
-		// the compiler's -Wswitch warning will flag the mismatch.
-		for (int i = 0, n = w * h; i < n; i++) {
-			const uae_u8 *p = raw + i * 4;
-			uae_u8 a = 0, r = 0, g = 0, b = 0;
-			switch (sprite_rgbformat) {
-			case RGBFB_A8R8G8B8: a = p[0]; r = p[1]; g = p[2]; b = p[3]; break;
-			case RGBFB_A8B8G8R8: a = p[0]; b = p[1]; g = p[2]; r = p[3]; break;
-			case RGBFB_R8G8B8A8: r = p[0]; g = p[1]; b = p[2]; a = p[3]; break;
-			case RGBFB_B8G8R8A8: b = p[0]; g = p[1]; r = p[2]; a = p[3]; break;
-			default: break;
-			}
-			cursor_argb[i] = (uae_u32(a) << 24) | (uae_u32(r) << 16) |
-			                 (uae_u32(g) << 8)  | b;
-		}
-		xfree(raw);
-
-		cursorwidth = std::min(w, CURSORMAXWIDTH);
-		cursorheight = std::min(h, CURSORMAXHEIGHT);
-
-		// One-shot log: records the first time IconLib (or any P96 client)
-		// actually picks up the advertised SoftSpriteFlags capability and
-		// uploads truecolor sprite data. If alpha-drag later regresses and
-		// this line is absent from the log, we know the handshake broke at
-		// the board/driver level rather than in the decode.
-		static bool logged_truecolor_sprite = false;
-		if (!logged_truecolor_sprite) {
-			write_log(_T("P96: first truecolor sprite accepted (fmt=%d, %dx%d)\n"),
-				(int)sprite_rgbformat, cursorwidth, cursorheight);
-			logged_truecolor_sprite = true;
-		}
-
-		createwindowscursor(currprefs.rtgboards[0].monitor_id, 1, 0);
-		setupcursor();
-		ret = 1;
-		cursorok = TRUE;
-		P96TRACE_SPR((_T("truecolor sprite created (fmt=%d, %dx%d)\n"),
-			(int)sprite_rgbformat, cursorwidth, cursorheight));
-		goto end;
-	}
-#endif
 
 	{
 	const int datasize = 4 * hiressprite + h * 4 * hiressprite;
@@ -2790,19 +2664,6 @@ static uae_u32 REGPARAM2 picasso_SetSprite (TrapContext *ctx)
 	const uae_u32 activate = trap_get_dreg(ctx, 0);
 	if (!hwsprite)
 		return 0;
-#ifdef AMIBERRY
-	// d7 carries the RGBFormat P96 will use for subsequent SetSpriteImage()
-	// calls. RGBFB_CLUT selects the classic 2-bit planar sprite; anything
-	// else (RGBFB_A8R8G8B8 etc.) means the sprite data is truecolor and we
-	// need to decode per-pixel RGBA. We remember this across SetSpriteImage
-	// so the decode path can branch on it.
-	//
-	// Amiga-supplied values can be arbitrary; if d7 holds something outside
-	// the RGBFTYPE enum, is_truecolor_sprite() returns false for unknown
-	// values and setspriteimage falls through to the classic decode. That
-	// is the intended safety net — no range check here on purpose.
-	sprite_rgbformat = static_cast<RGBFTYPE>(trap_get_dreg(ctx, 7));
-#endif
 	if (activate) {
 		picasso_SetSpriteImage (ctx);
 		cursorvisible = true;
@@ -3443,7 +3304,7 @@ static void inituaegfx(TrapContext *ctx, uaecptr ABI)
 	flags &= ~BIF_HARDWARESPRITE;
 
 #ifdef AMIBERRY
-	if (USE_HARDWARESPRITE && currprefs.rtg_hardwaresprite) {
+	if (USE_HARDWARESPRITE && p96_needs_separate_cursor_sprite()) {
 #else
 	if (D3D_setcursor && D3D_setcursor(0, -1, -1, -1, -1, 0, 0, false, false) && USE_HARDWARESPRITE && currprefs.rtg_hardwaresprite) {
 #endif
@@ -3479,17 +3340,11 @@ static void inituaegfx(TrapContext *ctx, uaecptr ABI)
 
 	trap_put_long(ctx, ABI + PSSO_BoardInfo_Flags, flags);
 #ifdef AMIBERRY
-	// SoftSpriteFlags advertises the RGBFormats in which the board accepts
-	// sprite image data. Setting the 32-bit-with-alpha formats tells P96's
-	// graphics driver / IconLib that this board accepts a truecolor mouse
-	// pointer and it can call SetSprite() with a non-planar RGBFormat and
-	// SetSpriteImage() with packed ARGB pixel data (see setspriteimage's
-	// truecolor branch). Only meaningful when we actually advertise
-	// BIF_HARDWARESPRITE.
-	if (hwsprite) {
-		const uae_u16 softspritefmts = static_cast<uae_u16>(RGBMASK_32BIT);
-		trap_put_word(ctx, ABI + PSSO_BoardInfo_SoftSpriteFlags, softspritefmts);
-	}
+	// This is a fallback mask, not a supported-cursor-format mask. Any bits
+	// set here tell P96 to draw the pointer into RTG memory for those screen
+	// formats, bypassing our hardware-sprite callbacks.
+	trap_put_word(ctx, ABI + PSSO_BoardInfo_SoftSpriteFlags,
+		amiberry_cursor_rtg_softsprite_fallback_mask());
 #endif
 	if (debug_rtg_blitter != 3)
 		write_log (_T("P96: Blitter mode = %x!\n"), debug_rtg_blitter);
@@ -7103,7 +6958,7 @@ static void inituaegfxfuncs(TrapContext *ctx, uaecptr start, uaecptr ABI)
 	RTGCALL2(PSSO_BoardInfo_SetPanning, picasso_SetPanning);
 	RTGCALL2(PSSO_BoardInfo_SetDisplay, picasso_SetDisplay);
 
-	if (USE_HARDWARESPRITE && currprefs.rtg_hardwaresprite) {
+	if (USE_HARDWARESPRITE && p96_needs_separate_cursor_sprite()) {
 		RTGCALL2(PSSO_BoardInfo_SetSprite, picasso_SetSprite);
 		RTGCALL2(PSSO_BoardInfo_SetSpritePosition, picasso_SetSpritePosition);
 		RTGCALL2(PSSO_BoardInfo_SetSpriteImage, picasso_SetSpriteImage);
@@ -7181,20 +7036,6 @@ static void picasso_reset2(int monid)
 		resetpalette(state);
 		state->dualclut = false;
 		state->advDragging = false;
-#ifdef AMIBERRY
-		// Drop any cached truecolor sprite state so warm reboots don't keep
-		// stale pixels or carry a stale RGBFormat across a fresh SetSprite().
-		// cursor_argb and sprite_rgbformat are file-scope globals shared
-		// across all monitors because uaegfx exposes a single hardware
-		// sprite to the Amiga — reset exactly once, on the primary monitor,
-		// not per-board. If sprite state ever becomes per-board, move this
-		// into a per-state struct instead of gating on monid.
-		if (!monid) {
-			xfree(cursor_argb);
-			cursor_argb = nullptr;
-			sprite_rgbformat = RGBFB_CLUT;
-		}
-#endif
 		InitPicasso96(monid);
 	}
 

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -64,12 +64,18 @@ static void test_rgba32_cursor_pixels_use_raw_rgb_order()
 static void test_host_only_forces_separate_rtg_sprite()
 {
 	const int host_only = 2;
+	const int magic_untrap = 2;
+	const int middle_untrap = 1;
 
-	const bool enabled = amiberry_cursor_host_only_enabled(1, host_only, host_only);
-	expect_true(enabled, "host-only cursor mode must be detected when virtual mouse is active");
-	expect_true(!amiberry_cursor_host_only_enabled(0, host_only, host_only),
+	const bool enabled = amiberry_cursor_host_only_enabled(1, magic_untrap, magic_untrap, host_only, host_only);
+	expect_true(enabled, "host-only cursor mode must be detected when virtual mouse and Magic Mouse are active");
+	expect_true(!amiberry_cursor_host_only_enabled(0, magic_untrap, magic_untrap, host_only, host_only),
 		"host-only cursor mode must require virtual mouse mode");
-	expect_true(!amiberry_cursor_host_only_enabled(1, 0, host_only),
+	expect_true(!amiberry_cursor_host_only_enabled(1, 0, magic_untrap, host_only, host_only),
+		"host-only cursor mode must require Magic Mouse untrap");
+	expect_true(!amiberry_cursor_host_only_enabled(1, middle_untrap, magic_untrap, host_only, host_only),
+		"host-only cursor mode must not activate for middle-button untrap only");
+	expect_true(!amiberry_cursor_host_only_enabled(1, magic_untrap, magic_untrap, 0, host_only),
 		"host-only cursor mode must require host-only cursor selection");
 
 	expect_true(amiberry_cursor_rtg_needs_separate_sprite(false, enabled),

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -1,0 +1,95 @@
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+
+typedef std::uint16_t uae_u16;
+typedef std::uint32_t uae_u32;
+
+#include "amiberry_cursor.h"
+
+static int failures;
+
+static void expect_eq(uae_u32 actual, uae_u32 expected, const char *message)
+{
+	if (actual != expected) {
+		std::cerr << message << ": expected 0x" << std::hex << expected
+			<< ", got 0x" << actual << std::dec << '\n';
+		failures++;
+	}
+}
+
+static void expect_true(bool condition, const char *message)
+{
+	if (!condition) {
+		std::cerr << message << '\n';
+		failures++;
+	}
+}
+
+static void test_rgb12_expands_to_rgb24()
+{
+	expect_eq(amiberry_cursor_rgb12_to_rgb24(0x000), 0x000000, "black must remain black");
+	expect_eq(amiberry_cursor_rgb12_to_rgb24(0x123), 0x112233, "12-bit RGB nibbles must duplicate");
+	expect_eq(amiberry_cursor_rgb12_to_rgb24(0xabc), 0xaabbcc, "12-bit RGB must preserve channel order");
+	expect_eq(amiberry_cursor_rgb12_to_rgb24(0xfff), 0xffffff, "white must expand fully");
+}
+
+static void test_rgba32_cursor_pixels_are_opaque()
+{
+	const uae_u32 pixel = amiberry_cursor_rgba32_from_rgb24(0x112233);
+	unsigned char bytes[4] = {};
+	std::memcpy(bytes, &pixel, sizeof bytes);
+
+	expect_true(bytes[0] == 0x11, "RGBA32 cursor byte 0 must be red");
+	expect_true(bytes[1] == 0x22, "RGBA32 cursor byte 1 must be green");
+	expect_true(bytes[2] == 0x33, "RGBA32 cursor byte 2 must be blue");
+	expect_true(bytes[3] == 0xff, "RGBA32 cursor byte 3 must be opaque alpha");
+}
+
+static void test_rgba32_cursor_pixels_use_raw_rgb_order()
+{
+	uae_u32 red = amiberry_cursor_rgba32_from_rgb24(0xff0000);
+	uae_u32 blue = amiberry_cursor_rgba32_from_rgb24(0x0000ff);
+	unsigned char red_bytes[4] = {};
+	unsigned char blue_bytes[4] = {};
+	std::memcpy(red_bytes, &red, sizeof red_bytes);
+	std::memcpy(blue_bytes, &blue, sizeof blue_bytes);
+
+	expect_true(red_bytes[0] == 0xff && red_bytes[1] == 0x00 && red_bytes[2] == 0x00 && red_bytes[3] == 0xff,
+		"pure red must not become blue in RGBA32 cursor memory");
+	expect_true(blue_bytes[0] == 0x00 && blue_bytes[1] == 0x00 && blue_bytes[2] == 0xff && blue_bytes[3] == 0xff,
+		"pure blue must not become red in RGBA32 cursor memory");
+}
+
+static void test_host_only_forces_separate_rtg_sprite()
+{
+	const int host_only = 2;
+
+	const bool enabled = amiberry_cursor_host_only_enabled(1, host_only, host_only);
+	expect_true(enabled, "host-only cursor mode must be detected when virtual mouse is active");
+	expect_true(!amiberry_cursor_host_only_enabled(0, host_only, host_only),
+		"host-only cursor mode must require virtual mouse mode");
+	expect_true(!amiberry_cursor_host_only_enabled(1, 0, host_only),
+		"host-only cursor mode must require host-only cursor selection");
+
+	expect_true(amiberry_cursor_rtg_needs_separate_sprite(false, enabled),
+		"RTG Host Only must force separate P96 sprite handling");
+	expect_true(amiberry_cursor_rtg_needs_separate_sprite(true, false),
+		"explicit RTG hardware sprite emulation must still request separate sprite handling");
+}
+
+static void test_rtg_cursor_keeps_softsprite_fallback_disabled()
+{
+	expect_eq(amiberry_cursor_rtg_softsprite_fallback_mask(), 0,
+		"RTG cursor must not force P96 software pointer fallback in 32-bit modes");
+}
+
+int main()
+{
+	test_rgb12_expands_to_rgb24();
+	test_rgba32_cursor_pixels_are_opaque();
+	test_rgba32_cursor_pixels_use_raw_rgb_order();
+	test_host_only_forces_separate_rtg_sprite();
+	test_rtg_cursor_keeps_softsprite_fallback_disabled();
+	return failures == 0 ? 0 : 1;
+}

--- a/tests/test_cursor_pixel_format.sh
+++ b/tests/test_cursor_pixel_format.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+cxx=${CXX:-c++}
+out="${TMPDIR:-/tmp}/cursor_pixel_format_test.$$"
+trap 'rm -f "$out"' EXIT
+
+"$cxx" -std=c++17 -Wall -Wextra -Werror -Isrc/include -o "$out" tests/cursor_pixel_format_test.cpp
+"$out"


### PR DESCRIPTION
## Summary
- hide the native chipset sprite for Magic Mouse Host Only without making the host cursor transparent
- keep P96 cursor handling on the hardware-sprite callback path in Host Only mode
- stop advertising 32-bit RTG modes through `SoftSpriteFlags`, which made P96 draw a software pointer into RTG memory
- add focused cursor-format coverage for raw RGB/RGBA cursor pixels and the RTG soft-sprite fallback mask

## Root Cause
`SoftSpriteFlags` was treated as a supported cursor-format mask, but it is a fallback mask. Setting `RGBMASK_32BIT` told P96 to draw the Amiga pointer into the RTG framebuffer for 32-bit modes, bypassing Amiberry's hardware-sprite callbacks and leaving both cursors visible in Host Only mode.

Fixes #2135

## Verification
- `bash tests/test_cursor_pixel_format.sh`
- `cmake --build out/build/windows-debug --parallel`
- runtime check with `A4000.uae -G --log`: log shows `P96: Hardware sprite support enabled`, `SetSwitch() - Picasso96 1280x1024x32`, and `p96_cursor: 16x24`