### PR TITLE
Fix serial RBF clear after SERDATR read

### DIFF
--- a/src/osdep/amiberry_serial.cpp
+++ b/src/osdep/amiberry_serial.cpp
@@ -1540,7 +1540,7 @@ uae_u16 SERDATR()
 	if (!data_in_serdatr) {
 		// interrupt was previously cleared but SERDATR was not read.
 		// Clear it now when SERDATR was read.
-		INTREQ_INT(11, 0);
+		INTREQ_f(1 << 11);
 	}
 	serdatr_last_got = 0;
 	return serdatr;


### PR DESCRIPTION
## Summary
- Restore SERDATR's post-read RBF clear path to use `INTREQ_f(1 << 11)`.
- Avoid reasserting the serial receive interrupt after software has already cleared RBF and then reads SERDATR.

## Root cause
The WinUAE merge in the 8.2.0 window changed this path from clearing bit 11 with `INTREQ_f(1 << 11)` to asserting it through `INTREQ_INT(11, 0)`, while the surrounding comment still described a clear operation. MIDI input arrives through the emulated serial receive path, so this could generate extra receive interrupts without a new MIDI byte and matches the reported random MIDI note events.

Refs #2134

## Validation
- Focused regression check confirmed `SERDATR()` now uses `INTREQ_f(1 << 11)` for this clear path.
- `git diff --check`
- `cmake --build out/build/windows-debug --parallel` (`ninja: no work to do` after the previous successful build)