### PR TITLE
Fix libretro audio starvation padding

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -2564,6 +2564,14 @@ static void libretro_emit_audio_starvation_guard()
 	if (libretro_audio_deficit_frames <= max_deferred_frames)
 		return;
 
+	// The FIFO drain handles normal pacing and small long-term drift while real
+	// audio is flowing. Do not repay that debt with synthetic padding, because
+	// repeated ramp-to-zero inserts are audible on sustained music.
+	if (libretro_audio_frames_this_run > 0) {
+		libretro_audio_deficit_frames = max_deferred_frames;
+		return;
+	}
+
 	unsigned missing_frames = static_cast<unsigned>(libretro_audio_deficit_frames - max_deferred_frames);
 	while (missing_frames > 0) {
 		const unsigned chunk = std::min(missing_frames, 1024U);

--- a/tools/check_libretro_contract.py
+++ b/tools/check_libretro_contract.py
@@ -154,13 +154,15 @@ def main():
 		and "libretro_audio_deficit_frames -= libretro_audio_frames_this_run;" in libretro_emit_audio_starvation_guard
 		and "libretro_audio_deficit_frames = max_deferred_frames * 4.0;" in libretro_emit_audio_starvation_guard
 		and "if (libretro_audio_deficit_frames <= max_deferred_frames)" in libretro_emit_audio_starvation_guard
+		and "if (libretro_audio_frames_this_run > 0)" in libretro_emit_audio_starvation_guard
+		and "libretro_audio_deficit_frames = max_deferred_frames;" in libretro_emit_audio_starvation_guard
 		and "libretro_fill_audio_padding(padding, chunk)" in libretro_emit_audio_starvation_guard
 		and "audio_batch_cb(padding, chunk)" in libretro_emit_audio_starvation_guard
 		and "audio_cb(padding[i * 2], padding[i * 2 + 1])" in libretro_emit_audio_starvation_guard
 		and "libretro_audio_note_emitted(padding, accepted)" in libretro_emit_audio_starvation_guard
 		and "libretro_audio_deficit_frames = 0.0;" in libretro_audio_reset
 		and "libretro_audio_reset();" in reset_core_runtime_state,
-		"retro_run() must guard sustained libretro audio starvation with click-safe padding, without padding normal bursty audio frames",
+		"retro_run() must guard sustained libretro audio starvation with click-safe padding, without adding synthetic padding while real audio is flowing",
 		failures,
 	)
 	require(


### PR DESCRIPTION
## Summary
- keep the libretro starvation guard from adding synthetic ramp-to-zero padding after real audio was emitted in the current `retro_run()`
- cap the accumulated audio deficit at the guard threshold so normal FIFO pacing remains responsible for small drift
- add a libretro contract check for the real-audio escape path

## Root cause
The starvation guard could repay accumulated audio deficit with generated padding even while the FIFO drain was already delivering real samples. On sustained music this can create repeated synthetic inserts, matching the periodic popping reported in #2136.

## Validation
- `python tools\check_libretro_contract.py`
- `wsl -e bash -lc "cd /mnt/d/Github/amiberry/libretro && make -j$(nproc)"`

Note: the libretro build still emits the existing `tmpnam` linker warning from `posixemu_vfs.cpp`.