### PR TITLE
Improve AutoCrop policy

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -113,6 +113,11 @@ static uint64_t libretro_crop_frame = 0;
 static uint64_t libretro_cached_crop_frame = 0;
 static bool libretro_cached_crop_valid = false;
 static libretro_crop libretro_cached_crop = {};
+static AutoCropState libretro_crop_state;
+static int libretro_crop_last_hres = 0;
+static int libretro_crop_last_vres = 0;
+static bool libretro_crop_last_is_ntsc = false;
+static bool libretro_crop_was_enabled = false;
 bool pixel_format_xrgb8888 = false;
 
 static retro_set_led_state_t led_state_cb = nullptr;
@@ -2155,6 +2160,16 @@ static void libretro_invalidate_crop_cache()
 	libretro_cached_crop_valid = false;
 }
 
+static void libretro_reset_crop_policy()
+{
+	libretro_crop_state = {};
+	libretro_crop_last_hres = 0;
+	libretro_crop_last_vres = 0;
+	libretro_crop_last_is_ntsc = false;
+	libretro_crop_was_enabled = false;
+	libretro_invalidate_crop_cache();
+}
+
 static libretro_crop libretro_cache_crop(const libretro_crop& crop)
 {
 	libretro_cached_crop = crop;
@@ -2170,16 +2185,26 @@ libretro_crop libretro_compute_crop(void)
 
 	libretro_crop crop = { 0, 0, 0, 0, 0.0f, false };
 
-	if (!crop_overscan_enabled())
+	if (!crop_overscan_enabled()) {
+		libretro_reset_crop_policy();
 		return libretro_cache_crop(crop);
+	}
+	if (!libretro_crop_was_enabled) {
+		libretro_reset_crop_policy();
+		libretro_crop_was_enabled = true;
+	}
 
 	// RTG/Workbench (Picasso96) has no overscan borders — nothing to crop.
-	if (adisplays[0].picasso_on)
+	if (adisplays[0].picasso_on) {
+		libretro_reset_crop_policy();
 		return libretro_cache_crop(crop);
+	}
 
 	SDL_Surface* surface = get_amiga_surface(0);
-	if (!surface || surface->w <= 0 || surface->h <= 0)
+	if (!surface || surface->w <= 0 || surface->h <= 0) {
+		libretro_reset_crop_policy();
 		return libretro_cache_crop(crop);
+	}
 
 	int cw = 0, ch = 0, cx = 0, cy = 0, crealh = 0;
 	int hres = currprefs.gfx_resolution;
@@ -2187,15 +2212,14 @@ libretro_crop libretro_compute_crop(void)
 	get_custom_limits(&cw, &ch, &cx, &cy, &crealh, &hres, &vres);
 
 	const bool is_ntsc = (vblank_hz > 55.0f);
-	static AutoCropState crop_state;
-	static int last_hres = 0, last_vres = 0;
-	static bool last_is_ntsc = false;
-	const bool reset_policy = last_hres != hres || last_vres != vres || last_is_ntsc != is_ntsc;
+	const bool reset_policy = libretro_crop_last_hres != hres
+		|| libretro_crop_last_vres != vres
+		|| libretro_crop_last_is_ntsc != is_ntsc;
 	SDL_Rect crop_rect = { cx, cy, cw, ch };
-	apply_auto_crop_policy(surface, crop_rect, hres, vres, is_ntsc, crop_state, reset_policy);
-	last_hres = hres;
-	last_vres = vres;
-	last_is_ntsc = is_ntsc;
+	apply_auto_crop_policy(surface, crop_rect, hres, vres, is_ntsc, libretro_crop_state, reset_policy);
+	libretro_crop_last_hres = hres;
+	libretro_crop_last_vres = vres;
+	libretro_crop_last_is_ntsc = is_ntsc;
 
 	cx = crop_rect.x;
 	cy = crop_rect.y;
@@ -3420,7 +3444,7 @@ static void reset_core_runtime_state()
 	last_geometry_width = -1;
 	last_geometry_height = -1;
 	last_geometry_aspect = -1.0f;
-	libretro_invalidate_crop_cache();
+	libretro_reset_crop_policy();
 	libretro_audio_reset();
 }
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -109,6 +109,10 @@ static bool ff_override_active = false;
 static int last_geometry_width = -1;
 static int last_geometry_height = -1;
 static float last_geometry_aspect = -1.0f;
+static uint64_t libretro_crop_frame = 0;
+static uint64_t libretro_cached_crop_frame = 0;
+static bool libretro_cached_crop_valid = false;
+static libretro_crop libretro_cached_crop = {};
 bool pixel_format_xrgb8888 = false;
 
 static retro_set_led_state_t led_state_cb = nullptr;
@@ -2146,20 +2150,36 @@ static bool crop_overscan_enabled()
 	return v && strcmp(v, "enabled") == 0;
 }
 
+static void libretro_invalidate_crop_cache()
+{
+	libretro_cached_crop_valid = false;
+}
+
+static libretro_crop libretro_cache_crop(const libretro_crop& crop)
+{
+	libretro_cached_crop = crop;
+	libretro_cached_crop_frame = libretro_crop_frame;
+	libretro_cached_crop_valid = true;
+	return crop;
+}
+
 libretro_crop libretro_compute_crop(void)
 {
+	if (libretro_cached_crop_valid && libretro_cached_crop_frame == libretro_crop_frame)
+		return libretro_cached_crop;
+
 	libretro_crop crop = { 0, 0, 0, 0, 0.0f, false };
 
 	if (!crop_overscan_enabled())
-		return crop;
+		return libretro_cache_crop(crop);
 
 	// RTG/Workbench (Picasso96) has no overscan borders — nothing to crop.
 	if (adisplays[0].picasso_on)
-		return crop;
+		return libretro_cache_crop(crop);
 
 	SDL_Surface* surface = get_amiga_surface(0);
 	if (!surface || surface->w <= 0 || surface->h <= 0)
-		return crop;
+		return libretro_cache_crop(crop);
 
 	int cw = 0, ch = 0, cx = 0, cy = 0, crealh = 0;
 	int hres = currprefs.gfx_resolution;
@@ -2182,7 +2202,7 @@ libretro_crop libretro_compute_crop(void)
 	cw = crop_rect.w;
 	ch = crop_rect.h;
 	if (cw <= 0 || ch <= 0)
-		return crop;
+		return libretro_cache_crop(crop);
 
 	int width, height;
 	auto_crop_display_dimensions(cw, ch, hres, vres, is_ntsc, width, height);
@@ -2193,7 +2213,7 @@ libretro_crop libretro_compute_crop(void)
 	crop.h = ch;
 	crop.aspect = (height > 0) ? static_cast<float>(width) / static_cast<float>(height) : 0.0f;
 	crop.active = true;
-	return crop;
+	return libretro_cache_crop(crop);
 }
 
 static int parse_audio_rate_value(const char* value)
@@ -3400,6 +3420,7 @@ static void reset_core_runtime_state()
 	last_geometry_width = -1;
 	last_geometry_height = -1;
 	last_geometry_aspect = -1.0f;
+	libretro_invalidate_crop_cache();
 	libretro_audio_reset();
 }
 
@@ -3734,6 +3755,7 @@ void retro_reset(void)
 
 void retro_run(void)
 {
+	libretro_crop_frame++;
 	apply_minimum_audio_latency();
 
 	if (!ensure_core_fiber()) {

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -2166,30 +2166,26 @@ libretro_crop libretro_compute_crop(void)
 	int vres = currprefs.gfx_vresolution;
 	get_custom_limits(&cw, &ch, &cx, &cy, &crealh, &hres, &vres);
 
-	// Clamp to surface bounds (mirrors auto_crop_image, amiberry_gfx.cpp:1660-1668).
-	if (cx < 0) cx = 0;
-	if (cy < 0) cy = 0;
-	if (cx >= surface->w) cx = 0;
-	if (cy >= surface->h) cy = 0;
-	if (cw <= 0 || cx + cw > surface->w) cw = surface->w - cx;
-	if (ch <= 0 || cy + ch > surface->h) ch = surface->h - cy;
+	const bool is_ntsc = (vblank_hz > 55.0f);
+	static AutoCropState crop_state;
+	static int last_hres = 0, last_vres = 0;
+	static bool last_is_ntsc = false;
+	const bool reset_policy = last_hres != hres || last_vres != vres || last_is_ntsc != is_ntsc;
+	SDL_Rect crop_rect = { cx, cy, cw, ch };
+	apply_auto_crop_policy(surface, crop_rect, hres, vres, is_ntsc, crop_state, reset_policy);
+	last_hres = hres;
+	last_vres = vres;
+	last_is_ntsc = is_ntsc;
 
+	cx = crop_rect.x;
+	cy = crop_rect.y;
+	cw = crop_rect.w;
+	ch = crop_rect.h;
 	if (cw <= 0 || ch <= 0)
 		return crop;
 
-	// PAR-corrected display aspect (mirrors auto_crop_image, amiberry_gfx.cpp:1623-1651).
-	int width = cw;
-	int height = ch;
-	if (vres == VRES_NONDOUBLE) {
-		if (hres == RES_HIRES || hres == RES_SUPERHIRES)
-			height *= 2;
-	} else {
-		if (hres == RES_LORES)
-			width *= 2;
-	}
-	const bool is_ntsc = (vblank_hz > 55.0f);
-	if (is_ntsc)
-		height = height * 6 / 5;
+	int width, height;
+	auto_crop_display_dimensions(cw, ch, hres, vres, is_ntsc, width, height);
 
 	crop.x = cx;
 	crop.y = cy;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -110,6 +110,269 @@ void update_system_pixel_format()
 	}
 }
 
+constexpr int auto_crop_base_width = 320;
+constexpr int auto_crop_normal_min_height = 180;
+constexpr int auto_crop_cinematic_min_height = 120;
+constexpr int auto_crop_pal_guard_height = 240;
+constexpr int auto_crop_ntsc_guard_height = 216;
+constexpr int auto_crop_full_width_tolerance = 4;
+constexpr int auto_crop_guard_top_base_tolerance = 8;
+constexpr int auto_crop_wide_aspect_w = 21;
+constexpr int auto_crop_wide_aspect_h = 9;
+constexpr int auto_crop_shrink_stable_frames = 6;
+
+static int auto_crop_rect_right(const SDL_Rect& rect)
+{
+	return rect.x + rect.w;
+}
+
+static int auto_crop_rect_bottom(const SDL_Rect& rect)
+{
+	return rect.y + rect.h;
+}
+
+static bool auto_crop_rect_equals(const SDL_Rect& a, const SDL_Rect& b)
+{
+	return a.x == b.x && a.y == b.y && a.w == b.w && a.h == b.h;
+}
+
+static bool auto_crop_rect_contains(const SDL_Rect& outer, const SDL_Rect& inner)
+{
+	return outer.x <= inner.x
+		&& outer.y <= inner.y
+		&& auto_crop_rect_right(outer) >= auto_crop_rect_right(inner)
+		&& auto_crop_rect_bottom(outer) >= auto_crop_rect_bottom(inner);
+}
+
+static bool auto_crop_rect_grows_beyond(const SDL_Rect& rect, const SDL_Rect& previous)
+{
+	return auto_crop_rect_contains(rect, previous) && !auto_crop_rect_equals(rect, previous);
+}
+
+static void clamp_auto_crop_rect(const SDL_Surface* surface, SDL_Rect& rect)
+{
+	if (!surface || surface->w <= 0 || surface->h <= 0) {
+		rect = {};
+		return;
+	}
+
+	if (rect.w <= 0 || rect.h <= 0 || rect.x >= surface->w || rect.y >= surface->h) {
+		rect = { 0, 0, surface->w, surface->h };
+		return;
+	}
+
+	if (rect.x < 0) {
+		rect.w += rect.x;
+		rect.x = 0;
+	}
+	if (rect.y < 0) {
+		rect.h += rect.y;
+		rect.y = 0;
+	}
+	if (rect.w <= 0 || rect.h <= 0) {
+		rect = { 0, 0, surface->w, surface->h };
+		return;
+	}
+	if (auto_crop_rect_right(rect) > surface->w) {
+		rect.w = surface->w - rect.x;
+	}
+	if (auto_crop_rect_bottom(rect) > surface->h) {
+		rect.h = surface->h - rect.y;
+	}
+}
+
+static int auto_crop_minimum_width(const int hres)
+{
+	const int clamped_hres = std::clamp(hres, RES_LORES, RES_SUPERHIRES);
+	return auto_crop_base_width << clamped_hres;
+}
+
+void auto_crop_display_dimensions(const int w, const int h, const int hres,
+	const int vres, const bool is_ntsc, int& display_w, int& display_h)
+{
+	display_w = w;
+	display_h = h;
+
+	if (vres == VRES_NONDOUBLE) {
+		if (hres == RES_HIRES || hres == RES_SUPERHIRES) {
+			display_h *= 2;
+		}
+	} else {
+		if (hres == RES_LORES) {
+			display_w *= 2;
+		}
+	}
+
+	if (is_ntsc) {
+		display_h = display_h * 6 / 5;
+	}
+}
+
+static bool auto_crop_uses_cinematic_minimum(const SDL_Rect& rect,
+	const int hres, const int vres, const bool is_ntsc)
+{
+	const int clamped_hres = std::clamp(hres, RES_LORES, RES_SUPERHIRES);
+	const int min_w = auto_crop_base_width << clamped_hres;
+	const int width_tolerance = auto_crop_full_width_tolerance << clamped_hres;
+	if (rect.w < min_w - width_tolerance || rect.h <= 0) {
+		return false;
+	}
+
+	int display_w, display_h;
+	auto_crop_display_dimensions(rect.w, rect.h, hres, vres, is_ntsc, display_w, display_h);
+	return display_h > 0 && display_w * auto_crop_wide_aspect_h >= display_h * auto_crop_wide_aspect_w;
+}
+
+static int auto_crop_minimum_height(const bool use_cinematic_minimum, const int vres)
+{
+	const int base_height = use_cinematic_minimum ? auto_crop_cinematic_min_height : auto_crop_normal_min_height;
+	return vres > VRES_NONDOUBLE ? base_height << 1 : base_height;
+}
+
+static int auto_crop_guard_height(const int vres, const bool is_ntsc)
+{
+	const int base_height = is_ntsc ? auto_crop_ntsc_guard_height : auto_crop_pal_guard_height;
+	return vres > VRES_NONDOUBLE ? base_height << 1 : base_height;
+}
+
+static int auto_crop_guard_top_tolerance(const int vres)
+{
+	return vres > VRES_NONDOUBLE ? auto_crop_guard_top_base_tolerance << 1 : auto_crop_guard_top_base_tolerance;
+}
+
+static int auto_crop_expanded_origin(const int pos, const int size, const int min_size,
+	const int limit, const int preferred_pos, const bool has_preferred)
+{
+	if (min_size <= size || limit <= 0) {
+		return pos;
+	}
+
+	const int expanded_size = std::min(min_size, limit);
+	const int min_origin = pos + size - expanded_size;
+	const int max_origin = pos;
+	const int centered_origin = pos - (expanded_size - size) / 2;
+	const int wanted_origin = has_preferred ? preferred_pos : centered_origin;
+	int origin = std::clamp(wanted_origin, min_origin, max_origin);
+	origin = std::clamp(origin, 0, limit - expanded_size);
+	return origin;
+}
+
+static void expand_auto_crop_rect_to_minimum(const SDL_Surface* surface, SDL_Rect& rect,
+	const int hres, const int vres, const bool is_ntsc, const SDL_Rect* preferred_rect)
+{
+	if (!surface || surface->w <= 0 || surface->h <= 0 || rect.w <= 0 || rect.h <= 0) {
+		return;
+	}
+
+	const int surface_w = surface->w;
+	const int surface_h = surface->h;
+	const int min_w = std::min(auto_crop_minimum_width(hres), surface_w);
+	const bool use_cinematic_minimum = auto_crop_uses_cinematic_minimum(rect, hres, vres, is_ntsc);
+	const int min_h = std::min(auto_crop_minimum_height(use_cinematic_minimum, vres), surface_h);
+	const int preferred_x = preferred_rect ? preferred_rect->x : 0;
+	const int preferred_y = preferred_rect ? preferred_rect->y : 0;
+	const bool has_preferred = preferred_rect && preferred_rect->w > 0 && preferred_rect->h > 0;
+
+	const int x = auto_crop_expanded_origin(rect.x, rect.w, min_w, surface_w, preferred_x, has_preferred);
+	const int y = auto_crop_expanded_origin(rect.y, rect.h, min_h, surface_h, preferred_y,
+		has_preferred && !use_cinematic_minimum);
+	rect.x = x;
+	rect.y = y;
+	rect.w = std::max(rect.w, min_w);
+	rect.h = std::max(rect.h, min_h);
+	clamp_auto_crop_rect(surface, rect);
+}
+
+static void preserve_auto_crop_bottom_edge(const SDL_Surface* surface, SDL_Rect& rect,
+	const int vres, const bool is_ntsc, const SDL_Rect& guard_rect, const bool guard_valid)
+{
+	if (!surface || surface->h <= 0 || rect.h <= 0 || !guard_valid || guard_rect.h <= 0) {
+		return;
+	}
+
+	const int surface_h = surface->h;
+	if (rect.y > guard_rect.y + auto_crop_guard_top_tolerance(vres)) {
+		return;
+	}
+
+	const int guard_h = std::min(auto_crop_guard_height(vres, is_ntsc), surface_h);
+	if (rect.h >= guard_h) {
+		return;
+	}
+
+	const int previous_bottom = auto_crop_rect_bottom(guard_rect);
+	const int rect_bottom = auto_crop_rect_bottom(rect);
+	if (rect_bottom >= previous_bottom) {
+		return;
+	}
+
+	const int guarded_bottom = std::min({ previous_bottom, surface_h, rect.y + guard_h });
+	if (guarded_bottom > rect_bottom) {
+		rect.h = guarded_bottom - rect.y;
+		clamp_auto_crop_rect(surface, rect);
+	}
+}
+
+void apply_auto_crop_policy(const SDL_Surface* surface, SDL_Rect& rect,
+	const int hres, const int vres, const bool is_ntsc, AutoCropState& state, const bool reset)
+{
+	clamp_auto_crop_rect(surface, rect);
+	if (rect.w <= 0 || rect.h <= 0) {
+		return;
+	}
+
+	const int surface_w = surface->w;
+	const int surface_h = surface->h;
+	const bool surface_changed = state.surface != surface
+		|| state.surface_w != surface_w
+		|| state.surface_h != surface_h;
+	if (reset || surface_changed || !state.valid) {
+		state = {};
+		state.surface = surface;
+		state.surface_w = surface_w;
+		state.surface_h = surface_h;
+		expand_auto_crop_rect_to_minimum(surface, rect, hres, vres, is_ntsc, nullptr);
+		state.rect = rect;
+		state.guard_rect = rect;
+		state.valid = true;
+		state.guard_valid = true;
+		return;
+	}
+
+	expand_auto_crop_rect_to_minimum(surface, rect, hres, vres, is_ntsc, &state.rect);
+	preserve_auto_crop_bottom_edge(surface, rect, vres, is_ntsc, state.guard_rect, state.guard_valid);
+	if (auto_crop_rect_equals(rect, state.rect)) {
+		state.shrink_frames = 0;
+		state.pending_valid = false;
+		return;
+	}
+
+	if (auto_crop_rect_grows_beyond(rect, state.rect)) {
+		state.rect = rect;
+		state.guard_rect = rect;
+		state.guard_valid = true;
+		state.shrink_frames = 0;
+		state.pending_valid = false;
+		return;
+	}
+
+	if (!state.pending_valid || !auto_crop_rect_equals(rect, state.pending_rect)) {
+		state.pending_rect = rect;
+		state.pending_valid = true;
+		state.shrink_frames = 1;
+	} else {
+		state.shrink_frames++;
+	}
+
+	if (state.shrink_frames >= auto_crop_shrink_stable_frames) {
+		state.rect = rect;
+		state.shrink_frames = 0;
+		state.pending_valid = false;
+	} else {
+		rect = state.rect;
+	}
+}
+
 static int dx = 0, dy = 0;
 const char* sdl_video_driver;
 bool kmsdrm_detected = false;
@@ -1595,7 +1858,11 @@ void auto_crop_image()
 	if (currprefs.gfx_auto_crop)
 	{
 		static int last_cw = 0, last_ch = 0, last_cx = 0, last_cy = 0;
+		static int last_hres = 0, last_vres = 0;
 		static bool last_is_ntsc = false;
+		static SDL_Surface* last_surface = nullptr;
+		static int last_surface_w = 0, last_surface_h = 0;
+		static AutoCropState crop_state;
 		int cw, ch, cx, cy, crealh = 0;
 		int hres = currprefs.gfx_resolution;
 		int vres = currprefs.gfx_vresolution;
@@ -1605,36 +1872,54 @@ void auto_crop_image()
 		// currprefs.ntscmode which may not reflect the chipset state
 		// (e.g. WHDLoad games that switch PAL/NTSC at runtime).
 		bool is_ntsc = (vblank_hz > 55.0f);
+		SDL_Surface* surface = get_amiga_surface(0);
+		const int surface_w = surface ? surface->w : 0;
+		const int surface_h = surface ? surface->h : 0;
 
 		if (!force_auto_crop && last_autocrop == currprefs.gfx_auto_crop
 			&& last_cw == cw && last_ch == ch && last_cx == cx && last_cy == cy
-			&& last_is_ntsc == is_ntsc)
+			&& last_hres == hres && last_vres == vres
+			&& last_is_ntsc == is_ntsc
+			&& last_surface == surface
+			&& last_surface_w == surface_w
+			&& last_surface_h == surface_h
+			&& crop_state.shrink_frames == 0)
 		{
 			return;
 		}
+
+		const int raw_cw = cw;
+		const int raw_ch = ch;
+		const int raw_cx = cx;
+		const int raw_cy = cy;
+		const bool reset_policy = force_auto_crop || last_autocrop != currprefs.gfx_auto_crop
+			|| last_hres != hres || last_vres != vres
+			|| last_is_ntsc != is_ntsc
+			|| last_surface != surface
+			|| last_surface_w != surface_w
+			|| last_surface_h != surface_h;
 
 		last_cw = cw;
 		last_ch = ch;
 		last_cx = cx;
 		last_cy = cy;
+		last_hres = hres;
+		last_vres = vres;
 		last_is_ntsc = is_ntsc;
+		last_surface = surface;
+		last_surface_w = surface_w;
+		last_surface_h = surface_h;
 		force_auto_crop = false;
 
-		int width = cw;
-		int height = ch;
-		if (vres == VRES_NONDOUBLE)
-		{
-			if (hres == RES_HIRES || hres == RES_SUPERHIRES)
-				height *= 2;
-		}
-		else
-		{
-			if (hres == RES_LORES)
-				width *= 2;
-		}
+		SDL_Rect crop_rect = { cx, cy, cw, ch };
+		apply_auto_crop_policy(surface, crop_rect, hres, vres, is_ntsc, crop_state, reset_policy);
+		cx = crop_rect.x;
+		cy = crop_rect.y;
+		cw = crop_rect.w;
+		ch = crop_rect.h;
 
-		if (is_ntsc)
-			height = height * 6 / 5;
+		int width, height;
+		auto_crop_display_dimensions(cw, ch, hres, vres, is_ntsc, width, height);
 
 		if (currprefs.gfx_correct_aspect == 0)
 		{
@@ -1651,21 +1936,10 @@ void auto_crop_image()
 		renderer->crop_aspect = (height > 0) ? static_cast<float>(width) / static_cast<float>(height) : 0.0f;
 		renderer->crop_display_w = width;
 		renderer->crop_display_h = height;
-		write_log(_T("auto_crop: cw=%d ch=%d cx=%d cy=%d hres=%d vres=%d ntsc=%d (vblank=%.1fHz) => display %dx%d aspect=%.4f\n"),
-			cw, ch, cx, cy, hres, vres, is_ntsc, vblank_hz, width, height, renderer->crop_aspect);
+		write_log(_T("auto_crop: raw=%dx%d+%d+%d final=%dx%d+%d+%d hres=%d vres=%d ntsc=%d (vblank=%.1fHz) => display %dx%d aspect=%.4f\n"),
+			raw_cw, raw_ch, raw_cx, raw_cy, cw, ch, cx, cy, hres, vres, is_ntsc, vblank_hz, width, height, renderer->crop_aspect);
 		rq = { dx, dy, width, height };
-		cr = { cx, cy, cw, ch };
-		SDL_Surface* surface = get_amiga_surface(0);
-		if (surface) {
-			if (cr.x < 0) cr.x = 0;
-			if (cr.y < 0) cr.y = 0;
-			if (cr.x >= surface->w) cr.x = 0;
-			if (cr.y >= surface->h) cr.y = 0;
-			if (cr.w <= 0 || cr.x + cr.w > surface->w)
-				cr.w = surface->w - cr.x;
-			if (cr.h <= 0 || cr.y + cr.h > surface->h)
-				cr.h = surface->h - cr.y;
-		}
+		cr = crop_rect;
 
 		// ImGui OSK does not need position updates from texture
 	}

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -149,6 +149,23 @@ static bool auto_crop_rect_grows_beyond(const SDL_Rect& rect, const SDL_Rect& pr
 	return auto_crop_rect_contains(rect, previous) && !auto_crop_rect_equals(rect, previous);
 }
 
+static bool auto_crop_rect_reveals_new_edges(const SDL_Rect& rect, const SDL_Rect& previous)
+{
+	return rect.x < previous.x
+		|| rect.y < previous.y
+		|| auto_crop_rect_right(rect) > auto_crop_rect_right(previous)
+		|| auto_crop_rect_bottom(rect) > auto_crop_rect_bottom(previous);
+}
+
+static SDL_Rect auto_crop_rect_union(const SDL_Rect& a, const SDL_Rect& b)
+{
+	const int x = std::min(a.x, b.x);
+	const int y = std::min(a.y, b.y);
+	const int right = std::max(auto_crop_rect_right(a), auto_crop_rect_right(b));
+	const int bottom = std::max(auto_crop_rect_bottom(a), auto_crop_rect_bottom(b));
+	return { x, y, right - x, bottom - y };
+}
+
 static void clamp_auto_crop_rect(const SDL_Surface* surface, SDL_Rect& rect)
 {
 	if (!surface || surface->w <= 0 || surface->h <= 0) {
@@ -348,6 +365,17 @@ void apply_auto_crop_policy(const SDL_Surface* surface, SDL_Rect& rect,
 	}
 
 	if (auto_crop_rect_grows_beyond(rect, state.rect)) {
+		state.rect = rect;
+		state.guard_rect = rect;
+		state.guard_valid = true;
+		state.shrink_frames = 0;
+		state.pending_valid = false;
+		return;
+	}
+
+	if (auto_crop_rect_reveals_new_edges(rect, state.rect)) {
+		rect = auto_crop_rect_union(rect, state.rect);
+		clamp_auto_crop_rect(surface, rect);
 		state.rect = rect;
 		state.guard_rect = rect;
 		state.guard_valid = true;

--- a/src/osdep/amiberry_gfx.h
+++ b/src/osdep/amiberry_gfx.h
@@ -78,6 +78,19 @@ struct winuae_currentmode {
 	int freq;
 };
 
+struct AutoCropState {
+	const SDL_Surface* surface = nullptr;
+	int surface_w = 0;
+	int surface_h = 0;
+	SDL_Rect rect{};
+	SDL_Rect guard_rect{};
+	SDL_Rect pending_rect{};
+	int shrink_frames = 0;
+	bool valid = false;
+	bool guard_valid = false;
+	bool pending_valid = false;
+};
+
 #define MAX_AMIGAMONITORS 4
 struct AmigaMonitor {
 	int monitor_id;
@@ -194,6 +207,10 @@ extern void gfx_unlock();
 struct MultiDisplay* getdisplay(const uae_prefs* p, int monid);
 extern int getrefreshrate(int monid, int width, int height);
 extern void auto_crop_image();
+extern void auto_crop_display_dimensions(int w, int h, int hres, int vres, bool is_ntsc,
+	int& display_w, int& display_h);
+extern void apply_auto_crop_policy(const SDL_Surface* surface, SDL_Rect& rect,
+	int hres, int vres, bool is_ntsc, AutoCropState& state, bool reset);
 extern bool vkbd_allowed(int monid);
 extern float calculate_desired_aspect(const AmigaMonitor* mon);
 extern void quit_drawing_thread();


### PR DESCRIPTION
## Summary
- Share the AutoCrop policy between standalone and libretro crop handling.
- Add minimum crop sizing with a 120-line cinematic floor for wide 21:9-style content.
- Preserve bottom content for cases like Toki while allowing tighter crops for demos and cinematic screens.
- Add shrink hysteresis and fast-path state checks so unchanged frames avoid policy work.

## Validation
- `git diff --check` (only CRLF normalization warnings for touched files)
- `cmake --build out/build/windows-debug --parallel` (standalone build, no work to do)
- Manual testing covered Toki, EON demo, Pinball Illusions, Agony, and additional wide-content scenarios.

Fixes #2141
