### PR TITLE
Persist used GFX filter settings

### DIFF
--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -2622,8 +2622,8 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 	cfgfile_dwrite (f, _T("gfx_center_horizontal_size"), _T("%d"), p->gfx_xcenter_size);
 	cfgfile_dwrite (f, _T("gfx_center_vertical_size"), _T("%d"), p->gfx_ycenter_size);
 
-	cfgfile_dwrite (f, _T("rtg_vert_zoom_multf"), _T("%.f"), p->rtg_vert_zoom_mult);
-	cfgfile_dwrite (f, _T("rtg_horiz_zoom_multf"), _T("%.f"), p->rtg_horiz_zoom_mult);
+	cfgfile_dwrite (f, _T("rtg_vert_zoom_multf"), _T("%f"), p->rtg_vert_zoom_mult);
+	cfgfile_dwrite (f, _T("rtg_horiz_zoom_multf"), _T("%f"), p->rtg_horiz_zoom_mult);
 
 #ifdef GFXFILTER
 	for (int j = 0; j < MAX_FILTERDATA; j++) {

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -2601,7 +2601,29 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		struct gfx_filterdata *gf = &p->gf[j];
 		const TCHAR *ext = j == 0 ? NULL : (j == 1 ? _T("_rtg") : _T("_lace"));
 		cfgfile_dwrite_strarr(f, _T("gfx_filter_autoscale"), ext, j != GF_RTG ? autoscale : autoscale_rtg, gf->gfx_filter_autoscale);
+		cfgfile_dwrite_ext(f, _T("gfx_filter_vert_zoom_multf"), ext, _T("%f"), gf->gfx_filter_vert_zoom_mult);
+		cfgfile_dwrite_ext(f, _T("gfx_filter_horiz_zoom_multf"), ext, _T("%f"), gf->gfx_filter_horiz_zoom_mult);
+		cfgfile_dwrite_ext(f, _T("gfx_filter_left_border"), ext, _T("%d"), gf->gfx_filter_left_border);
+		cfgfile_dwrite_ext(f, _T("gfx_filter_right_border"), ext, _T("%d"), gf->gfx_filter_right_border);
+		cfgfile_dwrite_ext(f, _T("gfx_filter_top_border"), ext, _T("%d"), gf->gfx_filter_top_border);
+		cfgfile_dwrite_ext(f, _T("gfx_filter_bottom_border"), ext, _T("%d"), gf->gfx_filter_bottom_border);
+		cfgfile_dwrite_ext(f, _T("gfx_filter_blur"), ext, _T("%d"), gf->gfx_filter_blur);
 	}
+
+	cfgfile_dwrite (f, _T("gfx_luminance"), _T("%d"), p->gfx_luminance);
+	cfgfile_dwrite (f, _T("gfx_contrast"), _T("%d"), p->gfx_contrast);
+	cfgfile_dwrite (f, _T("gfx_gamma"), _T("%d"), p->gfx_gamma);
+	cfgfile_dwrite (f, _T("gfx_gamma_r"), _T("%d"), p->gfx_gamma_ch[0]);
+	cfgfile_dwrite (f, _T("gfx_gamma_g"), _T("%d"), p->gfx_gamma_ch[1]);
+	cfgfile_dwrite (f, _T("gfx_gamma_b"), _T("%d"), p->gfx_gamma_ch[2]);
+
+	cfgfile_dwrite (f, _T("gfx_center_horizontal_position"), _T("%d"), p->gfx_xcenter_pos < MANUAL_SCALE_MIN_RANGE ? -1 : (p->gfx_xcenter_pos < 0 ? p->gfx_xcenter_pos - 1 : p->gfx_xcenter_pos));
+	cfgfile_dwrite (f, _T("gfx_center_vertical_position"), _T("%d"), p->gfx_ycenter_pos < MANUAL_SCALE_MIN_RANGE ? -1 : (p->gfx_ycenter_pos < 0 ? p->gfx_ycenter_pos - 1 : p->gfx_ycenter_pos));
+	cfgfile_dwrite (f, _T("gfx_center_horizontal_size"), _T("%d"), p->gfx_xcenter_size);
+	cfgfile_dwrite (f, _T("gfx_center_vertical_size"), _T("%d"), p->gfx_ycenter_size);
+
+	cfgfile_dwrite (f, _T("rtg_vert_zoom_multf"), _T("%.f"), p->rtg_vert_zoom_mult);
+	cfgfile_dwrite (f, _T("rtg_horiz_zoom_multf"), _T("%.f"), p->rtg_horiz_zoom_mult);
 
 #ifdef GFXFILTER
 	for (int j = 0; j < MAX_FILTERDATA; j++) {
@@ -2637,15 +2659,8 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		cfgfile_dwrite_strarr(f, _T("gfx_filter_mode2"), ext, filtermode2v, gf->gfx_filter_filtermodev);
 		cfgfile_dwrite_ext(f, _T("gfx_filter_vert_zoomf"), ext, _T("%f"), gf->gfx_filter_vert_zoom);
 		cfgfile_dwrite_ext(f, _T("gfx_filter_horiz_zoomf"), ext, _T("%f"), gf->gfx_filter_horiz_zoom);
-		cfgfile_dwrite_ext(f, _T("gfx_filter_vert_zoom_multf"), ext, _T("%f"), gf->gfx_filter_vert_zoom_mult);
-		cfgfile_dwrite_ext(f, _T("gfx_filter_horiz_zoom_multf"), ext, _T("%f"), gf->gfx_filter_horiz_zoom_mult);
 		cfgfile_dwrite_ext(f, _T("gfx_filter_vert_offsetf"), ext, _T("%f"), gf->gfx_filter_vert_offset);
 		cfgfile_dwrite_ext(f, _T("gfx_filter_horiz_offsetf"), ext, _T("%f"), gf->gfx_filter_horiz_offset);
-
-		cfgfile_dwrite_ext(f, _T("gfx_filter_left_border"), ext, _T("%d"), gf->gfx_filter_left_border);
-		cfgfile_dwrite_ext(f, _T("gfx_filter_right_border"), ext, _T("%d"), gf->gfx_filter_right_border);
-		cfgfile_dwrite_ext(f, _T("gfx_filter_top_border"), ext, _T("%d"), gf->gfx_filter_top_border);
-		cfgfile_dwrite_ext(f, _T("gfx_filter_bottom_border"), ext, _T("%d"), gf->gfx_filter_bottom_border);
 
 		cfgfile_dwrite_ext(f, _T("gfx_filter_scanlines"), ext, _T("%d"), gf->gfx_filter_scanlines);
 		cfgfile_dwrite_ext(f, _T("gfx_filter_scanlinelevel"), ext, _T("%d"), gf->gfx_filter_scanlinelevel);
@@ -2660,7 +2675,6 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		cfgfile_dwrite_ext(f, _T("gfx_filter_gamma_g"), ext, _T("%d"), gf->gfx_filter_gamma_ch[1]);
 		cfgfile_dwrite_ext(f, _T("gfx_filter_gamma_b"), ext, _T("%d"), gf->gfx_filter_gamma_ch[2]);
 
-		cfgfile_dwrite_ext(f, _T("gfx_filter_blur"), ext, _T("%d"), gf->gfx_filter_blur);
 		cfgfile_dwrite_ext(f, _T("gfx_filter_noise"), ext, _T("%d"), gf->gfx_filter_noise);
 		cfgfile_dwrite_bool(f, _T("gfx_filter_bilinear"), ext, gf->gfx_filter_bilinear != 0);
 
@@ -2676,20 +2690,6 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		}
 		cfgfile_dwrite_ext(f, _T("gfx_filter_rotation"), ext, _T("%d"), gf->gfx_filter_rotation);
 	}
-	cfgfile_dwrite (f, _T("gfx_luminance"), _T("%d"), p->gfx_luminance);
-	cfgfile_dwrite (f, _T("gfx_contrast"), _T("%d"), p->gfx_contrast);
-	cfgfile_dwrite (f, _T("gfx_gamma"), _T("%d"), p->gfx_gamma);
-	cfgfile_dwrite (f, _T("gfx_gamma_r"), _T("%d"), p->gfx_gamma_ch[0]);
-	cfgfile_dwrite (f, _T("gfx_gamma_g"), _T("%d"), p->gfx_gamma_ch[1]);
-	cfgfile_dwrite (f, _T("gfx_gamma_b"), _T("%d"), p->gfx_gamma_ch[2]);
-
-	cfgfile_dwrite (f, _T("gfx_center_horizontal_position"), _T("%d"), p->gfx_xcenter_pos < MANUAL_SCALE_MIN_RANGE ? -1 : (p->gfx_xcenter_pos < 0 ? p->gfx_xcenter_pos - 1 : p->gfx_xcenter_pos));
-	cfgfile_dwrite (f, _T("gfx_center_vertical_position"), _T("%d"), p->gfx_ycenter_pos < MANUAL_SCALE_MIN_RANGE ? -1 : (p->gfx_ycenter_pos < 0 ? p->gfx_ycenter_pos - 1 : p->gfx_ycenter_pos));
-	cfgfile_dwrite (f, _T("gfx_center_horizontal_size"), _T("%d"), p->gfx_xcenter_size);
-	cfgfile_dwrite (f, _T("gfx_center_vertical_size"), _T("%d"), p->gfx_ycenter_size);
-
-	cfgfile_dwrite (f, _T("rtg_vert_zoom_multf"), _T("%.f"), p->rtg_vert_zoom_mult);
-	cfgfile_dwrite (f, _T("rtg_horiz_zoom_multf"), _T("%.f"), p->rtg_horiz_zoom_mult);
 
 #endif
 
@@ -4078,7 +4078,14 @@ static int cfgfile_parse_host (struct uae_prefs *p, TCHAR *option, TCHAR *value)
 	for (int j = 0; j < MAX_FILTERDATA; j++) {
 		struct gfx_filterdata *gf = &p->gf[j];
 		const TCHAR *ext = j == 0 ? NULL : (j == 1 ? _T("_rtg") : _T("_lace"));
-		if (cfgfile_strval (option, value, _T("gfx_filter_autoscale"), ext, &gf->gfx_filter_autoscale, j != GF_RTG ? autoscale : autoscale_rtg, 0))
+		if (cfgfile_strval (option, value, _T("gfx_filter_autoscale"), ext, &gf->gfx_filter_autoscale, j != GF_RTG ? autoscale : autoscale_rtg, 0)
+			|| cfgfile_floatval(option, value, _T("gfx_filter_vert_zoom_multf"), ext, &gf->gfx_filter_vert_zoom_mult)
+			|| cfgfile_floatval(option, value, _T("gfx_filter_horiz_zoom_multf"), ext, &gf->gfx_filter_horiz_zoom_mult)
+			|| cfgfile_intval(option, value, _T("gfx_filter_left_border"), ext, &gf->gfx_filter_left_border, 1)
+			|| cfgfile_intval(option, value, _T("gfx_filter_right_border"), ext, &gf->gfx_filter_right_border, 1)
+			|| cfgfile_intval(option, value, _T("gfx_filter_top_border"), ext, &gf->gfx_filter_top_border, 1)
+			|| cfgfile_intval(option, value, _T("gfx_filter_bottom_border"), ext, &gf->gfx_filter_bottom_border, 1)
+			|| cfgfile_intval(option, value, _T("gfx_filter_blur"), ext, &gf->gfx_filter_blur, 1))
 			{
 				return 1;
 			}
@@ -4092,14 +4099,8 @@ static int cfgfile_parse_host (struct uae_prefs *p, TCHAR *option, TCHAR *value)
 			|| cfgfile_strval(option, value, _T("gfx_filter_autoscale_limit"), ext, &gf->gfx_filter_integerscalelimit, autoscalelimit, 0)
 			|| cfgfile_floatval(option, value, _T("gfx_filter_vert_zoomf"), ext, &gf->gfx_filter_vert_zoom)
 			|| cfgfile_floatval(option, value, _T("gfx_filter_horiz_zoomf"), ext, &gf->gfx_filter_horiz_zoom)
-			|| cfgfile_floatval(option, value, _T("gfx_filter_vert_zoom_multf"), ext, &gf->gfx_filter_vert_zoom_mult)
-			|| cfgfile_floatval(option, value, _T("gfx_filter_horiz_zoom_multf"), ext, &gf->gfx_filter_horiz_zoom_mult)
 			|| cfgfile_floatval(option, value, _T("gfx_filter_vert_offsetf"), ext, &gf->gfx_filter_vert_offset)
 			|| cfgfile_floatval(option, value, _T("gfx_filter_horiz_offsetf"), ext, &gf->gfx_filter_horiz_offset)
-			|| cfgfile_intval(option, value, _T("gfx_filter_left_border"), ext, &gf->gfx_filter_left_border, 1)
-			|| cfgfile_intval(option, value, _T("gfx_filter_right_border"), ext, &gf->gfx_filter_right_border, 1)
-			|| cfgfile_intval(option, value, _T("gfx_filter_top_border"), ext, &gf->gfx_filter_top_border, 1)
-			|| cfgfile_intval(option, value, _T("gfx_filter_bottom_border"), ext, &gf->gfx_filter_bottom_border, 1)
 			|| cfgfile_intval(option, value, _T("gfx_filter_scanlines"), ext, &gf->gfx_filter_scanlines, 1)
 			|| cfgfile_intval(option, value, _T("gfx_filter_scanlinelevel"), ext, &gf->gfx_filter_scanlinelevel, 1)
 			|| cfgfile_intval(option, value, _T("gfx_filter_scanlineratio"), ext, &gf->gfx_filter_scanlineratio, 1)
@@ -4111,7 +4112,6 @@ static int cfgfile_parse_host (struct uae_prefs *p, TCHAR *option, TCHAR *value)
 			|| cfgfile_intval(option, value, _T("gfx_filter_gamma_r"), ext, &gf->gfx_filter_gamma_ch[0], 1)
 			|| cfgfile_intval(option, value, _T("gfx_filter_gamma_g"), ext, &gf->gfx_filter_gamma_ch[1], 1)
 			|| cfgfile_intval(option, value, _T("gfx_filter_gamma_b"), ext, &gf->gfx_filter_gamma_ch[2], 1)
-			|| cfgfile_intval(option, value, _T("gfx_filter_blur"), ext, &gf->gfx_filter_blur, 1)
 			|| cfgfile_intval(option, value, _T("gfx_filter_noise"), ext, &gf->gfx_filter_noise, 1)
 			|| cfgfile_intval(option, value, _T("gfx_filter_bilinear"), ext, &gf->gfx_filter_bilinear, 1)
 			|| cfgfile_intval(option, value, _T("gfx_filter_keep_autoscale_aspect"), ext, &gf->gfx_filter_keep_autoscale_aspect, 1)

--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -8861,24 +8861,24 @@ void check_prefs_changed_custom(void)
 		}
 	}
 
-#ifdef GFXFILTER
 	for (int i = 0; i < 2; i++) {
 		int idx = i == 0 ? 0 : 2;
 		struct gfx_filterdata *fd = &currprefs.gf[idx];
 		struct gfx_filterdata *fdcp = &changed_prefs.gf[idx];
 
+#ifdef GFXFILTER
 		fd->gfx_filter_horiz_zoom = fdcp->gfx_filter_horiz_zoom;
 		fd->gfx_filter_vert_zoom = fdcp->gfx_filter_vert_zoom;
 		fd->gfx_filter_horiz_offset = fdcp->gfx_filter_horiz_offset;
 		fd->gfx_filter_vert_offset = fdcp->gfx_filter_vert_offset;
 		fd->gfx_filter_scanlines = fdcp->gfx_filter_scanlines;
+#endif
 
 		fd->gfx_filter_left_border = fdcp->gfx_filter_left_border;
 		fd->gfx_filter_right_border = fdcp->gfx_filter_right_border;
 		fd->gfx_filter_top_border = fdcp->gfx_filter_top_border;
 		fd->gfx_filter_bottom_border = fdcp->gfx_filter_bottom_border;
 	}
-#endif
 }
 
 static uae_u16 fetch16(struct rgabuf *r)

--- a/src/osdep/gfx_prefs_check.cpp
+++ b/src/osdep/gfx_prefs_check.cpp
@@ -187,6 +187,9 @@ int check_prefs_changed_gfx()
 	c |= currprefs.gfx_luminance != changed_prefs.gfx_luminance ? (1 | 256) : 0;
 	c |= currprefs.gfx_contrast != changed_prefs.gfx_contrast ? (1 | 256) : 0;
 	c |= currprefs.gfx_gamma != changed_prefs.gfx_gamma ? (1 | 256) : 0;
+	c |= currprefs.gfx_gamma_ch[0] != changed_prefs.gfx_gamma_ch[0] ? (1 | 256) : 0;
+	c |= currprefs.gfx_gamma_ch[1] != changed_prefs.gfx_gamma_ch[1] ? (1 | 256) : 0;
+	c |= currprefs.gfx_gamma_ch[2] != changed_prefs.gfx_gamma_ch[2] ? (1 | 256) : 0;
 
 	c |= currprefs.gfx_resolution != changed_prefs.gfx_resolution ? (128) : 0;
 	c |= currprefs.gfx_vresolution != changed_prefs.gfx_vresolution ? (128) : 0;
@@ -324,6 +327,9 @@ int check_prefs_changed_gfx()
 		currprefs.gfx_luminance = changed_prefs.gfx_luminance;
 		currprefs.gfx_contrast = changed_prefs.gfx_contrast;
 		currprefs.gfx_gamma = changed_prefs.gfx_gamma;
+		currprefs.gfx_gamma_ch[0] = changed_prefs.gfx_gamma_ch[0];
+		currprefs.gfx_gamma_ch[1] = changed_prefs.gfx_gamma_ch[1];
+		currprefs.gfx_gamma_ch[2] = changed_prefs.gfx_gamma_ch[2];
 
 		currprefs.gfx_resolution = changed_prefs.gfx_resolution;
 		currprefs.gfx_vresolution = changed_prefs.gfx_vresolution;

--- a/tests/test_cfgfile_gfxfilter_persistence.sh
+++ b/tests/test_cfgfile_gfxfilter_persistence.sh
@@ -80,6 +80,14 @@ unconditional_save_options = [
 for snippet in unconditional_save_options:
 	require_outside_gfxfilter(save_region, snippet, "cfgfile save")
 
+for option in ("rtg_vert_zoom_multf", "rtg_horiz_zoom_multf"):
+	rounded = f'cfgfile_dwrite (f, _T("{option}"), _T("%.f")'
+	fractional = f'cfgfile_dwrite (f, _T("{option}"), _T("%f")'
+	if rounded in save_region:
+		fail(f"{option} must preserve fractional values when saved")
+	if fractional not in save_region:
+		fail(f"{option} must be saved with a fractional float format")
+
 parse_region = region_between(
 	cfgfile,
 	'if (cfgfile_yesno(option, value, _T("magic_mouse"), &vb))',

--- a/tests/test_cfgfile_gfxfilter_persistence.sh
+++ b/tests/test_cfgfile_gfxfilter_persistence.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v python3 >/dev/null 2>&1; then
+	PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+	PYTHON=python
+elif command -v py >/dev/null 2>&1; then
+	PYTHON="py -3"
+else
+	echo "python3, python, or py is required" >&2
+	exit 1
+fi
+
+$PYTHON - <<'PY'
+from pathlib import Path
+import sys
+
+cfgfile = Path("src/cfgfile.cpp").read_text()
+gfx_prefs_check = Path("src/osdep/gfx_prefs_check.cpp").read_text()
+custom = Path("src/custom.cpp").read_text()
+
+
+def fail(message: str) -> None:
+	print(message, file=sys.stderr)
+	sys.exit(1)
+
+
+def region_between(text: str, start_marker: str, end_marker: str) -> str:
+	try:
+		start = text.index(start_marker)
+		end = text.index(end_marker, start)
+	except ValueError as exc:
+		fail(f"Could not find source marker: {exc}")
+	return text[start:end]
+
+
+def require_outside_gfxfilter(region: str, snippet: str, label: str) -> None:
+	guard = region.find("#ifdef GFXFILTER")
+	if guard < 0:
+		fail(f"Expected {label} region to retain a GFXFILTER-only subsection")
+	pos = region.find(snippet)
+	if pos < 0:
+		fail(f"Missing {label} for {snippet}")
+	if pos > guard:
+		fail(f"{snippet} must be outside the GFXFILTER-only block")
+	if region.find(snippet, guard) >= 0:
+		fail(f"{snippet} must not also remain inside the GFXFILTER-only block")
+
+
+save_region = region_between(
+	cfgfile,
+	'cfgfile_dwrite_bool(f, _T("gfx_ntscpixels"), p->gfx_ntscpixels);',
+	'cfgfile_write_bool (f, _T("immediate_blits"), p->immediate_blits);',
+)
+
+unconditional_save_options = [
+	'cfgfile_dwrite_strarr(f, _T("gfx_filter_autoscale")',
+	'cfgfile_dwrite (f, _T("gfx_luminance")',
+	'cfgfile_dwrite (f, _T("gfx_contrast")',
+	'cfgfile_dwrite (f, _T("gfx_gamma")',
+	'cfgfile_dwrite (f, _T("gfx_gamma_r")',
+	'cfgfile_dwrite (f, _T("gfx_gamma_g")',
+	'cfgfile_dwrite (f, _T("gfx_gamma_b")',
+	'cfgfile_dwrite (f, _T("gfx_center_horizontal_position")',
+	'cfgfile_dwrite (f, _T("gfx_center_vertical_position")',
+	'cfgfile_dwrite (f, _T("gfx_center_horizontal_size")',
+	'cfgfile_dwrite (f, _T("gfx_center_vertical_size")',
+	'cfgfile_dwrite (f, _T("rtg_vert_zoom_multf")',
+	'cfgfile_dwrite (f, _T("rtg_horiz_zoom_multf")',
+	'cfgfile_dwrite_ext(f, _T("gfx_filter_vert_zoom_multf")',
+	'cfgfile_dwrite_ext(f, _T("gfx_filter_horiz_zoom_multf")',
+	'cfgfile_dwrite_ext(f, _T("gfx_filter_left_border")',
+	'cfgfile_dwrite_ext(f, _T("gfx_filter_right_border")',
+	'cfgfile_dwrite_ext(f, _T("gfx_filter_top_border")',
+	'cfgfile_dwrite_ext(f, _T("gfx_filter_bottom_border")',
+	'cfgfile_dwrite_ext(f, _T("gfx_filter_blur")',
+]
+
+for snippet in unconditional_save_options:
+	require_outside_gfxfilter(save_region, snippet, "cfgfile save")
+
+parse_region = region_between(
+	cfgfile,
+	'if (cfgfile_yesno(option, value, _T("magic_mouse"), &vb))',
+	'if (cfgfile_intval (option, value, _T("floppy_volume"), &v, 1))',
+)
+
+unconditional_parse_options = [
+	'cfgfile_strval (option, value, _T("gfx_filter_autoscale")',
+	'cfgfile_floatval(option, value, _T("gfx_filter_vert_zoom_multf")',
+	'cfgfile_floatval(option, value, _T("gfx_filter_horiz_zoom_multf")',
+	'cfgfile_intval(option, value, _T("gfx_filter_left_border")',
+	'cfgfile_intval(option, value, _T("gfx_filter_right_border")',
+	'cfgfile_intval(option, value, _T("gfx_filter_top_border")',
+	'cfgfile_intval(option, value, _T("gfx_filter_bottom_border")',
+	'cfgfile_intval(option, value, _T("gfx_filter_blur")',
+]
+
+for snippet in unconditional_parse_options:
+	require_outside_gfxfilter(parse_region, snippet, "cfgfile parse")
+
+for channel in range(3):
+	compare = f"currprefs.gfx_gamma_ch[{channel}] != changed_prefs.gfx_gamma_ch[{channel}]"
+	copy = f"currprefs.gfx_gamma_ch[{channel}] = changed_prefs.gfx_gamma_ch[{channel}];"
+	if compare not in gfx_prefs_check:
+		fail(f"gfx_gamma_ch[{channel}] changes must be detected in gfx_prefs_check.cpp")
+	if copy not in gfx_prefs_check:
+		fail(f"gfx_gamma_ch[{channel}] changes must be copied in gfx_prefs_check.cpp")
+
+custom_region = region_between(
+	custom,
+	"void check_prefs_changed_custom(void)",
+	"static uae_u16 fetch16",
+)
+
+border_assignments = [
+	"fd->gfx_filter_left_border = fdcp->gfx_filter_left_border;",
+	"fd->gfx_filter_right_border = fdcp->gfx_filter_right_border;",
+	"fd->gfx_filter_top_border = fdcp->gfx_filter_top_border;",
+	"fd->gfx_filter_bottom_border = fdcp->gfx_filter_bottom_border;",
+]
+
+for snippet in border_assignments:
+	pos = custom_region.find(snippet)
+	if pos < 0:
+		fail(f"Missing custom prefs copy for {snippet}")
+	guard_start = custom_region.rfind("#ifdef GFXFILTER", 0, pos)
+	if guard_start >= 0:
+		guard_end = custom_region.find("#endif", guard_start)
+		if guard_end < 0 or pos < guard_end:
+			fail(f"{snippet} must not be guarded by GFXFILTER")
+PY


### PR DESCRIPTION
## Summary
- persist Amiberry-used display and filter settings without requiring `GFXFILTER`
- keep unsupported WinUAE filter backend keys behind `GFXFILTER`
- copy native border crop changes outside the filter backend guard
- detect and apply per-channel gamma changes live
- add a regression script to keep these guard boundaries explicit

## Validation
- `bash tests/test_cfgfile_gfxfilter_persistence.sh`
- `git diff --check HEAD~1 HEAD`
- `cmake --build out\build\windows-release`
- `cmake --build out\build\gfxfilter-probe -j 12`