### PR TITLE
Fix Host Only cursor without Magic Mouse untrap

### DIFF
--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -4425,8 +4425,8 @@ static void cursorsprite(struct sprite *s)
 	}
 	sprite_0_width = sprite_width;
 	if (amiberry_cursor_host_only_enabled(currprefs.input_tablet,
-		currprefs.input_mouse_untrap, MOUSEUNTRAP_MAGIC,
-		currprefs.input_magic_mouse_cursor, MAGICMOUSE_HOST_ONLY) && mousehack_alive()) {
+		currprefs.input_magic_mouse_cursor, MAGICMOUSE_HOST_ONLY,
+		isfullscreen() <= 0) && mousehack_alive()) {
 		magic_sprite_mask &= ~SPRITE_RENDER_MASK(0);
 	} else {
 		magic_sprite_mask |= SPRITE_RENDER_MASK(0);

--- a/src/include/amiberry_cursor.h
+++ b/src/include/amiberry_cursor.h
@@ -26,11 +26,11 @@ static inline std::uint32_t amiberry_cursor_rgba32_from_rgb24(std::uint32_t rgb)
 }
 
 static inline bool amiberry_cursor_host_only_enabled(int input_tablet,
-	int input_mouse_untrap, int magic_mouse_untrap_value,
-	int input_magic_mouse_cursor, int host_only_cursor_value)
+	int input_magic_mouse_cursor, int host_only_cursor_value, bool host_cursor_available)
 {
-	return input_tablet > 0
-		&& (input_mouse_untrap & magic_mouse_untrap_value) != 0
+	// Cursor visibility is independent of the selected mouse-untrap method.
+	return host_cursor_available
+		&& input_tablet > 0
 		&& input_magic_mouse_cursor == host_only_cursor_value;
 }
 

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -257,9 +257,10 @@ static uaecptr oldscr = 0;
 #ifdef AMIBERRY
 static bool magic_mouse_host_only_enabled()
 {
+	const bool host_cursor_available = currprefs.gfx_apmode[APMODE_RTG].gfx_fullscreen != GFX_FULLSCREEN;
 	return amiberry_cursor_host_only_enabled(currprefs.input_tablet,
-		currprefs.input_mouse_untrap, MOUSEUNTRAP_MAGIC,
-		currprefs.input_magic_mouse_cursor, MAGICMOUSE_HOST_ONLY);
+		currprefs.input_magic_mouse_cursor, MAGICMOUSE_HOST_ONLY,
+		host_cursor_available);
 }
 
 static bool p96_needs_separate_cursor_sprite()

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -64,19 +64,15 @@ static void test_rgba32_cursor_pixels_use_raw_rgb_order()
 static void test_host_only_forces_separate_rtg_sprite()
 {
 	const int host_only = 2;
-	const int magic_untrap = 2;
-	const int middle_untrap = 1;
 
-	const bool enabled = amiberry_cursor_host_only_enabled(1, magic_untrap, magic_untrap, host_only, host_only);
-	expect_true(enabled, "host-only cursor mode must be detected when virtual mouse and Magic Mouse are active");
-	expect_true(!amiberry_cursor_host_only_enabled(0, magic_untrap, magic_untrap, host_only, host_only),
+	const bool enabled = amiberry_cursor_host_only_enabled(1, host_only, host_only, true);
+	expect_true(enabled, "host-only cursor mode must be detected from virtual mouse and cursor selection");
+	expect_true(!amiberry_cursor_host_only_enabled(0, host_only, host_only, true),
 		"host-only cursor mode must require virtual mouse mode");
-	expect_true(!amiberry_cursor_host_only_enabled(1, 0, magic_untrap, host_only, host_only),
-		"host-only cursor mode must require Magic Mouse untrap");
-	expect_true(!amiberry_cursor_host_only_enabled(1, middle_untrap, magic_untrap, host_only, host_only),
-		"host-only cursor mode must not activate for middle-button untrap only");
-	expect_true(!amiberry_cursor_host_only_enabled(1, magic_untrap, magic_untrap, 0, host_only),
+	expect_true(!amiberry_cursor_host_only_enabled(1, 0, host_only, true),
 		"host-only cursor mode must require host-only cursor selection");
+	expect_true(!amiberry_cursor_host_only_enabled(1, host_only, host_only, false),
+		"host-only cursor mode must require a visible host cursor path");
 
 	expect_true(amiberry_cursor_rtg_needs_separate_sprite(false, enabled),
 		"RTG Host Only must force separate P96 sprite handling");


### PR DESCRIPTION
## Summary
- make Magic Mouse Host Only cursor handling independent of the mouse untrap method
- apply the Host Only predicate to both native sprite suppression and RTG/P96 cursor handling
- update the focused cursor helper coverage for the attached Linux config shape

## Root Cause
The previous Host Only fix gated cursor handling on `MOUSEUNTRAP_MAGIC`. The Linux user's attached config selected `magic_mousecursor=host` and `absolute_mouse=mousehack`, but only had middle-button untrap enabled via `amiberry.middle_mouse=true`. That meant Host Only mode was configured, but the Host Only cursor paths were skipped.

Cursor visibility should be controlled by virtual mouse mode plus the Host Only cursor setting. The selected untrap method is a separate capture/release preference.

Fixes #2135

## Verification
- `wsl -e bash -lc 'cd /mnt/d/Github/amiberry && out=/tmp/cursor_pixel_format_test.$$ && c++ -std=c++17 -Wall -Wextra -Werror -Isrc/include -o $out tests/cursor_pixel_format_test.cpp && $out; status=$?; rm -f $out; exit $status'`
- `git diff --check`
- `wsl -e bash -lc 'set -e; cd /mnt/d/Github/amiberry; build=/tmp/amiberry-pr-2135-verify; rm -rf "$build"; cmake -S . -B "$build" -DCMAKE_BUILD_TYPE=Debug -DUSE_IPC_SOCKET=ON >/tmp/amiberry-pr-2135-cmake.log; cmake --build "$build" --target src/custom.o --parallel 2; cmake --build "$build" --target src/osdep/picasso96.o --parallel 2; rm -rf "$build"'`