### PR TITLE
Keep libretro crop from hiding visible content

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1,5 +1,6 @@
 #include "libretro.h"
 #include "libretro_shared.h"
+#include "libretro_crop_helpers.h"
 #ifdef LIBRETRO
 #include "sdl_compat.h"
 #endif
@@ -2311,6 +2312,30 @@ static uint32_t libretro_crop_rgb_mask(const SDL_Surface* surface)
 	return details->Rmask | details->Gmask | details->Bmask;
 }
 
+static bool libretro_crop_surface_buffer(const SDL_Surface* surface, LibretroCropPixelBuffer& buffer)
+{
+	if (!surface || !surface->pixels || surface->w <= 0 || surface->h <= 0)
+		return false;
+
+	const int bytes_per_pixel = SDL_BYTESPERPIXEL(surface->format);
+	if (bytes_per_pixel != 4)
+		return false;
+
+	const uint32_t rgb_mask = libretro_crop_rgb_mask(surface);
+	if (rgb_mask == 0)
+		return false;
+
+	buffer = {
+		static_cast<const uint8_t*>(surface->pixels),
+		surface->w,
+		surface->h,
+		surface->pitch,
+		bytes_per_pixel,
+		rgb_mask
+	};
+	return true;
+}
+
 static int libretro_crop_minimum_trim_height()
 {
 	return currprefs.gfx_vresolution > VRES_NONDOUBLE ? 360 : 180;
@@ -2322,6 +2347,60 @@ static void libretro_update_crop_aspect(libretro_crop& crop)
 	auto_crop_display_dimensions(crop.w, crop.h, currprefs.gfx_resolution,
 		currprefs.gfx_vresolution, vblank_hz > 55.0f, width, height);
 	crop.aspect = height > 0 ? static_cast<float>(width) / static_cast<float>(height) : 0.0f;
+}
+
+static bool libretro_visible_content_bounds(const SDL_Surface* surface, LibretroCropRect& bounds)
+{
+	LibretroCropPixelBuffer buffer = {};
+	if (!libretro_crop_surface_buffer(surface, buffer))
+		return false;
+
+	const uint32_t border_color = libretro_crop_read_pixel(surface, 0, 0);
+	if ((border_color & buffer.rgb_mask) != 0)
+		return false;
+
+	return libretro_crop_find_visible_content_bounds(buffer, border_color, bounds);
+}
+
+static void libretro_expand_crop_to_visible_content(const SDL_Surface* surface, libretro_crop& crop)
+{
+	if (!surface || !crop.active)
+		return;
+
+	LibretroCropPixelBuffer buffer = {};
+	if (!libretro_crop_surface_buffer(surface, buffer))
+		return;
+
+	const uint32_t border_color = libretro_crop_read_pixel(surface, 0, 0);
+	if ((border_color & buffer.rgb_mask) != 0)
+		return;
+
+	LibretroCropRect rect = { crop.x, crop.y, crop.w, crop.h };
+	if (libretro_crop_expand_to_visible_content(buffer, border_color, 16, rect)) {
+		crop.x = rect.x;
+		crop.y = rect.y;
+		crop.w = rect.w;
+		crop.h = rect.h;
+		libretro_update_crop_aspect(crop);
+	}
+}
+
+static void libretro_fit_fixed_crop_to_visible_content(const SDL_Surface* surface, libretro_crop& crop)
+{
+	if (!surface || !crop.active)
+		return;
+
+	LibretroCropRect content = {};
+	if (!libretro_visible_content_bounds(surface, content))
+		return;
+
+	LibretroCropRect rect = { crop.x, crop.y, crop.w, crop.h };
+	if (libretro_crop_fit_rect_to_visible_content(surface->w, surface->h, content, rect)) {
+		crop.x = rect.x;
+		crop.y = rect.y;
+		crop.w = rect.w;
+		crop.h = rect.h;
+	}
 }
 
 static void libretro_expand_crop_to_minimum_frame(const SDL_Surface* surface, libretro_crop& crop)
@@ -2437,8 +2516,10 @@ static bool libretro_fixed_crop_from_surface(const SDL_Surface* surface,
 	crop.w = target_w;
 	crop.h = target_h;
 	crop.active = crop.w > 0 && crop.h > 0;
-	if (crop.active)
+	if (crop.active) {
+		libretro_fit_fixed_crop_to_visible_content(surface, crop);
 		libretro_update_crop_aspect(crop);
+	}
 	return crop.active;
 }
 
@@ -2682,6 +2763,7 @@ libretro_crop libretro_compute_crop(void)
 		auto_crop_image();
 		if (libretro_crop_from_renderer(surface, crop)) {
 			libretro_trim_black_crop_edges(surface, crop);
+			libretro_expand_crop_to_visible_content(surface, crop);
 			libretro_expand_crop_to_minimum_frame(surface, crop);
 			crop = libretro_stabilize_auto_crop(surface, crop);
 			if (!libretro_crop_used_renderer) {
@@ -2734,6 +2816,7 @@ libretro_crop libretro_compute_crop(void)
 	crop.aspect = (height > 0) ? static_cast<float>(width) / static_cast<float>(height) : 0.0f;
 	crop.active = true;
 	libretro_trim_black_crop_edges(surface, crop);
+	libretro_expand_crop_to_visible_content(surface, crop);
 	libretro_expand_crop_to_minimum_frame(surface, crop);
 	crop = libretro_stabilize_auto_crop(surface, crop);
 	return libretro_cache_crop(crop);

--- a/libretro/libretro_crop_helpers.h
+++ b/libretro/libretro_crop_helpers.h
@@ -1,0 +1,210 @@
+#ifndef LIBRETRO_CROP_HELPERS_H
+#define LIBRETRO_CROP_HELPERS_H
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+
+struct LibretroCropRect {
+	int x;
+	int y;
+	int w;
+	int h;
+};
+
+struct LibretroCropPixelBuffer {
+	const uint8_t* pixels;
+	int width;
+	int height;
+	int pitch;
+	int bytes_per_pixel;
+	uint32_t rgb_mask;
+};
+
+inline int libretro_crop_rect_right(const LibretroCropRect& rect)
+{
+	return rect.x + rect.w;
+}
+
+inline int libretro_crop_rect_bottom(const LibretroCropRect& rect)
+{
+	return rect.y + rect.h;
+}
+
+inline bool libretro_crop_rect_valid(const LibretroCropRect& rect)
+{
+	return rect.w > 0 && rect.h > 0;
+}
+
+inline bool libretro_crop_rect_equals(const LibretroCropRect& a, const LibretroCropRect& b)
+{
+	return a.x == b.x && a.y == b.y && a.w == b.w && a.h == b.h;
+}
+
+inline bool libretro_crop_buffer_valid(const LibretroCropPixelBuffer& buffer)
+{
+	return buffer.pixels
+		&& buffer.width > 0
+		&& buffer.height > 0
+		&& buffer.pitch > 0
+		&& buffer.bytes_per_pixel > 0
+		&& buffer.bytes_per_pixel <= static_cast<int>(sizeof(uint32_t))
+		&& buffer.rgb_mask != 0;
+}
+
+inline uint32_t libretro_crop_buffer_pixel(const LibretroCropPixelBuffer& buffer,
+	const int x, const int y)
+{
+	uint32_t value = 0;
+	const uint8_t* pixel = buffer.pixels + y * buffer.pitch + x * buffer.bytes_per_pixel;
+	std::memcpy(&value, pixel, buffer.bytes_per_pixel);
+	return value;
+}
+
+inline bool libretro_crop_rect_contains_point(const LibretroCropRect& rect,
+	const int x, const int y)
+{
+	return x >= rect.x && x < libretro_crop_rect_right(rect)
+		&& y >= rect.y && y < libretro_crop_rect_bottom(rect);
+}
+
+inline bool libretro_crop_rect_fits_buffer(const LibretroCropPixelBuffer& buffer,
+	const LibretroCropRect& rect)
+{
+	return libretro_crop_buffer_valid(buffer)
+		&& libretro_crop_rect_valid(rect)
+		&& rect.x >= 0
+		&& rect.y >= 0
+		&& libretro_crop_rect_right(rect) <= buffer.width
+		&& libretro_crop_rect_bottom(rect) <= buffer.height;
+}
+
+inline void libretro_crop_clamp_rect(const int surface_w, const int surface_h,
+	LibretroCropRect& rect)
+{
+	if (surface_w <= 0 || surface_h <= 0 || rect.w <= 0 || rect.h <= 0) {
+		rect = {};
+		return;
+	}
+
+	rect.w = std::min(rect.w, surface_w);
+	rect.h = std::min(rect.h, surface_h);
+	rect.x = std::clamp(rect.x, 0, surface_w - rect.w);
+	rect.y = std::clamp(rect.y, 0, surface_h - rect.h);
+}
+
+inline bool libretro_crop_find_visible_content_bounds(const LibretroCropPixelBuffer& buffer,
+	const uint32_t border_color, LibretroCropRect& bounds)
+{
+	if (!libretro_crop_buffer_valid(buffer))
+		return false;
+
+	const uint32_t border_rgb = border_color & buffer.rgb_mask;
+	int min_x = buffer.width;
+	int min_y = buffer.height;
+	int max_x = -1;
+	int max_y = -1;
+
+	for (int y = 0; y < buffer.height; y++) {
+		for (int x = 0; x < buffer.width; x++) {
+			if ((libretro_crop_buffer_pixel(buffer, x, y) & buffer.rgb_mask) == border_rgb)
+				continue;
+			min_x = std::min(min_x, x);
+			min_y = std::min(min_y, y);
+			max_x = std::max(max_x, x);
+			max_y = std::max(max_y, y);
+		}
+	}
+
+	if (max_x < min_x || max_y < min_y)
+		return false;
+
+	bounds = { min_x, min_y, max_x - min_x + 1, max_y - min_y + 1 };
+	return true;
+}
+
+inline bool libretro_crop_expand_to_visible_content(const LibretroCropPixelBuffer& buffer,
+	const uint32_t border_color, const int min_outside_pixels, LibretroCropRect& crop)
+{
+	if (!libretro_crop_rect_fits_buffer(buffer, crop))
+		return false;
+
+	const uint32_t border_rgb = border_color & buffer.rgb_mask;
+	const int required_pixels = std::max(1, min_outside_pixels);
+	int outside_pixels = 0;
+	int min_x = crop.x;
+	int min_y = crop.y;
+	int max_x = libretro_crop_rect_right(crop) - 1;
+	int max_y = libretro_crop_rect_bottom(crop) - 1;
+
+	for (int y = 0; y < buffer.height; y++) {
+		for (int x = 0; x < buffer.width; x++) {
+			if (libretro_crop_rect_contains_point(crop, x, y))
+				continue;
+			if ((libretro_crop_buffer_pixel(buffer, x, y) & buffer.rgb_mask) == border_rgb)
+				continue;
+
+			outside_pixels++;
+			min_x = std::min(min_x, x);
+			min_y = std::min(min_y, y);
+			max_x = std::max(max_x, x);
+			max_y = std::max(max_y, y);
+		}
+	}
+
+	if (outside_pixels < required_pixels)
+		return false;
+
+	LibretroCropRect expanded = { min_x, min_y, max_x - min_x + 1, max_y - min_y + 1 };
+	libretro_crop_clamp_rect(buffer.width, buffer.height, expanded);
+	if (libretro_crop_rect_equals(expanded, crop))
+		return false;
+
+	crop = expanded;
+	return true;
+}
+
+inline bool libretro_crop_fit_rect_to_visible_content(const int surface_w, const int surface_h,
+	const LibretroCropRect& content, LibretroCropRect& crop)
+{
+	if (surface_w <= 0 || surface_h <= 0
+		|| !libretro_crop_rect_valid(content)
+		|| !libretro_crop_rect_valid(crop)) {
+		return false;
+	}
+
+	LibretroCropRect fitted = crop;
+	libretro_crop_clamp_rect(surface_w, surface_h, fitted);
+
+	LibretroCropRect clamped_content = content;
+	libretro_crop_clamp_rect(surface_w, surface_h, clamped_content);
+	if (!libretro_crop_rect_valid(clamped_content))
+		return false;
+
+	if (clamped_content.w > fitted.w) {
+		fitted.x = clamped_content.x + clamped_content.w / 2 - fitted.w / 2;
+	} else {
+		if (clamped_content.x < fitted.x)
+			fitted.x = clamped_content.x;
+		if (libretro_crop_rect_right(clamped_content) > libretro_crop_rect_right(fitted))
+			fitted.x = libretro_crop_rect_right(clamped_content) - fitted.w;
+	}
+
+	if (clamped_content.h > fitted.h) {
+		fitted.y = clamped_content.y + clamped_content.h / 2 - fitted.h / 2;
+	} else {
+		if (clamped_content.y < fitted.y)
+			fitted.y = clamped_content.y;
+		if (libretro_crop_rect_bottom(clamped_content) > libretro_crop_rect_bottom(fitted))
+			fitted.y = libretro_crop_rect_bottom(clamped_content) - fitted.h;
+	}
+
+	libretro_crop_clamp_rect(surface_w, surface_h, fitted);
+	if (libretro_crop_rect_equals(fitted, crop))
+		return false;
+
+	crop = fitted;
+	return true;
+}
+
+#endif

--- a/tests/libretro_crop_policy_test.cpp
+++ b/tests/libretro_crop_policy_test.cpp
@@ -1,0 +1,108 @@
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include "libretro/libretro_crop_helpers.h"
+
+static int failures;
+
+static void expect_true(const bool actual, const char* message)
+{
+	if (!actual) {
+		std::cerr << message << '\n';
+		failures++;
+	}
+}
+
+template<typename T>
+static void expect_eq(const T actual, const T expected, const char* message)
+{
+	if (actual != expected) {
+		std::cerr << message << ": expected " << expected << ", got " << actual << '\n';
+		failures++;
+	}
+}
+
+static LibretroCropPixelBuffer make_buffer(const std::vector<uint32_t>& pixels,
+	const int width, const int height)
+{
+	return {
+		reinterpret_cast<const uint8_t*>(pixels.data()),
+		width,
+		height,
+		width * static_cast<int>(sizeof(uint32_t)),
+		static_cast<int>(sizeof(uint32_t)),
+		0x00ffffffu
+	};
+}
+
+static void test_expands_to_visible_pixels_below_crop()
+{
+	constexpr int width = 32;
+	constexpr int height = 32;
+	std::vector<uint32_t> pixels(width * height, 0);
+
+	for (int y = 8; y < 20; y++) {
+		for (int x = 6; x < 26; x++)
+			pixels[y * width + x] = 0x00ffffffu;
+	}
+	for (int y = 26; y < 28; y++) {
+		for (int x = 8; x < 24; x++)
+			pixels[y * width + x] = 0x0000ff00u;
+	}
+
+	auto buffer = make_buffer(pixels, width, height);
+	LibretroCropRect crop{ 6, 8, 20, 12 };
+
+	const bool changed = libretro_crop_expand_to_visible_content(buffer, 0, 4, crop);
+
+	expect_true(changed, "Crop should expand when visible content exists below it");
+	expect_eq(crop.x, 6, "Crop x should stay anchored");
+	expect_eq(crop.y, 8, "Crop y should stay anchored");
+	expect_eq(crop.w, 20, "Crop width should not change for bottom-only content");
+	expect_eq(crop.h, 20, "Crop bottom should expand to include lower content");
+}
+
+static void test_ignores_isolated_outside_pixels()
+{
+	constexpr int width = 32;
+	constexpr int height = 32;
+	std::vector<uint32_t> pixels(width * height, 0);
+
+	for (int y = 8; y < 20; y++) {
+		for (int x = 6; x < 26; x++)
+			pixels[y * width + x] = 0x00ffffffu;
+	}
+	pixels[27 * width + 16] = 0x00ffffffu;
+
+	auto buffer = make_buffer(pixels, width, height);
+	LibretroCropRect crop{ 6, 8, 20, 12 };
+
+	const bool changed = libretro_crop_expand_to_visible_content(buffer, 0, 4, crop);
+
+	expect_true(!changed, "Crop should ignore isolated outside pixels");
+	expect_eq(crop.h, 12, "Crop height should remain unchanged for isolated pixels");
+}
+
+static void test_fixed_crop_shifts_to_keep_content_visible()
+{
+	LibretroCropRect content{ 8, 3, 16, 18 };
+	LibretroCropRect crop{ 6, 8, 20, 20 };
+
+	const bool changed = libretro_crop_fit_rect_to_visible_content(40, 40, content, crop);
+
+	expect_true(changed, "Fixed crop should shift when visible content is above it");
+	expect_eq(crop.x, 6, "Fixed crop x should not move unnecessarily");
+	expect_eq(crop.y, 3, "Fixed crop y should move up to include visible content");
+	expect_eq(crop.w, 20, "Fixed crop width should remain fixed");
+	expect_eq(crop.h, 20, "Fixed crop height should remain fixed");
+}
+
+int main()
+{
+	test_expands_to_visible_pixels_below_crop();
+	test_ignores_isolated_outside_pixels();
+	test_fixed_crop_shifts_to_keep_content_visible();
+
+	return failures == 0 ? 0 : 1;
+}

--- a/tests/test_libretro_crop_policy.sh
+++ b/tests/test_libretro_crop_policy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cxx="${CXX:-c++}"
+out="${TMPDIR:-/tmp}/libretro_crop_policy_test.$$"
+trap 'rm -f "$out"' EXIT
+
+"$cxx" -std=c++17 -Wall -Wextra -Werror \
+	-I. \
+	-o "$out" \
+	tests/libretro_crop_policy_test.cpp
+"$out"


### PR DESCRIPTION
## Summary

This improves libretro crop handling so visible content outside the initial chipset/display crop bounds is not hidden. AUTO crop now expands back out to include meaningful visible pixels, and fixed crop presets are shifted to keep visible content in frame where possible.

The helper logic is split into `libretro_crop_helpers.h` so the crop policy can be tested without pulling in the full libretro core.

Refs #2141.

## Local testing

Tested locally with Steam RetroArch using the locally built Amiberry libretro DLL via `-L`, loading `Fuzzball_v1.0_1940.lha` from the local Amiberry `LHA` folder.

Observed captures:

- Crop disabled: `1440x1080`, black border visible.
- AUTO crop enabled: `1340x1080`, bottom HUD/round text still visible.
- AUTO crop at 3000 frames: still `1340x1080`, with no additional geometry churn after initial settling.

## Validation

- `bash tests/test_libretro_crop_policy.sh`
- `git diff --check` passed, with only Git's LF-to-CRLF warning for `libretro.cpp`
- `make platform=win -B libretro.o ...` passed, with the existing `WITH_MIDI` redefinition warning
