### PR TITLE
Fix native host cursor coordinate clamp

### DIFF
--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -27,6 +27,7 @@
 #include "options.h"
 #include "keyboard.h"
 #include "inputdevice.h"
+#include "amiberry_input_helpers.h"
 
 #include <algorithm>
 #include "inputrecord.h"
@@ -2679,22 +2680,11 @@ static bool get_mouse_position(int *xp, int *yp, int inx, int iny)
 		y = (int)(y * fmy);
 		x -= (int)(fdx * 1.0) - 0;
 		y -= (int)(fdy * 1.0) - 2;
-		if (x < 0) {
-			ob = true;
-			x = 0;
-		}
-		if (x * fmx >= vidinfo->outbuffer->outwidth) {
-			ob = true;
-			x = vidinfo->outbuffer->outwidth - 1;
-		}
-		if (y < 0) {
-			ob = true;
-			y = 0;
-		}
-		if (y * fmy >= vidinfo->outbuffer->outheight) {
-			ob = true;
-			y = vidinfo->outbuffer->outheight - 1;
-		}
+		bool axis_ob = false;
+		x = amiberry_input_clamp_native_axis(x, vidinfo->outbuffer->outwidth, &axis_ob);
+		ob |= axis_ob;
+		y = amiberry_input_clamp_native_axis(y, vidinfo->outbuffer->outheight, &axis_ob);
+		ob |= axis_ob;
 		if (currprefs.gfx_resolution == RES_LORES) {
 			x *= 2;
 		} else if (currprefs.gfx_resolution == RES_SUPERHIRES) {

--- a/src/osdep/amiberry_input_helpers.h
+++ b/src/osdep/amiberry_input_helpers.h
@@ -1,0 +1,30 @@
+#ifndef AMIBERRY_INPUT_HELPERS_H
+#define AMIBERRY_INPUT_HELPERS_H
+
+static inline int amiberry_input_clamp_native_axis(int value, int extent, bool* out_of_bounds)
+{
+	if (extent <= 0) {
+		if (out_of_bounds) {
+			*out_of_bounds = true;
+		}
+		return 0;
+	}
+	if (value < 0) {
+		if (out_of_bounds) {
+			*out_of_bounds = true;
+		}
+		return 0;
+	}
+	if (value >= extent) {
+		if (out_of_bounds) {
+			*out_of_bounds = true;
+		}
+		return extent - 1;
+	}
+	if (out_of_bounds) {
+		*out_of_bounds = false;
+	}
+	return value;
+}
+
+#endif

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -6,6 +6,7 @@ typedef std::uint16_t uae_u16;
 typedef std::uint32_t uae_u32;
 
 #include "amiberry_cursor.h"
+#include "amiberry_input_helpers.h"
 
 static int failures;
 
@@ -86,6 +87,24 @@ static void test_rtg_cursor_keeps_softsprite_fallback_disabled()
 		"RTG cursor must not force P96 software pointer fallback in 32-bit modes");
 }
 
+static void test_native_axis_clamp_uses_native_extent()
+{
+	bool out_of_bounds = true;
+	int value = amiberry_input_clamp_native_axis(239, 240, &out_of_bounds);
+	expect_eq(value, 239, "last native pixel must stay in range");
+	expect_true(!out_of_bounds, "last native pixel must not be treated as out of bounds");
+
+	out_of_bounds = false;
+	value = amiberry_input_clamp_native_axis(240, 240, &out_of_bounds);
+	expect_eq(value, 239, "one-past-native pixel must clamp to the last pixel");
+	expect_true(out_of_bounds, "one-past-native pixel must be reported out of bounds");
+
+	out_of_bounds = false;
+	value = amiberry_input_clamp_native_axis(-1, 240, &out_of_bounds);
+	expect_eq(value, 0, "negative native pixel must clamp to zero");
+	expect_true(out_of_bounds, "negative native pixel must be reported out of bounds");
+}
+
 int main()
 {
 	test_rgb12_expands_to_rgb24();
@@ -93,5 +112,6 @@ int main()
 	test_rgba32_cursor_pixels_use_raw_rgb_order();
 	test_host_only_forces_separate_rtg_sprite();
 	test_rtg_cursor_keeps_softsprite_fallback_disabled();
+	test_native_axis_clamp_uses_native_extent();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/test_cursor_pixel_format.sh
+++ b/tests/test_cursor_pixel_format.sh
@@ -5,5 +5,5 @@ cxx=${CXX:-c++}
 out="${TMPDIR:-/tmp}/cursor_pixel_format_test.$$"
 trap 'rm -f "$out"' EXIT
 
-"$cxx" -std=c++17 -Wall -Wextra -Werror -Isrc/include -o "$out" tests/cursor_pixel_format_test.cpp
+"$cxx" -std=c++17 -Wall -Wextra -Werror -Isrc/include -Isrc/osdep -o "$out" tests/cursor_pixel_format_test.cpp
 "$out"


### PR DESCRIPTION
## Summary
- fix native-screen mouse coordinate clamping after SDL/window scaling has already been applied
- add a small Amiberry input helper for native-axis clamping
- extend the focused cursor test and its script include path

Refs #2135 

## Root cause
The native mousehack path converted window coordinates into native/source coordinates with `fmx`/`fmy`, then checked the bounds with `x * fmx` and `y * fmy`. That applied the scaling factor a second time when deciding whether the pointer was outside the native output buffer, which could leave clicks vertically offset in scaled native modes.

## Validation
- `bash tests/test_cursor_pixel_format.sh`
- `git diff --cached --check`
- `rg -n "[ \t]+$" src\inputdevice.cpp src\osdep\amiberry_input_helpers.h tests\cursor_pixel_format_test.cpp tests\test_cursor_pixel_format.sh`
