### PR TITLE
a2065: poll the host receive queue from the hsync handler

### DIFF
--- a/src/a2065.cpp
+++ b/src/a2065.cpp
@@ -749,6 +749,14 @@ static void a2065_hsync_handler(void)
 {
 	static int cnt;
 
+	/* Pull host->guest frames out of the uaenet worker queue into the a2065
+	 * receive_buffer. Delivery was refactored to poll-based (uaenet_receive_poll
+	 * on the emulation thread) and wired into sana2, but the a2065 hsync handler
+	 * was left only draining its own buffer -- so received frames never arrived.
+	 * Without this, host->guest networking is dead (ping/telnet/ftp), while
+	 * guest->host TX still works. */
+	if (td != NULL)
+		ethernet_receive_poll(td, sysdata);
 	receive_queue_drain();
 
 	cnt--;


### PR DESCRIPTION
Fixes # (no existing issue — found while bringing up an A2065-networked guest)

### Problem

Host → guest networking on the **A2065** (Am7990 LANCE) is dead: a guest using the A2065 can *transmit* but never *receive*. `ping`/`telnet`/`ftp` to the guest don't work, while guest-initiated traffic goes out fine (the host even learns the card's MAC). `tcpdump -ni <tap>` shows the guest ARPing repeatedly for the host and the host replying, but the guest never sees the reply and keeps re-requesting.

### Root cause

The A2065 receive path is poll-based: the host TAP worker thread (`amiberry_uaenet.cpp`) only *queues* incoming frames, and actual delivery to the emulated LANCE happens on the emulation thread via `ethernet_receive_poll()` → `uaenet_receive_poll()` → the card's `gotfunc` (which fills the a2065 `receive_buffer`).

That poll is wired into the SANA2 driver (`sana2.cpp`) but was **missing from `a2065_hsync_handler()`**, which only called `receive_queue_drain()` — draining the a2065's own `receive_buffer`, a buffer that is only ever filled by `gotfunc`, which is only ever called by `uaenet_receive_poll()`. So the A2065 never pulled received frames out of the worker queue, and host → guest delivery silently stalled.

### Changes proposed in this pull request:

- Call `ethernet_receive_poll(td, sysdata)` from `a2065_hsync_handler()` (before `receive_queue_drain()`), so received frames are pulled from the host into the a2065 receive buffer and then delivered to the guest.

### Testing

Headless Amiga Unix (SVR4/68k) guest on a routed TAP:
- **Before:** `tcpdump` shows guest ARP requests + host ARP replies, guest never receives → `ping`/`telnet`/`ftp` all fail.
- **After:** `ping` 3/3, `telnet` (23) and `ftp` (21) reachable; interactive login + file transfer work.

@midwan
