### PR TITLE
a4091: reject illegal 53C710 Memory Move opcodes (ncr7xx bus/DMA tests)

### DIFF
--- a/src/qemuvga/lsi53c710.cpp
+++ b/src/qemuvga/lsi53c710.cpp
@@ -1419,40 +1419,22 @@ again:
         break;
 
     case 3:
-        if ((insn & (1 << 29)) == 0) {
-            /* Memory move.  */
+        /* Memory Move (DCMD 0xc0) is the only group-3 instruction on the
+           53C710; the Load/Store forms are 53C810+. Reject anything else as
+           an illegal instruction rather than running away on garbage fetched
+           from a non-responding address. */
+        if ((insn >> 24) != 0xc0) {
+            lsi_script_dma_interrupt(s, LSI_DSTAT_IID);
+            break;
+        }
+        {
             uint32_t dest;
             /* ??? The docs imply the destination address is loaded into
                the TEMP register.  However the Linux drivers rely on
-               the value being presrved.  */
+               the value being preserved.  */
             dest = read_dword(s, s->dsp);
             s->dsp += 4;
             lsi_memcpy(s, dest, addr, insn & 0xffffff);
-        } else {
-            uint8_t data[7];
-            int reg;
-            int n;
-            int i;
-
-            if (insn & (1 << 28)) {
-                addr = s->dsa + sextract32(addr, 0, 24);
-            }
-            n = (insn & 7);
-            reg = (insn >> 16) & 0xff;
-            if (insn & (1 << 24)) {
-				pci710_dma_read(pci_dev, addr, data, n);
-                DPRINTF("Load reg 0x%x size %d addr 0x%08x = %08x\n", reg, n,
-                        addr, *(int *)data);
-                for (i = 0; i < n; i++) {
-                    lsi_reg_writeb(s, reg + i, data[i]);
-                }
-            } else {
-                DPRINTF("Store reg 0x%x size %d addr 0x%08x\n", reg, n, addr);
-                for (i = 0; i < n; i++) {
-                    data[i] = lsi_reg_readb(s, reg + i);
-                }
-				pci710_dma_write(pci_dev, addr, data, n);
-            }
         }
     }
     if (insn_processed > 10000 && !s->waiting) {


### PR DESCRIPTION
Follow-up to #2156.

`ncr7xx -t4` (bus access test) executes a SCRIPTS program fetched from the board's own ROM/config window. A DMA read of a non-responding address returns `0xff` bytes, and the SCRIPTS decoder treated any group-3 opcode with bit 29 clear as a Memory Move, so `0xcfffffff` ran `lsi_memcpy()` with a 16MB byte count and a `0xdffxxxxx` destination - scribbling over custom-register space ("crazy blits") and never raising a DMA interrupt, so the driver's poll on DSTAT timed out (apparent hang).

The 53C710 Memory Move opcode is exactly `0xc0`; the Load/Store-register forms are 53C810+. This rejects any other group-3 encoding with an Illegal Instruction DMA interrupt (`DSTAT.IID`), matching the real chip. With this, `ncr7xx -t` passes the bus-access, DMA, DMA-copy, and DMA-copy-perf tests (the next failure, the SCSI pin test, fails gracefully without crashing).

References:
- Test source: `ncr7xx.c` `test_bus_access` in the a4091-software tree.
- Reference implementation: Copperline `a4091.rs` SCRIPTS engine (strict group-3 decode: only `0xc0-0xc7` is a Memory Move, everything else raises `DSTAT.IID`).

Refs #2155

🤖 Generated with [Claude Code](https://claude.com/claude-code)