### PR TITLE
a4091: emulate 53C710 SCSI loopback pins (ncr7xx -t8)

### DIFF
--- a/src/qemuvga/lsi53c710.cpp
+++ b/src/qemuvga/lsi53c710.cpp
@@ -1858,9 +1858,9 @@ static void lsi_reg_writeb(LSIState710 *s, int offset, uint8_t val)
         break;
     case 0x01: /* SCNTL1 */
         s->scntl1 = val;
-        if (val & LSI_SCNTL1_ADB) {
-            BADF("Immediate Arbritration not implemented\n");
-        }
+        /* SCNTL1.ADB (Assert Data Bus) drives the SODL/SOCL latches onto the
+           bus; in loopback (CTEST4.SLBE) they feed back into SBDL/SBCL, which
+           the read handlers realize. Just latch the bit here. */
         if (val & LSI_SCNTL1_RST) {
             if (!(s->sstat0 & LSI_SSTAT0_RST)) {
 //                qbus_reset_all(&s->bus.qbus);

--- a/src/qemuvga/lsi53c710.cpp
+++ b/src/qemuvga/lsi53c710.cpp
@@ -1651,6 +1651,23 @@ static uint8_t lsi_reg_readb(LSIState710 *s, int offset)
 }
 #endif
 
+/* SCSI loopback self-test (ncr7xx -t8): with CTEST4.SLBE (0x10) and
+   SCNTL1.ADB set, the SODL/SOCL output latches feed straight back into the
+   SBDL/SBCL input registers - there is no real bus on the emulated board. */
+static bool lsi_scsi_loopback(LSIState710 *s)
+{
+    return (s->ctest4 & 0x10) && (s->scntl1 & LSI_SCNTL1_ADB);
+}
+
+/* Generated SCSI data parity: odd by default, even when SCNTL1.AESP is set. */
+static int lsi_scsi_parity(LSIState710 *s, uint8_t val)
+{
+    int p = __builtin_popcount(val) & 1;
+    if (!(s->scntl1 & LSI_SCNTL1_AESP))
+        p ^= 1;
+    return p;
+}
+
 static uint8_t lsi_reg_readb2(LSIState710 *s, int offset)
 {
     uint8_t tmp;
@@ -1683,7 +1700,19 @@ static uint8_t lsi_reg_readb2(LSIState710 *s, int offset)
         /* This is needed by the linux drivers.  We currently only update it
            during the MSG IN phase.  */
         return s->sidl;
+    case 0xa: /* SBDL - SCSI bus data lines */
+        /* Loopback self-test: the SODL output latch feeds straight back;
+           the idle bus otherwise reads all-deasserted. */
+        return lsi_scsi_loopback(s) ? s->sodl : 0;
     case 0xb: /* SBCL */
+		if (lsi_scsi_loopback(s)) {
+			/* Loopback: SBCL mirrors the SOCL latch. ACK/REQ (bits 3 and 6)
+			   assert only in target mode (SCNTL0.TRG, bit 0). */
+			tmp = s->socl;
+			if (!(s->scntl0 & 0x01))
+				tmp &= ~0x48;
+			return tmp;
+		}
 		tmp = 0;
 		if (s->scntl1 & LSI_SCNTL1_CON) {
 			/* NetBSD 1.x checks for REQ */
@@ -1707,7 +1736,16 @@ static uint8_t lsi_reg_readb2(LSIState710 *s, int offset)
         lsi_update_irq(s);
        return tmp;
     case 0x0e: /* SSTAT1 */
-        return s->sstat1;
+        /* PAR (bit 0) is the generated parity of the driven data in
+           loopback with parity generation (SCNTL0.EPG, bit 2); RST (bit 1)
+           reflects a SCNTL1.RST bus-reset request. */
+        tmp = s->sstat1 & ~0x03;
+        if (s->scntl1 & LSI_SCNTL1_RST)
+            tmp |= 0x02;
+        if (lsi_scsi_loopback(s) && (s->scntl0 & 0x04)
+            && lsi_scsi_parity(s, s->sodl))
+            tmp |= 0x01;
+        return tmp;
     case 0x0f: /* SSTAT2 */
         /* High nibble is the SCSI FIFO byte count. */
         return (s->sstat2 & 0x0f) | (s->scsi_fifo_count << 4);
@@ -1855,9 +1893,12 @@ static void lsi_reg_writeb(LSIState710 *s, int offset, uint8_t val)
             s->scsi_fifo[s->scsi_fifo_count++] = (par << 8) | val;
         }
         break;
-	case 0x0b: /* SBCL */
-		lsi_set_phase (s, val & PHASE_MASK);
-		break;
+    case 0x07: /* SOCL - SCSI output control latch */
+        s->socl = val;
+        break;
+    case 0x0b: /* SBCL */
+        lsi_set_phase (s, val & PHASE_MASK);
+        break;
     case 0x0c: case 0x0d: case 0x0e: case 0x0f:
         /* Linux writes to these readonly registers on startup.  */
         return;


### PR DESCRIPTION
Follow-up in the a4091 `ncr7xx -t` series (see #2156, #2157).

The SCSI pin test (`ncr7xx -t8`) drives the 53C710 output latches and reads them back through the bus input registers in loopback mode (`CTEST4.SLBE` + `SCNTL1.ADB`), a path the emulation didn't model:

- **SBDL** (lsi 0x0a) was unhandled -> data lines read as 0.
- **SBCL** (lsi 0x0b) had no loopback path.
- **SSTAT1** never reflected generated parity or the bus-reset request.
- **SOCL** (0x07) writes were dropped entirely, so the control-line pattern never reached the latch.

This models the loopback:
- SBDL mirrors the SODL latch (idle bus reads 0).
- SBCL mirrors the SOCL latch; ACK/REQ (bits 3 and 6) assert only in target mode (`SCNTL0.TRG`).
- SSTAT1 reports the generated data parity (bit 0) under `SCNTL0.EPG`, and the `SCNTL1.RST` bus-reset request (bit 1).
- Adds the missing SOCL write handler.

With this, `ncr7xx -t8` passes. Ported from the Copperline `a4091.rs` reference implementation.

Refs #2155

🤖 Generated with [Claude Code](https://claude.com/claude-code)