### PR TITLE
Fix native host cursor hotspot

### DIFF
--- a/src/include/inputdevice.h
+++ b/src/include/inputdevice.h
@@ -242,6 +242,9 @@ extern int is_touch_lightpen (void);
 extern int inputdevice_is_tablet (void);
 extern int input_mousehack_status(TrapContext *ctx, int mode, uaecptr diminfo, uaecptr dispinfo, uaecptr vp, uae_u32 moffset);
 extern void input_mousehack_mouseoffset (uaecptr pointerprefs);
+extern void input_mousehack_cursor_hotspot(int cursor_width, int cursor_height, int* hotspot_x, int* hotspot_y,
+	int* residual_x, int* residual_y);
+extern void input_mousehack_set_host_cursor_uses_hotspot(bool enabled, int residual_x, int residual_y);
 extern int mousehack_alive (void);
 extern void mousehack_wakeup(void);
 extern void mousehack_write(int reg, uae_u16 val);

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -2452,6 +2452,8 @@ static int lastmxy_abs[2][2];
 static uaecptr magicmouse_ibase, magicmouse_gfxbase;
 static int dimensioninfo_width, dimensioninfo_height, dimensioninfo_dbl;
 static int vp_xoffset, vp_yoffset, mouseoffset_x, mouseoffset_y;
+static bool mousehack_host_cursor_uses_hotspot;
+static int mousehack_host_cursor_residual_x, mousehack_host_cursor_residual_y;
 static int tablet_maxx, tablet_maxy, tablet_maxz;
 static int tablet_resx, tablet_resy;
 static int tablet_maxax, tablet_maxay, tablet_maxaz;
@@ -2577,6 +2579,8 @@ static void mousehack_reset (void)
 {
 	dimensioninfo_width = dimensioninfo_height = 0;
 	mouseoffset_x = mouseoffset_y = 0;
+	mousehack_host_cursor_uses_hotspot = false;
+	mousehack_host_cursor_residual_x = mousehack_host_cursor_residual_y = 0;
 	dimensioninfo_dbl = 0;
 	mousehack_alive_cnt = 0;
 	vp_xoffset = vp_yoffset = 0;
@@ -2642,6 +2646,26 @@ void input_mousehack_mouseoffset(uaecptr pointerprefs)
 {
 	mouseoffset_x = (uae_s16)get_word (pointerprefs + 28);
 	mouseoffset_y = (uae_s16)get_word (pointerprefs + 30);
+}
+
+void input_mousehack_cursor_hotspot(int cursor_width, int cursor_height, int* hotspot_x, int* hotspot_y,
+	int* residual_x, int* residual_y)
+{
+	amiberry_input_mousehack_cursor_hotspot(mouseoffset_x, mouseoffset_y, cursor_width, cursor_height,
+		hotspot_x, hotspot_y);
+	if (residual_x) {
+		*residual_x = amiberry_input_mousehack_hotspot_residual_axis(mouseoffset_x, cursor_width, 1);
+	}
+	if (residual_y) {
+		*residual_y = amiberry_input_mousehack_hotspot_residual_axis(mouseoffset_y, cursor_height, 2);
+	}
+}
+
+void input_mousehack_set_host_cursor_uses_hotspot(bool enabled, int residual_x, int residual_y)
+{
+	mousehack_host_cursor_uses_hotspot = enabled;
+	mousehack_host_cursor_residual_x = enabled ? residual_x : 0;
+	mousehack_host_cursor_residual_y = enabled ? residual_y : 0;
 }
 
 static bool get_mouse_position(int *xp, int *yp, int inx, int iny)
@@ -2991,8 +3015,13 @@ void inputdevice_tablet_info (int maxx, int maxy, int maxz, int maxax, int maxay
 
 static void inputdevice_mh_abs (int x, int y, uae_u32 buttonbits)
 {
-	x -= mouseoffset_x + 1;
-	y -= mouseoffset_y + 2;
+	if (mousehack_host_cursor_uses_hotspot) {
+		x -= mousehack_host_cursor_residual_x;
+		y -= mousehack_host_cursor_residual_y;
+	} else {
+		x -= mouseoffset_x + 1;
+		y -= mouseoffset_y + 2;
+	}
 
 	mousehack_enable ();
 	if (mousehack_address) {

--- a/src/osdep/amiberry_input_helpers.h
+++ b/src/osdep/amiberry_input_helpers.h
@@ -27,4 +27,41 @@ static inline int amiberry_input_clamp_native_axis(int value, int extent, bool* 
 	return value;
 }
 
+static inline int amiberry_input_mousehack_hotspot_axis(int pointer_offset, int extent, int bias)
+{
+	if (extent <= 0) {
+		return 0;
+	}
+
+	const int hotspot = -(pointer_offset + bias);
+	if (hotspot < 0) {
+		return 0;
+	}
+	if (hotspot >= extent) {
+		return extent - 1;
+	}
+	return hotspot;
+}
+
+static inline int amiberry_input_mousehack_hotspot_residual_axis(int pointer_offset, int extent, int bias)
+{
+	if (extent <= 0) {
+		return 0;
+	}
+
+	const int hotspot = amiberry_input_mousehack_hotspot_axis(pointer_offset, extent, bias);
+	return pointer_offset + bias + hotspot;
+}
+
+static inline void amiberry_input_mousehack_cursor_hotspot(int pointer_x_offset, int pointer_y_offset,
+	int cursor_width, int cursor_height, int* hotspot_x, int* hotspot_y)
+{
+	if (hotspot_x) {
+		*hotspot_x = amiberry_input_mousehack_hotspot_axis(pointer_x_offset, cursor_width, 1);
+	}
+	if (hotspot_y) {
+		*hotspot_y = amiberry_input_mousehack_hotspot_axis(pointer_y_offset, cursor_height, 2);
+	}
+}
+
 #endif

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -59,6 +59,7 @@
 #ifdef AMIBERRY
 #include "amiberry_cursor.h"
 #include "amiberry_gfx.h"
+#include "amiberry_input_helpers.h"
 #include "gfx_colors.h"
 #include "gfx_window.h"
 #include "display_modes.h"
@@ -199,6 +200,25 @@ static int wincursor_shown;
 static uaecptr boardinfo, ABI_interrupt;
 static int interrupt_enabled;
 float p96vblank;
+
+#ifdef AMIBERRY
+static void clear_host_cursor_hotspot_compensation()
+{
+	input_mousehack_set_host_cursor_uses_hotspot(false, 0, 0);
+}
+
+static void destroy_p96_host_cursor(bool restore_normal_cursor)
+{
+	if (p96_cursor) {
+		if (restore_normal_cursor && SDL_GetCursor() == p96_cursor) {
+			SDL_SetCursor(normalcursor);
+		}
+		SDL_DestroyCursor(p96_cursor);
+		p96_cursor = nullptr;
+	}
+	clear_host_cursor_hotspot_compensation();
+}
+#endif
 
 static int overlay_src_width_in, overlay_src_height_in;
 static int overlay_src_height, overlay_src_width;
@@ -986,10 +1006,7 @@ static void setupcursor()
 		update_cursor_overlay_surface();
 		
 		// Ensure any native SDL cursor is hidden/freed so it doesn't conflict
-		if (p96_cursor) {
-			SDL_DestroyCursor(p96_cursor);
-			p96_cursor = nullptr;
-		}
+		destroy_p96_host_cursor(false);
 
 		setupcursor_needed = 0;
 		P96TRACE_SPR((_T("cursorsurface3d updated (overlay)\n")));
@@ -1042,10 +1059,7 @@ static void disablemouse ()
 	if (!hwsprite)
 		return;
 #ifdef AMIBERRY
-	if (p96_cursor) {
-		SDL_DestroyCursor(p96_cursor);
-		p96_cursor = nullptr;
-	}
+	destroy_p96_host_cursor(false);
 #else
 	D3D_setcursor(0, 0, 0, 0, 0, 0, 0, false, true);
 #endif
@@ -2181,6 +2195,11 @@ static void putwinmousepixel(HDC andDC, HDC xorDC, int x, int y, int c, uae_u32 
 static int tmp_sprite_w, tmp_sprite_h;
 static uae_u8 tmp_sprite_data[CURSORMAXWIDTH * CURSORMAXHEIGHT];
 static uae_u32 tmp_sprite_colors[4];
+#ifdef AMIBERRY
+static int tmp_sprite_hotspot_x, tmp_sprite_hotspot_y;
+static int tmp_sprite_residual_x, tmp_sprite_residual_y;
+static int tmp_sprite_chipset = -1;
+#endif
 
 extern uaecptr sprite_0;
 extern int sprite_0_width, sprite_0_height, sprite_0_doubled;
@@ -2199,8 +2218,11 @@ static int createwindowscursor(int monid, int set, int chipset)
 	uae_u8 *image = nullptr;
 	uae_u8 tmp_sprite[CURSORMAXWIDTH * CURSORMAXHEIGHT];
 	int datasize;
+	int hotspot_x = 0, hotspot_y = 0;
+	int residual_x = 0, residual_y = 0;
 
 	wincursor_shown = 0;
+	clear_host_cursor_hotspot_compensation();
 
 	if (isfullscreen() > 0 || !magic_mouse_host_only_enabled()) {
 		goto exit;
@@ -2260,11 +2282,20 @@ static int createwindowscursor(int monid, int set, int chipset)
 		image = cursordata;
 	}
 
+	if (chipset) {
+		input_mousehack_cursor_hotspot(w, h, &hotspot_x, &hotspot_y, &residual_x, &residual_y);
+	}
+
 	datasize = h * ((w + 15) / 16) * 16;
 
 	if (p96_cursor) {
-		if (w == tmp_sprite_w && h == tmp_sprite_h && !memcmp(tmp_sprite_data, image, datasize) && !memcmp(tmp_sprite_colors, ct, sizeof(uae_u32) * 4)) {
+		if (w == tmp_sprite_w && h == tmp_sprite_h && hotspot_x == tmp_sprite_hotspot_x &&
+			hotspot_y == tmp_sprite_hotspot_y && chipset == tmp_sprite_chipset &&
+			!memcmp(tmp_sprite_data, image, datasize) && !memcmp(tmp_sprite_colors, ct, sizeof(uae_u32) * 4)) {
 			if (SDL_GetCursor() == p96_cursor) {
+				tmp_sprite_residual_x = residual_x;
+				tmp_sprite_residual_y = residual_y;
+				input_mousehack_set_host_cursor_uses_hotspot(chipset != 0, residual_x, residual_y);
 				wincursor_shown = 1;
 				return 1;
 			}
@@ -2276,6 +2307,9 @@ static int createwindowscursor(int monid, int set, int chipset)
 	write_log(_T("p96_cursor: %dx%d\n"), w, h);
 
 	tmp_sprite_w = tmp_sprite_h = 0;
+	tmp_sprite_hotspot_x = tmp_sprite_hotspot_y = 0;
+	tmp_sprite_residual_x = tmp_sprite_residual_y = 0;
+	tmp_sprite_chipset = -1;
 
 	cursor_surface = SDL_CreateSurface(w, h, SDL_PIXELFORMAT_RGBA32);
 	if (!cursor_surface)
@@ -2296,9 +2330,14 @@ static int createwindowscursor(int monid, int set, int chipset)
 
 end:
 	if (isdata) {
-		p96_cursor = SDL_CreateColorCursor(cursor_surface, 0, 0);
+		p96_cursor = SDL_CreateColorCursor(cursor_surface, hotspot_x, hotspot_y);
 		tmp_sprite_w = w;
 		tmp_sprite_h = h;
+		tmp_sprite_hotspot_x = hotspot_x;
+		tmp_sprite_hotspot_y = hotspot_y;
+		tmp_sprite_residual_x = residual_x;
+		tmp_sprite_residual_y = residual_y;
+		tmp_sprite_chipset = chipset;
 		memcpy(tmp_sprite_data, image, datasize);
 		memcpy(tmp_sprite_colors, ct, sizeof(uae_u32) * 4);
 	}
@@ -2311,6 +2350,7 @@ end:
 
 	if (p96_cursor) {
 		SDL_SetCursor(p96_cursor);
+		input_mousehack_set_host_cursor_uses_hotspot(chipset != 0, residual_x, residual_y);
 		wincursor_shown = 1;
 	}
 
@@ -2326,13 +2366,7 @@ end:
 	return ret;
 
 exit:
-	if (p96_cursor) {
-		if (SDL_GetCursor() == p96_cursor) {
-			SDL_SetCursor(normalcursor);
-		}
-		SDL_DestroyCursor(p96_cursor);
-		p96_cursor = nullptr;
-	}
+	destroy_p96_host_cursor(true);
 
 	return ret;
 #else
@@ -2518,6 +2552,8 @@ int picasso_setwincursor(int monid)
 #ifdef AMIBERRY
 	if (p96_cursor) {
 		SDL_SetCursor(p96_cursor);
+		input_mousehack_set_host_cursor_uses_hotspot(tmp_sprite_chipset != 0,
+			tmp_sprite_residual_x, tmp_sprite_residual_y);
 		return 1;
 	} else if (!ad->picasso_on) {
 		if (createwindowscursor(monid, 0, 1))

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -19,6 +19,15 @@ static void expect_eq(uae_u32 actual, uae_u32 expected, const char *message)
 	}
 }
 
+static void expect_int_eq(int actual, int expected, const char *message)
+{
+	if (actual != expected) {
+		std::cerr << message << ": expected " << expected
+			<< ", got " << actual << '\n';
+		failures++;
+	}
+}
+
 static void expect_true(bool condition, const char *message)
 {
 	if (!condition) {
@@ -105,6 +114,44 @@ static void test_native_axis_clamp_uses_native_extent()
 	expect_true(out_of_bounds, "negative native pixel must be reported out of bounds");
 }
 
+static void test_mousehack_hotspot_matches_pointer_offset()
+{
+	int hotspot_x = -1;
+	int hotspot_y = -1;
+
+	amiberry_input_mousehack_cursor_hotspot(-1, -2, 16, 16, &hotspot_x, &hotspot_y);
+	expect_eq(hotspot_x, 0, "default x pointer offset must keep top-left hotspot");
+	expect_eq(hotspot_y, 0, "default y pointer offset must keep top-left hotspot");
+	expect_int_eq(amiberry_input_mousehack_hotspot_residual_axis(-1, 16, 1), 0,
+		"default x pointer offset must not leave residual compensation");
+	expect_int_eq(amiberry_input_mousehack_hotspot_residual_axis(-2, 16, 2), 0,
+		"default y pointer offset must not leave residual compensation");
+
+	amiberry_input_mousehack_cursor_hotspot(-26, -32, 51, 61, &hotspot_x, &hotspot_y);
+	expect_eq(hotspot_x, 25, "centered cross cursor x offset must become centered host hotspot");
+	expect_eq(hotspot_y, 30, "centered cross cursor y offset must become centered host hotspot");
+	expect_int_eq(amiberry_input_mousehack_hotspot_residual_axis(-26, 51, 1), 0,
+		"centered cross cursor x offset must be fully represented by host hotspot");
+	expect_int_eq(amiberry_input_mousehack_hotspot_residual_axis(-32, 61, 2), 0,
+		"centered cross cursor y offset must be fully represented by host hotspot");
+
+	amiberry_input_mousehack_cursor_hotspot(4, 4, 16, 16, &hotspot_x, &hotspot_y);
+	expect_eq(hotspot_x, 0, "positive x pointer offset must clamp hotspot to left edge");
+	expect_eq(hotspot_y, 0, "positive y pointer offset must clamp hotspot to top edge");
+	expect_int_eq(amiberry_input_mousehack_hotspot_residual_axis(4, 16, 1), 5,
+		"positive x pointer offset must leave residual compensation after hotspot clamping");
+	expect_int_eq(amiberry_input_mousehack_hotspot_residual_axis(4, 16, 2), 6,
+		"positive y pointer offset must leave residual compensation after hotspot clamping");
+
+	amiberry_input_mousehack_cursor_hotspot(-80, -80, 16, 16, &hotspot_x, &hotspot_y);
+	expect_eq(hotspot_x, 15, "oversized x pointer offset must clamp hotspot to right edge");
+	expect_eq(hotspot_y, 15, "oversized y pointer offset must clamp hotspot to bottom edge");
+	expect_int_eq(amiberry_input_mousehack_hotspot_residual_axis(-80, 16, 1), -64,
+		"oversized x pointer offset must leave negative residual compensation after hotspot clamping");
+	expect_int_eq(amiberry_input_mousehack_hotspot_residual_axis(-80, 16, 2), -63,
+		"oversized y pointer offset must leave negative residual compensation after hotspot clamping");
+}
+
 int main()
 {
 	test_rgb12_expands_to_rgb24();
@@ -113,5 +160,6 @@ int main()
 	test_host_only_forces_separate_rtg_sprite();
 	test_rtg_cursor_keeps_softsprite_fallback_disabled();
 	test_native_axis_clamp_uses_native_extent();
+	test_mousehack_hotspot_matches_pointer_offset();
 	return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- use the native Amiga pointer offset as the SDL host cursor hotspot for Host Only native cursors
- avoid applying the same mousehack pointer offset twice once the host cursor already carries that hotspot
- add focused helper coverage for top-left and centered native cursor hotspot cases

## Root cause
The native Host Only cursor was generated from the Amiga sprite pixels, but SDL always received hotspot `(0, 0)`. Mousehack still compensated using the Amiga pointer offset, so centered cursors such as the 51x61 cross looked correct visually but clicked from the wrong point and clipped oddly at the top/bottom when trapped.

Refs #2135

## Validation
- `bash tests/test_cursor_pixel_format.sh`
- `git diff --check HEAD~1 HEAD`
- `cmake --build out/build/windows-debug --parallel`
