### PR TITLE
Fix native host cursor hotspot learning

### DIFF
--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -31,6 +31,7 @@
 #include "xwin.h"
 #include "inputdevice.h"
 #include "amiberry_cursor.h"
+#include "amiberry_input_helpers.h"
 #ifdef SERIAL_PORT
 #include "serial.h"
 #endif
@@ -692,7 +693,7 @@ struct sprite {
 
 static struct sprite spr[MAX_SPRITES];
 uaecptr sprite_0;
-int sprite_0_width, sprite_0_height, sprite_0_doubled;
+int sprite_0_width, sprite_0_height, sprite_0_doubled, sprite_0_x, sprite_0_y;
 uae_u32 sprite_0_colors[4];
 uae_u32 magic_sprite_mask = 0xffffffff;
 
@@ -4403,6 +4404,8 @@ static void cursorsprite(struct sprite *s)
 		return;
 	}
 	sprite_0 = s->pt;
+	sprite_0_x = amiberry_input_native_sprite_x(s->pos, s->ctl, aga_mode || ecs_denise);
+	sprite_0_y = amiberry_input_native_sprite_y(s->pos, s->ctl, ecs_agnus);
 	sprite_0_height = s->vstop - s->vstart;
 	sprite_0_colors[0] = 0;
 	sprite_0_doubled = 0;

--- a/src/include/inputdevice.h
+++ b/src/include/inputdevice.h
@@ -244,6 +244,7 @@ extern int input_mousehack_status(TrapContext *ctx, int mode, uaecptr diminfo, u
 extern void input_mousehack_mouseoffset (uaecptr pointerprefs);
 extern void input_mousehack_cursor_hotspot(int cursor_width, int cursor_height, int* hotspot_x, int* hotspot_y,
 	int* residual_x, int* residual_y);
+extern bool input_mousehack_get_last_abs_position(int* x, int* y);
 extern void input_mousehack_set_host_cursor_uses_hotspot(bool enabled, int residual_x, int residual_y);
 extern int mousehack_alive (void);
 extern void mousehack_wakeup(void);

--- a/src/include/inputdevice.h
+++ b/src/include/inputdevice.h
@@ -245,6 +245,7 @@ extern void input_mousehack_mouseoffset (uaecptr pointerprefs);
 extern void input_mousehack_cursor_hotspot(int cursor_width, int cursor_height, int* hotspot_x, int* hotspot_y,
 	int* residual_x, int* residual_y);
 extern bool input_mousehack_get_last_abs_position(int* x, int* y);
+extern void input_mousehack_invalidate_last_abs_position();
 extern void input_mousehack_set_host_cursor_uses_hotspot(bool enabled, int residual_x, int residual_y);
 extern int mousehack_alive (void);
 extern void mousehack_wakeup(void);

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -2686,6 +2686,11 @@ bool input_mousehack_get_last_abs_position(int* x, int* y)
 	return true;
 }
 
+void input_mousehack_invalidate_last_abs_position()
+{
+	mousehack_last_abs_valid = false;
+}
+
 static bool get_mouse_position(int *xp, int *yp, int inx, int iny)
 {
 	extern int mouse_monid;

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -2454,6 +2454,8 @@ static int dimensioninfo_width, dimensioninfo_height, dimensioninfo_dbl;
 static int vp_xoffset, vp_yoffset, mouseoffset_x, mouseoffset_y;
 static bool mousehack_host_cursor_uses_hotspot;
 static int mousehack_host_cursor_residual_x, mousehack_host_cursor_residual_y;
+static int mousehack_last_abs_x, mousehack_last_abs_y;
+static bool mousehack_last_abs_valid;
 static int tablet_maxx, tablet_maxy, tablet_maxz;
 static int tablet_resx, tablet_resy;
 static int tablet_maxax, tablet_maxay, tablet_maxaz;
@@ -2581,6 +2583,8 @@ static void mousehack_reset (void)
 	mouseoffset_x = mouseoffset_y = 0;
 	mousehack_host_cursor_uses_hotspot = false;
 	mousehack_host_cursor_residual_x = mousehack_host_cursor_residual_y = 0;
+	mousehack_last_abs_x = mousehack_last_abs_y = 0;
+	mousehack_last_abs_valid = false;
 	dimensioninfo_dbl = 0;
 	mousehack_alive_cnt = 0;
 	vp_xoffset = vp_yoffset = 0;
@@ -2666,6 +2670,20 @@ void input_mousehack_set_host_cursor_uses_hotspot(bool enabled, int residual_x, 
 	mousehack_host_cursor_uses_hotspot = enabled;
 	mousehack_host_cursor_residual_x = enabled ? residual_x : 0;
 	mousehack_host_cursor_residual_y = enabled ? residual_y : 0;
+}
+
+bool input_mousehack_get_last_abs_position(int* x, int* y)
+{
+	if (!mousehack_last_abs_valid) {
+		return false;
+	}
+	if (x) {
+		*x = mousehack_last_abs_x;
+	}
+	if (y) {
+		*y = mousehack_last_abs_y;
+	}
+	return true;
 }
 
 static bool get_mouse_position(int *xp, int *yp, int inx, int iny)
@@ -3013,7 +3031,7 @@ void inputdevice_tablet_info (int maxx, int maxy, int maxz, int maxax, int maxay
 	inputdevice_update_tablet_params();
 }
 
-static void inputdevice_mh_abs (int x, int y, uae_u32 buttonbits)
+static void inputdevice_mh_abs (int x, int y, uae_u32 buttonbits, bool position_valid)
 {
 	if (mousehack_host_cursor_uses_hotspot) {
 		x -= mousehack_host_cursor_residual_x;
@@ -3024,6 +3042,10 @@ static void inputdevice_mh_abs (int x, int y, uae_u32 buttonbits)
 	}
 
 	mousehack_enable ();
+	// Keep the Amiga coordinate actually delivered after host-hotspot compensation.
+	mousehack_last_abs_x = x;
+	mousehack_last_abs_y = y;
+	mousehack_last_abs_valid = position_valid && mousehack_address;
 	if (mousehack_address) {
 		uae_u8 tmp1[4], tmp2[4];
 		uae_u8 *p = mousehack_address;
@@ -3294,8 +3316,8 @@ static void mousehack_helper (uae_u32 buttonmask)
 		return;
 	}
 
-	get_mouse_position(&x, &y, lastmx, lastmy);
-	inputdevice_mh_abs(x, y, buttonmask);
+	const bool position_valid = get_mouse_position(&x, &y, lastmx, lastmy);
+	inputdevice_mh_abs(x, y, buttonmask, position_valid);
 }
 
 static int mouseedge_x, mouseedge_y, mouseedge_time;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -1277,6 +1277,8 @@ void gfx_set_picasso_state(const int monid, const int on)
 
 	if (mon->screen_is_picasso == on)
 		return;
+	// Absolute coordinates from the previous display mode use a different coordinate space.
+	input_mousehack_invalidate_last_abs_position();
 	mon->screen_is_picasso = on;
 #ifdef RETROPLATFORM
 	rp_rtg_switch();

--- a/src/osdep/amiberry_input_helpers.h
+++ b/src/osdep/amiberry_input_helpers.h
@@ -64,4 +64,101 @@ static inline void amiberry_input_mousehack_cursor_hotspot(int pointer_x_offset,
 	}
 }
 
+static inline int amiberry_input_native_sprite_x(uae_u16 pos, uae_u16 ctl, bool extended_x)
+{
+	// Mousehack uses hires-granularity coordinates, so AGA's half-step bit cannot be represented here.
+	int x = ((pos & 0xff) << 2) | ((ctl & 0x01) << 1);
+	if (extended_x && (ctl & 0x10)) {
+		x |= 1;
+	}
+	return x;
+}
+
+static inline int amiberry_input_native_sprite_y(uae_u16 pos, uae_u16 ctl, bool extended_y)
+{
+	int y = pos >> 8;
+	if (ctl & 0x04) {
+		y |= 0x0100;
+	}
+	if (extended_y && (ctl & 0x40)) {
+		y |= 0x0200;
+	}
+	return y << 1;
+}
+
+struct amiberry_input_cursor_hotspot_tracker
+{
+	bool have_sample = false;
+	bool learned = false;
+	int last_pointer_x = 0;
+	int last_pointer_y = 0;
+	int last_sprite_x = 0;
+	int last_sprite_y = 0;
+	int candidate_x = 0;
+	int candidate_y = 0;
+	int stable_samples = 0;
+	int hotspot_x = 0;
+	int hotspot_y = 0;
+};
+
+static inline void amiberry_input_cursor_hotspot_tracker_reset(
+	amiberry_input_cursor_hotspot_tracker* tracker)
+{
+	if (tracker) {
+		*tracker = {};
+	}
+}
+
+static inline bool amiberry_input_cursor_hotspot_tracker_sample(
+	amiberry_input_cursor_hotspot_tracker* tracker, bool position_valid,
+	int pointer_x, int pointer_y, int sprite_x, int sprite_y,
+	int cursor_width, int cursor_height, int required_stable_samples,
+	int* hotspot_x, int* hotspot_y)
+{
+	if (!tracker) {
+		return false;
+	}
+
+	const int candidate_x = pointer_x - sprite_x;
+	const int candidate_y = pointer_y - sprite_y;
+	const bool candidate_valid = position_valid && cursor_width > 0 && cursor_height > 0
+		&& candidate_x >= 0 && candidate_x < cursor_width
+		&& candidate_y >= 0 && candidate_y < cursor_height;
+
+	if (candidate_valid) {
+		const bool stationary = tracker->have_sample
+			&& pointer_x == tracker->last_pointer_x && pointer_y == tracker->last_pointer_y
+			&& sprite_x == tracker->last_sprite_x && sprite_y == tracker->last_sprite_y
+			&& candidate_x == tracker->candidate_x && candidate_y == tracker->candidate_y;
+
+		tracker->stable_samples = stationary ? tracker->stable_samples + 1 : 1;
+		tracker->have_sample = true;
+		tracker->last_pointer_x = pointer_x;
+		tracker->last_pointer_y = pointer_y;
+		tracker->last_sprite_x = sprite_x;
+		tracker->last_sprite_y = sprite_y;
+		tracker->candidate_x = candidate_x;
+		tracker->candidate_y = candidate_y;
+
+		if (tracker->stable_samples >= required_stable_samples) {
+			tracker->learned = true;
+			tracker->hotspot_x = candidate_x;
+			tracker->hotspot_y = candidate_y;
+		}
+	} else {
+		tracker->have_sample = false;
+		tracker->stable_samples = 0;
+	}
+
+	if (tracker->learned) {
+		if (hotspot_x) {
+			*hotspot_x = tracker->hotspot_x;
+		}
+		if (hotspot_y) {
+			*hotspot_y = tracker->hotspot_y;
+		}
+	}
+	return tracker->learned;
+}
+
 #endif

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -2232,6 +2232,7 @@ static int createwindowscursor(int monid, int set, int chipset)
 	int datasize;
 	int hotspot_x = 0, hotspot_y = 0;
 	int residual_x = 0, residual_y = 0;
+	bool cursor_cache_matches = false;
 
 	wincursor_shown = 0;
 
@@ -2293,10 +2294,16 @@ static int createwindowscursor(int monid, int set, int chipset)
 		image = cursordata;
 	}
 
+	datasize = h * ((w + 15) / 16) * 16;
+	cursor_cache_matches = p96_cursor
+		&& w == tmp_sprite_w && h == tmp_sprite_h && chipset == tmp_sprite_chipset
+		&& !memcmp(tmp_sprite_data, image, datasize)
+		&& !memcmp(tmp_sprite_colors, ct, sizeof(uae_u32) * 4);
+
 	if (chipset) {
 		input_mousehack_cursor_hotspot(w, h, &hotspot_x, &hotspot_y, &residual_x, &residual_y);
 
-		if (native_cursor_tracker_width != w || native_cursor_tracker_height != h) {
+		if (native_cursor_tracker_width != w || native_cursor_tracker_height != h || !cursor_cache_matches) {
 			amiberry_input_cursor_hotspot_tracker_reset(&native_cursor_hotspot_tracker);
 			native_cursor_tracker_width = w;
 			native_cursor_tracker_height = h;
@@ -2323,19 +2330,13 @@ static int createwindowscursor(int monid, int set, int chipset)
 		reset_native_cursor_hotspot_tracker();
 	}
 
-	datasize = h * ((w + 15) / 16) * 16;
-
-	if (p96_cursor) {
-		if (w == tmp_sprite_w && h == tmp_sprite_h && hotspot_x == tmp_sprite_hotspot_x &&
-			hotspot_y == tmp_sprite_hotspot_y && chipset == tmp_sprite_chipset &&
-			!memcmp(tmp_sprite_data, image, datasize) && !memcmp(tmp_sprite_colors, ct, sizeof(uae_u32) * 4)) {
-			if (SDL_GetCursor() == p96_cursor) {
-				tmp_sprite_residual_x = residual_x;
-				tmp_sprite_residual_y = residual_y;
-				input_mousehack_set_host_cursor_uses_hotspot(chipset != 0, residual_x, residual_y);
-				wincursor_shown = 1;
-				return 1;
-			}
+	if (cursor_cache_matches && hotspot_x == tmp_sprite_hotspot_x && hotspot_y == tmp_sprite_hotspot_y) {
+		if (SDL_GetCursor() == p96_cursor) {
+			tmp_sprite_residual_x = residual_x;
+			tmp_sprite_residual_y = residual_y;
+			input_mousehack_set_host_cursor_uses_hotspot(chipset != 0, residual_x, residual_y);
+			wincursor_shown = 1;
+			return 1;
 		}
 	}
 

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -202,6 +202,17 @@ static int interrupt_enabled;
 float p96vblank;
 
 #ifdef AMIBERRY
+static amiberry_input_cursor_hotspot_tracker native_cursor_hotspot_tracker;
+static int native_cursor_tracker_width = -1;
+static int native_cursor_tracker_height = -1;
+
+static void reset_native_cursor_hotspot_tracker()
+{
+	amiberry_input_cursor_hotspot_tracker_reset(&native_cursor_hotspot_tracker);
+	native_cursor_tracker_width = -1;
+	native_cursor_tracker_height = -1;
+}
+
 static void clear_host_cursor_hotspot_compensation()
 {
 	input_mousehack_set_host_cursor_uses_hotspot(false, 0, 0);
@@ -217,6 +228,7 @@ static void destroy_p96_host_cursor(bool restore_normal_cursor)
 		p96_cursor = nullptr;
 	}
 	clear_host_cursor_hotspot_compensation();
+	reset_native_cursor_hotspot_tracker();
 }
 #endif
 
@@ -2202,7 +2214,7 @@ static int tmp_sprite_chipset = -1;
 #endif
 
 extern uaecptr sprite_0;
-extern int sprite_0_width, sprite_0_height, sprite_0_doubled;
+extern int sprite_0_width, sprite_0_height, sprite_0_doubled, sprite_0_x, sprite_0_y;
 extern uae_u32 sprite_0_colors[4];
 
 static int createwindowscursor(int monid, int set, int chipset)
@@ -2222,7 +2234,6 @@ static int createwindowscursor(int monid, int set, int chipset)
 	int residual_x = 0, residual_y = 0;
 
 	wincursor_shown = 0;
-	clear_host_cursor_hotspot_compensation();
 
 	if (isfullscreen() > 0 || !magic_mouse_host_only_enabled()) {
 		goto exit;
@@ -2284,6 +2295,32 @@ static int createwindowscursor(int monid, int set, int chipset)
 
 	if (chipset) {
 		input_mousehack_cursor_hotspot(w, h, &hotspot_x, &hotspot_y, &residual_x, &residual_y);
+
+		if (native_cursor_tracker_width != w || native_cursor_tracker_height != h) {
+			amiberry_input_cursor_hotspot_tracker_reset(&native_cursor_hotspot_tracker);
+			native_cursor_tracker_width = w;
+			native_cursor_tracker_height = h;
+		}
+
+		int pointer_x = 0;
+		int pointer_y = 0;
+		const bool position_valid = input_mousehack_get_last_abs_position(&pointer_x, &pointer_y);
+		const bool was_learned = native_cursor_hotspot_tracker.learned;
+		const int previous_hotspot_x = native_cursor_hotspot_tracker.hotspot_x;
+		const int previous_hotspot_y = native_cursor_hotspot_tracker.hotspot_y;
+		// Delivered mousehack coordinates and sprite DMA coordinates share the same Amiga space.
+		if (amiberry_input_cursor_hotspot_tracker_sample(&native_cursor_hotspot_tracker,
+			position_valid, pointer_x, pointer_y, sprite_0_x, sprite_0_y, w, h, 3,
+			&hotspot_x, &hotspot_y)) {
+			residual_x = 0;
+			residual_y = 0;
+			if (!was_learned || hotspot_x != previous_hotspot_x || hotspot_y != previous_hotspot_y) {
+				write_log(_T("Native host cursor hotspot learned: %dx%d hotspot=%d,%d pointer=%d,%d sprite=%d,%d\n"),
+					w, h, hotspot_x, hotspot_y, pointer_x, pointer_y, sprite_0_x, sprite_0_y);
+			}
+		}
+	} else {
+		reset_native_cursor_hotspot_tracker();
 	}
 
 	datasize = h * ((w + 15) / 16) * 16;
@@ -2352,6 +2389,8 @@ end:
 		SDL_SetCursor(p96_cursor);
 		input_mousehack_set_host_cursor_uses_hotspot(chipset != 0, residual_x, residual_y);
 		wincursor_shown = 1;
+	} else {
+		clear_host_cursor_hotspot_compensation();
 	}
 
 	if (!ret) {

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -152,6 +152,68 @@ static void test_mousehack_hotspot_matches_pointer_offset()
 		"oversized y pointer offset must leave negative residual compensation after hotspot clamping");
 }
 
+static void test_native_sprite_position_decoding()
+{
+	expect_int_eq(amiberry_input_native_sprite_x(0x1234, 0x0000, false), 0xd0,
+		"native sprite x must decode the horizontal position byte");
+	expect_int_eq(amiberry_input_native_sprite_x(0x1234, 0x0001, false), 0xd2,
+		"native sprite x must include the low control bit");
+	expect_int_eq(amiberry_input_native_sprite_x(0x1234, 0x0011, true), 0xd3,
+		"ECS/AGA sprite x must include the extended low bit");
+
+	expect_int_eq(amiberry_input_native_sprite_y(0x1200, 0x0000, false), 0x24,
+		"native sprite y must decode the vertical position byte");
+	expect_int_eq(amiberry_input_native_sprite_y(0x1200, 0x0004, false), 0x224,
+		"native sprite y must include the first high control bit");
+	expect_int_eq(amiberry_input_native_sprite_y(0x1200, 0x0044, true), 0x624,
+		"ECS sprite y must include the extended high bit");
+}
+
+static void test_native_cursor_hotspot_learning_requires_stationary_samples()
+{
+	amiberry_input_cursor_hotspot_tracker tracker;
+	int hotspot_x = -1;
+	int hotspot_y = -1;
+
+	expect_true(!amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+		300, 220, 275, 190, 51, 61, 3, &hotspot_x, &hotspot_y),
+		"first hotspot sample must not be trusted immediately");
+	expect_true(!amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+		304, 224, 279, 194, 51, 61, 3, &hotspot_x, &hotspot_y),
+		"matching pointer and sprite movement must not count as stationary");
+	expect_true(!amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+		304, 224, 279, 194, 51, 61, 3, &hotspot_x, &hotspot_y),
+		"second stationary sample must still wait for confirmation");
+	expect_true(amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+		304, 224, 279, 194, 51, 61, 3, &hotspot_x, &hotspot_y),
+		"third stationary sample must learn the hotspot");
+	expect_int_eq(hotspot_x, 25, "learned cross cursor hotspot x must use the live sprite displacement");
+	expect_int_eq(hotspot_y, 30, "learned cross cursor hotspot y must use the live sprite displacement");
+}
+
+static void test_native_cursor_hotspot_learning_keeps_last_valid_result()
+{
+	amiberry_input_cursor_hotspot_tracker tracker;
+	int hotspot_x = -1;
+	int hotspot_y = -1;
+
+	for (int i = 0; i < 3; i++) {
+		amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+			200, 160, 199, 158, 16, 16, 3, &hotspot_x, &hotspot_y);
+	}
+	expect_int_eq(hotspot_x, 1, "tracker must learn a valid arrow hotspot x");
+	expect_int_eq(hotspot_y, 2, "tracker must learn a valid arrow hotspot y");
+
+	expect_true(amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+		200, 160, 80, 40, 16, 16, 3, &hotspot_x, &hotspot_y),
+		"an unrelated sprite position must retain the last learned hotspot");
+	expect_int_eq(hotspot_x, 1, "invalid candidate must not replace learned hotspot x");
+	expect_int_eq(hotspot_y, 2, "invalid candidate must not replace learned hotspot y");
+
+	amiberry_input_cursor_hotspot_tracker_reset(&tracker);
+	expect_true(!tracker.learned, "reset must discard a hotspot learned for old cursor dimensions");
+}
+
 int main()
 {
 	test_rgb12_expands_to_rgb24();
@@ -161,5 +223,8 @@ int main()
 	test_rtg_cursor_keeps_softsprite_fallback_disabled();
 	test_native_axis_clamp_uses_native_extent();
 	test_mousehack_hotspot_matches_pointer_offset();
+	test_native_sprite_position_decoding();
+	test_native_cursor_hotspot_learning_requires_stationary_samples();
+	test_native_cursor_hotspot_learning_keeps_last_valid_result();
 	return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- learn native host cursor hotspots from the absolute mousehack coordinate delivered to AmigaOS and sprite 0's live hardware position
- retain the existing Pointer preference fallback until three stable, valid samples establish the actual hotspot
- reset learned state across cursor teardown, dimension changes, and RTG transitions
- add focused coverage for native sprite coordinate decoding and hotspot tracking

## Root cause
The previous fix derived the SDL cursor hotspot from global Pointer preferences. Applications can install custom pointers whose hotspot is not represented by those preferences, so the adjustment could make no visible difference. The delivered mousehack coordinate and sprite 0 position provide the runtime relationship needed to measure that hotspot directly.

## Validation
- `bash tests/test_cursor_pixel_format.sh`
- `cmake --build out/build/windows-debug --parallel`
- `git diff --check`

This is a follow-up to #2135. The reporter's exact application setup is still needed for final runtime confirmation.