### PR TITLE
Add optional on-screen keyboard numpad

### DIFF
--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/AndroidControlSettings.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/AndroidControlSettings.kt
@@ -26,6 +26,11 @@ object AndroidControlSettings {
 				settings.onScreenKeyboard
 			} else {
 				fallback.onScreenKeyboard
+			},
+			onScreenKeyboardNumpad = if ("amiberry.vkbd_numpad" in keys) {
+				settings.onScreenKeyboardNumpad
+			} else {
+				fallback.onScreenKeyboardNumpad
 			}
 		)
 	}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/AndroidLaunchConfig.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/AndroidLaunchConfig.kt
@@ -47,7 +47,8 @@ object AndroidLaunchConfig {
 			joyport0 = currentSettings.joyport0,
 			joyport1 = currentSettings.joyport1,
 			onScreenJoystick = currentSettings.onScreenJoystick,
-			onScreenKeyboard = currentSettings.onScreenKeyboard
+			onScreenKeyboard = currentSettings.onScreenKeyboard,
+			onScreenKeyboardNumpad = currentSettings.onScreenKeyboardNumpad
 		)
 	}
 

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/AppPreferences.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/AppPreferences.kt
@@ -35,7 +35,8 @@ class AppPreferences private constructor(context: Context) {
 			joyport0 = prefs.getString(KEY_LAST_JOYPORT0, DEFAULT_JOYPORT0) ?: DEFAULT_JOYPORT0,
 			joyport1 = prefs.getString(KEY_LAST_JOYPORT1, DEFAULT_JOYPORT1) ?: DEFAULT_JOYPORT1,
 			onScreenJoystick = prefs.getBoolean(KEY_LAST_ON_SCREEN_JOYSTICK, DEFAULT_ON_SCREEN_JOYSTICK),
-			onScreenKeyboard = prefs.getBoolean(KEY_LAST_ON_SCREEN_KEYBOARD, DEFAULT_ON_SCREEN_KEYBOARD)
+			onScreenKeyboard = prefs.getBoolean(KEY_LAST_ON_SCREEN_KEYBOARD, DEFAULT_ON_SCREEN_KEYBOARD),
+			onScreenKeyboardNumpad = prefs.getBoolean(KEY_LAST_ON_SCREEN_KEYBOARD_NUMPAD, false)
 		)
 
 	fun applyRememberedAndroidControls(settings: EmulatorSettings, explicitKeys: Set<String>): EmulatorSettings =
@@ -51,6 +52,7 @@ class AppPreferences private constructor(context: Context) {
 			putString(KEY_LAST_JOYPORT1, settings.joyport1)
 			putBoolean(KEY_LAST_ON_SCREEN_JOYSTICK, settings.onScreenJoystick)
 			putBoolean(KEY_LAST_ON_SCREEN_KEYBOARD, settings.onScreenKeyboard)
+			putBoolean(KEY_LAST_ON_SCREEN_KEYBOARD_NUMPAD, settings.onScreenKeyboardNumpad)
 		}
 	}
 
@@ -119,6 +121,7 @@ class AppPreferences private constructor(context: Context) {
 		private const val KEY_LAST_JOYPORT1 = "last_joyport1"
 		private const val KEY_LAST_ON_SCREEN_JOYSTICK = "last_on_screen_joystick"
 		private const val KEY_LAST_ON_SCREEN_KEYBOARD = "last_on_screen_keyboard"
+		private const val KEY_LAST_ON_SCREEN_KEYBOARD_NUMPAD = "last_on_screen_keyboard_numpad"
 		private const val KEY_RECENT_LAUNCHES = "recent_launches"
 		private const val KEY_LAUNCH_COUNT = "emulator_launch_count"
 		private const val FIRST_REVIEW_LAUNCH = 5

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigGenerator.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigGenerator.kt
@@ -109,6 +109,7 @@ object ConfigGenerator {
 		// Amiberry-specific
 		sb.appendLine("amiberry.onscreen_joystick=${settings.onScreenJoystick.toCfg()}")
 		sb.appendLine("amiberry.vkbd_enabled=${settings.onScreenKeyboard.toCfg()}")
+		sb.appendLine("amiberry.vkbd_numpad=${settings.onScreenKeyboardNumpad.toCfg()}")
 		sb.appendLine("input.default_osk=${settings.onScreenKeyboard.toCfg()}")
 
 		// Skip GUI when launched from Android native UI
@@ -129,6 +130,7 @@ object ConfigGenerator {
 		sb.appendLine("amiberry.android_joyport1=${settings.joyport1}")
 		sb.appendLine("amiberry.onscreen_joystick=${settings.onScreenJoystick.toCfg()}")
 		sb.appendLine("amiberry.vkbd_enabled=${settings.onScreenKeyboard.toCfg()}")
+		sb.appendLine("amiberry.vkbd_numpad=${settings.onScreenKeyboardNumpad.toCfg()}")
 		sb.appendLine("input.default_osk=${settings.onScreenKeyboard.toCfg()}")
 		sb.appendLine("use_gui=no")
 

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigParser.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigParser.kt
@@ -35,7 +35,7 @@ object ConfigParser {
 		"amiberry.gfx_correct_aspect", "amiberry.gfx_auto_crop",
 		"scaling_method", "amiberry.scaling_method", "gfx_autoresolution",
 		"joyport0", "joyport1",
-		"amiberry.onscreen_joystick", "amiberry.vkbd_enabled", "input.default_osk",
+		"amiberry.onscreen_joystick", "amiberry.vkbd_enabled", "amiberry.vkbd_numpad", "input.default_osk",
 		"amiberry.android_joyport1",
 		"use_gui", "config_description", "config_hardware_path"
 	)
@@ -163,7 +163,8 @@ object ConfigParser {
 				}
 			},
 			onScreenJoystick = kv["amiberry.onscreen_joystick"].toBool(true),
-			onScreenKeyboard = kv["amiberry.vkbd_enabled"]?.toBool(true) ?: kv["input.default_osk"].toBool(true)
+			onScreenKeyboard = kv["amiberry.vkbd_enabled"]?.toBool(true) ?: kv["input.default_osk"].toBool(true),
+			onScreenKeyboardNumpad = kv["amiberry.vkbd_numpad"].toBool(false)
 		)
 	}
 

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchRequest.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchRequest.kt
@@ -83,7 +83,8 @@ sealed interface LaunchRequest {
 		val joyport0: String,
 		val joyport1: String,
 		val onScreenJoystick: Boolean,
-		val onScreenKeyboard: Boolean
+		val onScreenKeyboard: Boolean,
+		val onScreenKeyboardNumpad: Boolean = false
 	) {
 		fun toArgs(): List<String> {
 			val args = mutableListOf("-s", "joyport0=$joyport0")
@@ -95,6 +96,7 @@ sealed interface LaunchRequest {
 				listOf(
 					"-s", "amiberry.onscreen_joystick=${onScreenJoystick.toCfg()}",
 					"-s", "amiberry.vkbd_enabled=${onScreenKeyboard.toCfg()}",
+					"-s", "amiberry.vkbd_numpad=${onScreenKeyboardNumpad.toCfg()}",
 					"-s", "input.default_osk=${onScreenKeyboard.toCfg()}"
 				)
 			)
@@ -108,7 +110,8 @@ sealed interface LaunchRequest {
 					joyport0 = settings.joyport0,
 					joyport1 = settings.joyport1,
 					onScreenJoystick = settings.onScreenJoystick,
-					onScreenKeyboard = settings.onScreenKeyboard
+					onScreenKeyboard = settings.onScreenKeyboard,
+					onScreenKeyboardNumpad = settings.onScreenKeyboardNumpad
 				)
 		}
 	}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/WhdLoadAutoConfig.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/WhdLoadAutoConfig.kt
@@ -78,7 +78,8 @@ object WhdLoadAutoConfig {
 			joyport0 = currentSettings.joyport0,
 			joyport1 = currentSettings.joyport1,
 			onScreenJoystick = currentSettings.onScreenJoystick,
-			onScreenKeyboard = currentSettings.onScreenKeyboard
+			onScreenKeyboard = currentSettings.onScreenKeyboard,
+			onScreenKeyboardNumpad = currentSettings.onScreenKeyboardNumpad
 		)
 
 		settings = applyHardware(settings, hardware, a600Available, useAgaCpuProfile = isAga || isCd32)

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettings.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettings.kt
@@ -67,7 +67,8 @@ data class EmulatorSettings(
 	val joyport0: String = "mouse",
 	val joyport1: String = "onscreen_joy",
 	val onScreenJoystick: Boolean = true,
-	val onScreenKeyboard: Boolean = true
+	val onScreenKeyboard: Boolean = true,
+	val onScreenKeyboardNumpad: Boolean = false
 ) {
 	companion object {
 		/** Create settings from an AmigaModel with sensible defaults. */

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/SettingsChangeSummary.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/SettingsChangeSummary.kt
@@ -30,6 +30,7 @@ object SettingsChangeSummary {
 		addIfChanged("Joy port 1", before.joyport1, after.joyport1)
 		addIfChanged("On-screen joystick", yesNo(before.onScreenJoystick), yesNo(after.onScreenJoystick))
 		addIfChanged("On-screen keyboard", yesNo(before.onScreenKeyboard), yesNo(after.onScreenKeyboard))
+		addIfChanged("On-screen keyboard numpad", yesNo(before.onScreenKeyboardNumpad), yesNo(after.onScreenKeyboardNumpad))
 	}
 
 	private fun MutableList<SettingsChange>.addIfChanged(label: String, before: String, after: String) {

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/InputTab.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/InputTab.kt
@@ -155,13 +155,14 @@ fun InputTab(viewModel: SettingsViewModel) {
 			}
 		}
 
-		// On-screen controls (only shown on devices with a touchscreen)
-		if (hasTouchScreen) {
-			OutlinedCard(modifier = Modifier.fillMaxWidth()) {
-				Column(modifier = Modifier.padding(16.dp)) {
-					Text(stringResource(R.string.settings_input_on_screen_controls_title), style = MaterialTheme.typography.titleMedium)
-					Spacer(modifier = Modifier.height(8.dp))
+		// The keyboard can be driven by a game controller, so keep its settings
+		// available on non-touch devices as well.
+		OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+			Column(modifier = Modifier.padding(16.dp)) {
+				Text(stringResource(R.string.settings_input_on_screen_controls_title), style = MaterialTheme.typography.titleMedium)
+				Spacer(modifier = Modifier.height(8.dp))
 
+				if (hasTouchScreen) {
 					SwitchRow(
 						label = stringResource(R.string.settings_input_on_screen_joystick),
 						checked = settings.onScreenJoystick,
@@ -169,15 +170,25 @@ fun InputTab(viewModel: SettingsViewModel) {
 							viewModel.updateSettings { s -> InputSettingsActions.setOnScreenJoystick(s, isEnabled) }
 						}
 					)
-
-					SwitchRow(
-						label = stringResource(R.string.settings_input_on_screen_keyboard_button),
-						checked = settings.onScreenKeyboard,
-						onCheckedChange = {
-							viewModel.updateSettings { s -> s.copy(onScreenKeyboard = it) }
-						}
-					)
 				}
+
+				SwitchRow(
+					label = stringResource(R.string.settings_input_on_screen_keyboard_button),
+					checked = settings.onScreenKeyboard,
+					onCheckedChange = {
+						viewModel.updateSettings { s -> s.copy(onScreenKeyboard = it) }
+					}
+				)
+
+				SwitchRow(
+					label = stringResource(R.string.settings_input_on_screen_keyboard_numpad),
+					checked = settings.onScreenKeyboardNumpad,
+					enabled = settings.onScreenKeyboard,
+					supportingText = stringResource(R.string.settings_input_on_screen_keyboard_numpad_summary),
+					onCheckedChange = {
+						viewModel.updateSettings { s -> s.copy(onScreenKeyboardNumpad = it) }
+					}
+				)
 			}
 		}
 	}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
@@ -123,7 +123,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 			joyport0 = previousSettings.joyport0,
 			joyport1 = previousSettings.joyport1,
 			onScreenJoystick = previousSettings.onScreenJoystick,
-			onScreenKeyboard = previousSettings.onScreenKeyboard
+			onScreenKeyboard = previousSettings.onScreenKeyboard,
+			onScreenKeyboardNumpad = previousSettings.onScreenKeyboardNumpad
 		)
 		applyConstrainedSettings(newSettings, publishNotices = true)
 		appPreferences.saveAndroidControls(settings)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -297,6 +297,8 @@
     <string name="settings_input_on_screen_controls_title">On-Screen Controls</string>
     <string name="settings_input_on_screen_joystick">On-Screen Joystick</string>
     <string name="settings_input_on_screen_keyboard_button">On-Screen Keyboard Button</string>
+    <string name="settings_input_on_screen_keyboard_numpad">Include Numeric Keypad</string>
+    <string name="settings_input_on_screen_keyboard_numpad_summary">Fits the full Amiga keyboard on screen using smaller keys.</string>
     <string name="settings_input_device_mouse">Mouse</string>
     <string name="settings_input_device_joystick_0">Joystick 0</string>
     <string name="settings_input_device_joystick_1">Joystick 1</string>

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/AndroidControlSettingsTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/AndroidControlSettingsTest.kt
@@ -17,7 +17,8 @@ class AndroidControlSettingsTest {
 				joyport0 = "joy0",
 				joyport1 = "joy1",
 				onScreenJoystick = false,
-				onScreenKeyboard = false
+				onScreenKeyboard = false,
+				onScreenKeyboardNumpad = true
 			)
 		)
 
@@ -25,6 +26,7 @@ class AndroidControlSettingsTest {
 		assertEquals("joy1", settings.joyport1)
 		assertFalse(settings.onScreenJoystick)
 		assertFalse(settings.onScreenKeyboard)
+		assertTrue(settings.onScreenKeyboardNumpad)
 	}
 
 	@Test
@@ -34,13 +36,15 @@ class AndroidControlSettingsTest {
 				joyport0 = "mouse",
 				joyport1 = "onscreen_joy",
 				onScreenJoystick = true,
-				onScreenKeyboard = true
+				onScreenKeyboard = true,
+				onScreenKeyboardNumpad = true
 			),
 			explicitKeys = setOf(
 				"joyport0",
 				"amiberry.android_joyport1",
 				"amiberry.onscreen_joystick",
-				"amiberry.vkbd_enabled"
+				"amiberry.vkbd_enabled",
+				"amiberry.vkbd_numpad"
 			),
 			fallback = EmulatorSettings(
 				joyport0 = "joy0",
@@ -54,5 +58,6 @@ class AndroidControlSettingsTest {
 		assertEquals("onscreen_joy", settings.joyport1)
 		assertTrue(settings.onScreenJoystick)
 		assertTrue(settings.onScreenKeyboard)
+		assertTrue(settings.onScreenKeyboardNumpad)
 	}
 }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/AndroidLaunchConfigTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/AndroidLaunchConfigTest.kt
@@ -15,7 +15,8 @@ class AndroidLaunchConfigTest {
 			joyport0 = "joy0",
 			joyport1 = "joy1",
 			onScreenJoystick = false,
-			onScreenKeyboard = false
+			onScreenKeyboard = false,
+			onScreenKeyboardNumpad = true
 		)
 
 		val snapshot = AndroidLaunchConfig.buildQuickStartSettingsSnapshot(
@@ -36,6 +37,7 @@ class AndroidLaunchConfigTest {
 		assertEquals("joy1", snapshot.joyport1)
 		assertEquals(false, snapshot.onScreenJoystick)
 		assertEquals(false, snapshot.onScreenKeyboard)
+		assertEquals(true, snapshot.onScreenKeyboardNumpad)
 	}
 
 	@Test

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
@@ -171,7 +171,8 @@ class ConfigGeneratorTest {
 			EmulatorSettings(
 				joyport1 = "onscreen_joy",
 				onScreenJoystick = true,
-				onScreenKeyboard = true
+				onScreenKeyboard = true,
+				onScreenKeyboardNumpad = true
 			)
 		)
 		val lines = output.lines()
@@ -180,6 +181,7 @@ class ConfigGeneratorTest {
 		assertContainsLine(lines, "amiberry.android_joyport1=onscreen_joy")
 		assertContainsLine(lines, "amiberry.onscreen_joystick=true")
 		assertContainsLine(lines, "amiberry.vkbd_enabled=true")
+		assertContainsLine(lines, "amiberry.vkbd_numpad=true")
 		assertContainsLine(lines, "input.default_osk=true")
 	}
 
@@ -198,6 +200,7 @@ class ConfigGeneratorTest {
 		assertContainsLine(lines, "amiberry.android_joyport1=joy1")
 		assertContainsLine(lines, "amiberry.onscreen_joystick=false")
 		assertContainsLine(lines, "amiberry.vkbd_enabled=false")
+		assertContainsLine(lines, "amiberry.vkbd_numpad=false")
 		assertContainsLine(lines, "input.default_osk=false")
 	}
 
@@ -218,6 +221,7 @@ class ConfigGeneratorTest {
 		assertContainsLine(lines, "amiberry.android_joyport1=joy1")
 		assertContainsLine(lines, "amiberry.onscreen_joystick=false")
 		assertContainsLine(lines, "amiberry.vkbd_enabled=false")
+		assertContainsLine(lines, "amiberry.vkbd_numpad=false")
 		assertContainsLine(lines, "input.default_osk=false")
 		assertContainsLine(lines, "use_gui=no")
 		assertNotContains(output, "cpu_model=")
@@ -360,7 +364,8 @@ class ConfigGeneratorTest {
 			joyport0 = "mouse",
 			joyport1 = "joy0",
 			onScreenJoystick = false,
-			onScreenKeyboard = true
+			onScreenKeyboard = true,
+			onScreenKeyboardNumpad = true
 		)
 
 		val configText = ConfigGenerator.generate(original)
@@ -396,6 +401,7 @@ class ConfigGeneratorTest {
 		assertEquals(original.joyport1, result.joyport1)
 		assertEquals(original.onScreenJoystick, result.onScreenJoystick)
 		assertEquals(original.onScreenKeyboard, result.onScreenKeyboard)
+		assertEquals(original.onScreenKeyboardNumpad, result.onScreenKeyboardNumpad)
 	}
 
 	@Test

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
@@ -256,6 +256,14 @@ class ConfigParserTest {
 	}
 
 	@Test
+	fun `parse input reads optional keyboard numpad`() {
+		val result = ConfigParser.parse(writeConfig("amiberry.vkbd_numpad=true"))
+
+		assertTrue(result.settings.onScreenKeyboardNumpad)
+		assertTrue(result.unknownLines.isEmpty())
+	}
+
+	@Test
 	fun `parse input infers onscreen_joy when no android key`() {
 		val file = writeConfig("""
 			joyport0=mouse
@@ -482,6 +490,7 @@ class ConfigParserTest {
 		explicitFile.writeText("""
 			amiberry.onscreen_joystick=false
 			amiberry.vkbd_enabled=false
+			amiberry.vkbd_numpad=true
 		""".trimIndent())
 		val absentFile = tempDir.newFile("absent_android_controls.uae")
 		absentFile.writeText("cpu_model=68000")
@@ -490,8 +499,10 @@ class ConfigParserTest {
 
 		assertTrue("amiberry.onscreen_joystick" in explicit.explicitKeys)
 		assertTrue("amiberry.vkbd_enabled" in explicit.explicitKeys)
+		assertTrue("amiberry.vkbd_numpad" in explicit.explicitKeys)
 		assertFalse("amiberry.onscreen_joystick" in absent.explicitKeys)
 		assertFalse("amiberry.vkbd_enabled" in absent.explicitKeys)
+		assertFalse("amiberry.vkbd_numpad" in absent.explicitKeys)
 	}
 
 	// --- Whitespace handling ---

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/LaunchRequestTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/LaunchRequestTest.kt
@@ -139,6 +139,7 @@ class LaunchRequestTest {
 				"-s", "joyport0=mouse",
 				"-s", "amiberry.onscreen_joystick=true",
 				"-s", "amiberry.vkbd_enabled=false",
+				"-s", "amiberry.vkbd_numpad=false",
 				"-s", "input.default_osk=false",
 				"-G"
 			),
@@ -156,7 +157,8 @@ class LaunchRequestTest {
 				joyport0 = "mouse",
 				joyport1 = "joy1",
 				onScreenJoystick = false,
-				onScreenKeyboard = true
+				onScreenKeyboard = true,
+				onScreenKeyboardNumpad = true
 			),
 			skipGui = true
 		).toArgs()
@@ -169,6 +171,7 @@ class LaunchRequestTest {
 				"-s", "joyport1=joy1",
 				"-s", "amiberry.onscreen_joystick=false",
 				"-s", "amiberry.vkbd_enabled=true",
+				"-s", "amiberry.vkbd_numpad=true",
 				"-s", "input.default_osk=true",
 				"-G"
 			),

--- a/src/include/options.h
+++ b/src/include/options.h
@@ -1106,6 +1106,7 @@ struct uae_prefs {
 
 #ifdef AMIBERRY
 	bool vkbd_enabled;
+	bool vkbd_numpad;
 	bool vkbd_hires;
 	bool vkbd_exit;
 	char vkbd_language[256];

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -3263,13 +3263,10 @@ static void process_event(const SDL_Event& event)
 			bool consumed = false;
 
 			// Let ImGui on-screen keyboard consume the event first when visible.
-			// OSK geometry is in drawable-pixel space, so convert touch coords
-			// using pixel size (not window size) for HiDPI correctness.
+			// OSK geometry uses ImGui's logical window coordinate space.
 			if (imgui_osk_should_render() && mon->amiga_window) {
-				int pw = 0, ph = 0;
-				SDL_GetWindowSizeInPixels(mon->amiga_window, &pw, &ph);
-				float sx = event.tfinger.x * pw;
-				float sy = event.tfinger.y * ph;
+				float sx = event.tfinger.x * ww;
+				float sy = event.tfinger.y * wh;
 				int fid = static_cast<int>(event.tfinger.fingerID);
 				if (event.type == SDL_EVENT_FINGER_DOWN)
 					consumed = imgui_osk_handle_finger_down(sx, sy, fid);
@@ -3318,12 +3315,10 @@ static void process_event(const SDL_Event& event)
 			if (mon->amiga_window)
 				SDL_GetWindowSize(mon->amiga_window, &ww, &wh);
 			bool consumed = false;
-			// Let ImGui on-screen keyboard consume motion first (drawable-pixel space)
+			// Let ImGui on-screen keyboard consume motion first (logical window space)
 			if (imgui_osk_should_render() && mon->amiga_window) {
-				int pw = 0, ph = 0;
-				SDL_GetWindowSizeInPixels(mon->amiga_window, &pw, &ph);
-				float sx = event.tfinger.x * pw;
-				float sy = event.tfinger.y * ph;
+				float sx = event.tfinger.x * ww;
+				float sy = event.tfinger.y * wh;
 				int fid = static_cast<int>(event.tfinger.fingerID);
 				consumed = imgui_osk_handle_finger_motion(sx, sy, fid);
 				if (!consumed && imgui_osk_hit_test(sx, sy))
@@ -4934,6 +4929,7 @@ void target_default_options(uae_prefs* p, const int type)
 
 	// On-screen keyboard default options
 	p->vkbd_enabled = amiberry_options.default_vkbd_enabled;
+	p->vkbd_numpad = false;
 
 #ifdef __ANDROID__
 	// Touch-only Android: enable on-screen controls by default. If a physical
@@ -5117,6 +5113,7 @@ void target_save_options(zfile* f, uae_prefs* p)
 
 	cfgfile_target_dwrite_bool(f, _T("onscreen_joystick"), p->onscreen_joystick);
 	cfgfile_target_dwrite_bool(f, _T("vkbd_enabled"), p->vkbd_enabled);
+	cfgfile_target_dwrite_bool(f, _T("vkbd_numpad"), p->vkbd_numpad);
 	cfgfile_target_dwrite(f, _T("vkbd_transparency"), "%d", p->vkbd_transparency);
 	cfgfile_target_dwrite_str(f, _T("vkbd_language"), p->vkbd_language);
 	cfgfile_target_dwrite_str(f, _T("vkbd_toggle"), p->vkbd_toggle);
@@ -5276,6 +5273,7 @@ static int target_parse_option_host(uae_prefs *p, const TCHAR *option, const TCH
 		return 1;
 
 	if (cfgfile_yesno(option, value, _T("vkbd_enabled"), &p->vkbd_enabled)
+		|| cfgfile_yesno(option, value, _T("vkbd_numpad"), &p->vkbd_numpad)
 		|| cfgfile_yesno(option, value, _T("vkbd_hires"), &p->vkbd_hires)
 		|| cfgfile_yesno(option, value, _T("vkbd_exit"), &p->vkbd_exit)
 		|| cfgfile_intval(option, value, _T("vkbd_transparency"), &p->vkbd_transparency, 1)

--- a/src/osdep/amiberry_whdbooter.cpp
+++ b/src/osdep/amiberry_whdbooter.cpp
@@ -1602,6 +1602,7 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath, const bool prese
 #ifdef __ANDROID__
 	const bool android_onscreen_joystick = prefs->onscreen_joystick;
 	const bool android_vkbd_enabled = prefs->vkbd_enabled;
+	const bool android_vkbd_numpad = prefs->vkbd_numpad;
 	const bool android_input_default_osk = prefs->input_default_onscreen_keyboard;
 #endif
 
@@ -1826,6 +1827,7 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath, const bool prese
 	// Preserve the launcher's explicit choice across the WHDLoad hardware preset.
 	prefs->onscreen_joystick = android_onscreen_joystick;
 	prefs->vkbd_enabled = android_vkbd_enabled;
+	prefs->vkbd_numpad = android_vkbd_numpad;
 	prefs->input_default_onscreen_keyboard = android_input_default_osk;
 #endif
 

--- a/src/osdep/gfx_prefs_check.cpp
+++ b/src/osdep/gfx_prefs_check.cpp
@@ -657,11 +657,13 @@ int check_prefs_changed_gfx()
 #ifdef AMIBERRY
 	// On-screen keyboard
 	if (currprefs.vkbd_enabled != changed_prefs.vkbd_enabled ||
+		currprefs.vkbd_numpad != changed_prefs.vkbd_numpad ||
 		currprefs.vkbd_transparency != changed_prefs.vkbd_transparency ||
 		_tcscmp(currprefs.vkbd_language, changed_prefs.vkbd_language) ||
 		_tcscmp(currprefs.vkbd_toggle, changed_prefs.vkbd_toggle))
 	{
 		currprefs.vkbd_enabled = changed_prefs.vkbd_enabled;
+		currprefs.vkbd_numpad = changed_prefs.vkbd_numpad;
 		currprefs.vkbd_transparency = changed_prefs.vkbd_transparency;
 		_tcscpy(currprefs.vkbd_language, changed_prefs.vkbd_language);
 		_tcscpy(currprefs.vkbd_toggle, changed_prefs.vkbd_toggle);
@@ -673,6 +675,7 @@ int check_prefs_changed_gfx()
 				: 0.85f;
 			imgui_osk_set_transparency(alpha);
 			imgui_osk_set_language(currprefs.vkbd_language);
+			imgui_osk_set_numpad(currprefs.vkbd_numpad);
 			vkbd_key = get_hotkey_from_config(string(currprefs.vkbd_toggle));
 			vkbd_button = SDL_GetGamepadButtonFromString(currprefs.vkbd_toggle);
 			imgui_osk_init();

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -1356,6 +1356,7 @@ bool doInit(AmigaMonitor* mon)
 			? static_cast<float>(currprefs.vkbd_transparency) / 100.0f
 			: 0.85f);
 	imgui_osk_set_language(currprefs.vkbd_language);
+	imgui_osk_set_numpad(currprefs.vkbd_numpad);
 
 	// Initialize on-screen joystick if enabled
 	if (currprefs.onscreen_joystick)

--- a/src/osdep/imgui/imgui_help_text.h
+++ b/src/osdep/imgui/imgui_help_text.h
@@ -867,6 +867,7 @@ static const char* help_text_virtual_keyboard =
 	"\"On-screen Joystick\": shows a virtual D-pad and fire buttons for touchscreen control.\n"
 	"\n"
 	"\"On-screen Keyboard enabled\": enables the Amiga-style on-screen keyboard overlay.\n"
+	"\"Include numeric keypad\": adds the Amiga keypad and reduces key size so the full keyboard fits.\n"
 	" The keyboard can be operated via touch or controller D-pad navigation.\n"
 	" It works in both native (ECS/AGA) and RTG screen modes.\n"
 	"\n"

--- a/src/osdep/imgui/virtualkeyboard.cpp
+++ b/src/osdep/imgui/virtualkeyboard.cpp
@@ -177,6 +177,11 @@ void render_panel_virtual_keyboard()
 
 	ImGui::BeginDisabled(!changed_prefs.vkbd_enabled);
 
+	AmigaCheckbox("Include numeric keypad", &changed_prefs.vkbd_numpad);
+	if (ImGui::IsItemHovered()) {
+		ImGui::SetTooltip("Include the Amiga numeric keypad; keys will be smaller to fit the full keyboard");
+	}
+
 	// Transparency slider
 	ImGui::AlignTextToFramePadding();
 	ImGui::Text("Transparency:");

--- a/src/osdep/imgui_osk.cpp
+++ b/src/osdep/imgui_osk.cpp
@@ -29,6 +29,7 @@ enum OskKeyType {
 	KEY_AMIGA_R,
 	KEY_RETURN,
 	KEY_ARROW,
+	KEY_NUMPAD,
 };
 
 // ============================================================
@@ -46,7 +47,8 @@ struct OskKeyDef {
 // A500 US keyboard layout
 // ============================================================
 // Layout uses a coordinate system where one standard key = 1.0 units wide.
-// Row heights are 1.0 units. The keyboard is ~17 units wide (main + cursor keys).
+// Row heights are 1.0 units. The compact keyboard is 17 units wide; the
+// optional full layout is 20 units wide with the numeric keypad.
 
 // Row Y positions
 static constexpr float ROW_FUNC  = 0.0f;
@@ -61,6 +63,9 @@ static constexpr float FUNC_H = 0.7f; // function key height (shorter)
 
 // Arrow cluster X offset (right of main keys)
 static constexpr float AR_X = 14.0f;
+
+// Numpad X offset (right of the arrow cluster)
+static constexpr float NP_X = 16.0f;
 
 static const OskKeyDef s_keys_us[] = {
 	// ---- Row 0: Function keys ----
@@ -113,20 +118,20 @@ static const OskKeyDef s_keys_us[] = {
 	{13.5f, ROW_QWERT, 2.0f, KEY_H * 2.0f + 0.1f, AK_RET, "Ret", nullptr, KEY_RETURN},
 
 	// ---- Row 3: Home row (indented to fit under QWERTY, Return fills the gap) ----
-	{0.0f,  ROW_HOME, 1.75f, KEY_H, AK_CTRL,      "Ctrl",  nullptr, KEY_MODIFIER},
-	{1.75f, ROW_HOME, 1.0f,  KEY_H, AK_CAPSLOCK,  "Caps",  nullptr, KEY_MODIFIER},
-	{2.75f, ROW_HOME, 1.0f,  KEY_H, AK_A,         "A",     nullptr, KEY_NORMAL},
-	{3.75f, ROW_HOME, 1.0f,  KEY_H, AK_S,         "S",     nullptr, KEY_NORMAL},
-	{4.75f, ROW_HOME, 1.0f,  KEY_H, AK_D,         "D",     nullptr, KEY_NORMAL},
-	{5.75f, ROW_HOME, 1.0f,  KEY_H, AK_F,         "F",     nullptr, KEY_NORMAL},
-	{6.75f, ROW_HOME, 1.0f,  KEY_H, AK_G,         "G",     nullptr, KEY_NORMAL},
-	{7.75f, ROW_HOME, 1.0f,  KEY_H, AK_H,         "H",     nullptr, KEY_NORMAL},
-	{8.75f, ROW_HOME, 1.0f,  KEY_H, AK_J,         "J",     nullptr, KEY_NORMAL},
-	{9.75f, ROW_HOME, 1.0f,  KEY_H, AK_K,         "K",     nullptr, KEY_NORMAL},
-	{10.75f,ROW_HOME, 1.0f,  KEY_H, AK_L,         "L",     nullptr, KEY_NORMAL},
-	{11.75f,ROW_HOME, 0.75f, KEY_H, AK_SEMICOLON, ";",     ":",  KEY_NORMAL},
-	{12.5f, ROW_HOME, 0.5f,  KEY_H, AK_QUOTE,     "'",     "\"", KEY_NORMAL},
-	{13.0f, ROW_HOME, 0.5f,  KEY_H, AK_NUMBERSIGN,"#",     "~",  KEY_NORMAL},
+	{0.0f,  ROW_HOME, 1.25f, KEY_H, AK_CTRL,      "Ctrl",  nullptr, KEY_MODIFIER},
+	{1.25f, ROW_HOME, 1.0f,  KEY_H, AK_CAPSLOCK,  "Caps",  nullptr, KEY_MODIFIER},
+	{2.25f, ROW_HOME, 1.0f,  KEY_H, AK_A,         "A",     nullptr, KEY_NORMAL},
+	{3.25f, ROW_HOME, 1.0f,  KEY_H, AK_S,         "S",     nullptr, KEY_NORMAL},
+	{4.25f, ROW_HOME, 1.0f,  KEY_H, AK_D,         "D",     nullptr, KEY_NORMAL},
+	{5.25f, ROW_HOME, 1.0f,  KEY_H, AK_F,         "F",     nullptr, KEY_NORMAL},
+	{6.25f, ROW_HOME, 1.0f,  KEY_H, AK_G,         "G",     nullptr, KEY_NORMAL},
+	{7.25f, ROW_HOME, 1.0f,  KEY_H, AK_H,         "H",     nullptr, KEY_NORMAL},
+	{8.25f, ROW_HOME, 1.0f,  KEY_H, AK_J,         "J",     nullptr, KEY_NORMAL},
+	{9.25f, ROW_HOME, 1.0f,  KEY_H, AK_K,         "K",     nullptr, KEY_NORMAL},
+	{10.25f,ROW_HOME, 1.0f,  KEY_H, AK_L,         "L",     nullptr, KEY_NORMAL},
+	{11.25f,ROW_HOME, 0.75f, KEY_H, AK_SEMICOLON, ";",     ":",  KEY_NORMAL},
+	{12.0f, ROW_HOME, 0.75f, KEY_H, AK_QUOTE,     "'",     "\"", KEY_NORMAL},
+	{12.75f,ROW_HOME, 0.75f, KEY_H, AK_NUMBERSIGN,"#",     "~",  KEY_NORMAL},
 	// Return spans from row 2 at x=13.5. No overlap.
 
 	// ---- Row 4: Shift row ----
@@ -156,9 +161,41 @@ static const OskKeyDef s_keys_us[] = {
 	{AR_X,       ROW_SPACE, 1.0f, KEY_H, AK_LF, "<", nullptr, KEY_ARROW},
 	{AR_X + 1.0f,ROW_SPACE, 1.0f, KEY_H, AK_DN, "v", nullptr, KEY_ARROW},
 	{AR_X + 2.0f,ROW_SPACE, 1.0f, KEY_H, AK_RT, ">", nullptr, KEY_ARROW},
+
+	// ---- Optional numpad ----
+	// Row 0: ( ) / *
+	{NP_X,       ROW_FUNC, 1.0f, FUNC_H, AK_NPLPAREN, "(", nullptr, KEY_NUMPAD},
+	{NP_X + 1.0f,ROW_FUNC, 1.0f, FUNC_H, AK_NPRPAREN, ")", nullptr, KEY_NUMPAD},
+	{NP_X + 2.0f,ROW_FUNC, 1.0f, FUNC_H, AK_NPDIV,    "/", nullptr, KEY_NUMPAD},
+	{NP_X + 3.0f,ROW_FUNC, 1.0f, FUNC_H, AK_NPMUL,    "*", nullptr, KEY_NUMPAD},
+
+	// Row 1: 7 8 9 -
+	{NP_X,       ROW_NUM, 1.0f, KEY_H, AK_NP7,  "7", nullptr, KEY_NUMPAD},
+	{NP_X + 1.0f,ROW_NUM, 1.0f, KEY_H, AK_NP8,  "8", nullptr, KEY_NUMPAD},
+	{NP_X + 2.0f,ROW_NUM, 1.0f, KEY_H, AK_NP9,  "9", nullptr, KEY_NUMPAD},
+	{NP_X + 3.0f,ROW_NUM, 1.0f, KEY_H, AK_NPSUB,"-", nullptr, KEY_NUMPAD},
+
+	// Row 2: 4 5 6 +
+	{NP_X,       ROW_QWERT, 1.0f, KEY_H, AK_NP4,  "4", nullptr, KEY_NUMPAD},
+	{NP_X + 1.0f,ROW_QWERT, 1.0f, KEY_H, AK_NP5,  "5", nullptr, KEY_NUMPAD},
+	{NP_X + 2.0f,ROW_QWERT, 1.0f, KEY_H, AK_NP6,  "6", nullptr, KEY_NUMPAD},
+	{NP_X + 3.0f,ROW_QWERT, 1.0f, KEY_H, AK_NPADD,"+", nullptr, KEY_NUMPAD},
+
+	// Row 3: 1 2 3 Enter (spans two rows)
+	{NP_X,       ROW_HOME, 1.0f, KEY_H, AK_NP1, "1", nullptr, KEY_NUMPAD},
+	{NP_X + 1.0f,ROW_HOME, 1.0f, KEY_H, AK_NP2, "2", nullptr, KEY_NUMPAD},
+	{NP_X + 2.0f,ROW_HOME, 1.0f, KEY_H, AK_NP3, "3", nullptr, KEY_NUMPAD},
+	{NP_X + 3.0f,ROW_HOME, 1.0f, KEY_H * 2.0f + 0.1f, AK_ENT, "Ent", nullptr, KEY_NUMPAD},
+
+	// Row 4: 0 (wide) .
+	{NP_X,       ROW_SHIFT, 2.0f, KEY_H, AK_NP0,   "0", nullptr, KEY_NUMPAD},
+	{NP_X + 2.0f,ROW_SHIFT, 1.0f, KEY_H, AK_NPDEL, ".", nullptr, KEY_NUMPAD},
 };
 
-static const int NUM_KEYS = sizeof(s_keys_us) / sizeof(s_keys_us[0]);
+static constexpr int NUM_MAIN_KEYS = 78;
+static constexpr int NUM_NUMPAD_KEYS = 18;
+static constexpr int NUM_KEYS = sizeof(s_keys_us) / sizeof(s_keys_us[0]);
+static_assert(NUM_MAIN_KEYS + NUM_NUMPAD_KEYS == NUM_KEYS, "Unexpected on-screen keyboard layout size");
 
 // ============================================================
 // Language-specific label overrides
@@ -271,6 +308,7 @@ static ImU32 col_amiga_r;
 static ImU32 col_focus_border;
 static ImU32 col_key_shadow;
 static ImU32 col_key_arrow;
+static ImU32 col_key_numpad;
 static ImU32 col_key_space;
 static ImU32 col_key_return;
 
@@ -291,6 +329,7 @@ static void init_colors()
 	col_focus_border   = IM_COL32(255, 210, 60, 255);    // yellow focus highlight
 	col_key_shadow     = IM_COL32(0, 0, 0, 110);         // stronger drop shadow
 	col_key_arrow      = IM_COL32(188, 174, 150, 255);   // arrow keys
+	col_key_numpad     = IM_COL32(206, 192, 168, 255);   // slightly cooler beige
 	col_key_space      = IM_COL32(236, 224, 200, 255);   // space bar (lighter)
 	col_key_return     = IM_COL32(206, 192, 168, 255);   // return key
 }
@@ -306,6 +345,7 @@ static Uint64 s_anim_start_time = 0;
 static constexpr float ANIM_DURATION_MS = 300.0f; // slide animation duration
 
 static float s_transparency = 0.85f; // configurable alpha
+static bool s_numpad_enabled = false;
 
 static int s_focused_key = -1; // currently focused key (for D-pad navigation)
 static std::set<int> s_sticky_keys; // set of AK_* codes for active sticky modifiers
@@ -331,13 +371,24 @@ static float s_kb_x = 0, s_kb_y = 0, s_kb_w = 0, s_kb_h = 0;
 static float s_unit_w = 0, s_unit_h = 0;
 
 // Total layout dimensions in units
-static constexpr float LAYOUT_W = 17.0f; // total width in key units
+static constexpr float COMPACT_LAYOUT_W = 17.0f;
+static constexpr float FULL_LAYOUT_W = 20.0f;
 static constexpr float LAYOUT_H = 6.1f;  // total height in key units
 #ifdef __ANDROID__
 static constexpr float KB_HEIGHT_FRAC = 0.55f; // larger keys for finger taps on phones
 #else
 static constexpr float KB_HEIGHT_FRAC = 0.42f; // keyboard occupies 42% of screen height
 #endif
+
+static int active_key_count()
+{
+	return s_numpad_enabled ? NUM_KEYS : NUM_MAIN_KEYS;
+}
+
+static float active_layout_width()
+{
+	return s_numpad_enabled ? FULL_LAYOUT_W : COMPACT_LAYOUT_W;
+}
 
 static void reset_navigation_state()
 {
@@ -374,7 +425,7 @@ static void compute_geometry(int dw, int dh)
 	float usable_w = s_kb_w - pad * 2.0f;
 	float usable_h = s_kb_h - pad * 2.0f;
 
-	s_unit_w = usable_w / LAYOUT_W;
+	s_unit_w = usable_w / active_layout_width();
 	s_unit_h = usable_h / LAYOUT_H;
 
 	// Position: bottom of screen
@@ -413,6 +464,7 @@ static ImU32 get_key_color(const OskKeyDef& key)
 	case KEY_AMIGA_R:   return col_key_modifier;
 	case KEY_RETURN:    return col_key_return;
 	case KEY_ARROW:     return col_key_arrow;
+	case KEY_NUMPAD:    return col_key_numpad;
 	default:            return col_key_normal;
 	}
 }
@@ -566,6 +618,8 @@ static void draw_key(ImDrawList* dl, const OskKeyDef& key, int key_index,
 // Public API
 // ============================================================
 
+static void release_pressed_keys();
+
 void imgui_osk_init()
 {
 	if (s_initialized)
@@ -641,12 +695,28 @@ void imgui_osk_set_language(const char* lang)
 		s_active_overrides = nullptr; // unknown = US fallback
 }
 
-void imgui_osk_render(int dw, int dh)
+void imgui_osk_set_numpad(const bool enabled)
+{
+	if (s_numpad_enabled == enabled)
+		return;
+
+	// Release anything held before changing the active index range.
+	release_pressed_keys();
+	s_numpad_enabled = enabled;
+	s_viewport_w = 0; // force geometry recomputation for the new layout width
+	if (s_focused_key >= active_key_count())
+		s_focused_key = 0;
+}
+
+void imgui_osk_render()
 {
 	if (!s_initialized || !imgui_overlay_is_initialized())
 		return;
 
-	compute_geometry(dw, dh);
+	const ImVec2 display_size = ImGui::GetIO().DisplaySize;
+	if (display_size.x <= 0.0f || display_size.y <= 0.0f)
+		return;
+	compute_geometry(static_cast<int>(display_size.x), static_cast<int>(display_size.y));
 
 	// Update animation
 	float anim_offset = 0.0f;
@@ -709,7 +779,7 @@ void imgui_osk_render(int dw, int dh)
 		border_light, 1.5f);
 
 	// Draw all keys
-	for (int i = 0; i < NUM_KEYS; i++) {
+	for (int i = 0; i < active_key_count(); i++) {
 		float kx, ky, kw, kh;
 		key_to_screen(s_keys_us[i], anim_offset, &kx, &ky, &kw, &kh);
 		draw_key(dl, s_keys_us[i], i, kx, ky, kw, kh, alpha, font, font_small);
@@ -732,7 +802,7 @@ static int find_key_at(float screen_x, float screen_y)
 			anim_offset = s_kb_h * s_anim_progress;
 	}
 
-	for (int i = 0; i < NUM_KEYS; i++) {
+	for (int i = 0; i < active_key_count(); i++) {
 		float kx, ky, kw, kh;
 		key_to_screen(s_keys_us[i], anim_offset, &kx, &ky, &kw, &kh);
 		if (screen_x >= kx && screen_x <= kx + kw &&
@@ -800,7 +870,7 @@ static void release_pressed_keys()
 {
 	std::set<int> pressed_keys = s_pressed_keys;
 	for (int key_idx : pressed_keys) {
-		if (key_idx >= 0 && key_idx < NUM_KEYS)
+		if (key_idx >= 0 && key_idx < active_key_count())
 			release_key(s_keys_us[key_idx].ak_code);
 	}
 	s_finger_keys.clear();
@@ -844,7 +914,7 @@ bool imgui_osk_handle_finger_up(float screen_x, float screen_y, int finger_id)
 	s_finger_keys.erase(it);
 	s_pressed_keys.erase(key_idx);
 
-	if (key_idx >= 0 && key_idx < NUM_KEYS) {
+	if (key_idx >= 0 && key_idx < active_key_count()) {
 		release_key(s_keys_us[key_idx].ak_code);
 	}
 	return true;
@@ -861,11 +931,11 @@ bool imgui_osk_handle_finger_motion(float screen_x, float screen_y, int finger_i
 
 	if (new_idx != old_idx) {
 		// Finger moved to a different key
-		if (old_idx >= 0 && old_idx < NUM_KEYS) {
+		if (old_idx >= 0 && old_idx < active_key_count()) {
 			s_pressed_keys.erase(old_idx);
 			release_key(s_keys_us[old_idx].ak_code);
 		}
-		if (new_idx >= 0 && new_idx < NUM_KEYS) {
+		if (new_idx >= 0 && new_idx < active_key_count()) {
 			s_finger_keys[finger_id] = new_idx;
 			s_pressed_keys.insert(new_idx);
 			press_key(s_keys_us[new_idx].ak_code);
@@ -887,7 +957,7 @@ bool imgui_osk_handle_finger_motion(float screen_x, float screen_y, int finger_i
 //   horizontally closest key in that row.
 static int find_nearest_key(int from_idx, int direction)
 {
-	if (from_idx < 0 || from_idx >= NUM_KEYS)
+	if (from_idx < 0 || from_idx >= active_key_count())
 		return 0;
 
 	const OskKeyDef& from = s_keys_us[from_idx];
@@ -904,7 +974,7 @@ static int find_nearest_key(int from_idx, int direction)
 		int best = -1;
 		float best_dx = 999999.0f;
 
-		for (int i = 0; i < NUM_KEYS; i++) {
+		for (int i = 0; i < active_key_count(); i++) {
 			if (i == from_idx) continue;
 			const OskKeyDef& to = s_keys_us[i];
 			float to_cx = to.x + to.w * 0.5f;
@@ -929,7 +999,7 @@ static int find_nearest_key(int from_idx, int direction)
 
 		// If nothing found on same row, try any row (fallback)
 		if (best < 0) {
-			for (int i = 0; i < NUM_KEYS; i++) {
+			for (int i = 0; i < active_key_count(); i++) {
 				if (i == from_idx) continue;
 				const OskKeyDef& to = s_keys_us[i];
 				float to_cx = to.x + to.w * 0.5f;
@@ -949,7 +1019,7 @@ static int find_nearest_key(int from_idx, int direction)
 	// Vertical (UP/DOWN): two-phase — find nearest row, then closest key in it
 	// Phase 1: find the nearest row center Y in the pressed direction
 	float nearest_row_dy = 999999.0f;
-	for (int i = 0; i < NUM_KEYS; i++) {
+	for (int i = 0; i < active_key_count(); i++) {
 		if (i == from_idx) continue;
 		const OskKeyDef& to = s_keys_us[i];
 		float to_cy = to.y + to.h * 0.5f;
@@ -970,7 +1040,7 @@ static int find_nearest_key(int from_idx, int direction)
 	int best = -1;
 	float best_dx = 999999.0f;
 
-	for (int i = 0; i < NUM_KEYS; i++) {
+	for (int i = 0; i < active_key_count(); i++) {
 		if (i == from_idx) continue;
 		const OskKeyDef& to = s_keys_us[i];
 		float to_cx = to.x + to.w * 0.5f;
@@ -1047,7 +1117,7 @@ bool imgui_osk_process(int state, int* keycode, int* pressed)
 	}
 
 	// Button press/release
-	if (s_focused_key >= 0 && s_focused_key < NUM_KEYS) {
+	if (s_focused_key >= 0 && s_focused_key < active_key_count()) {
 		int ak = s_keys_us[s_focused_key].ak_code;
 
 		if (rising & OSK_BUTTON) {

--- a/src/osdep/imgui_osk.h
+++ b/src/osdep/imgui_osk.h
@@ -27,8 +27,8 @@ bool imgui_osk_is_active();
 bool imgui_osk_should_render();
 
 // Render the keyboard. Called between imgui_overlay_begin_frame/end_frame.
-// dw, dh = drawable (viewport) dimensions in pixels.
-void imgui_osk_render(int dw, int dh);
+// Geometry uses ImGui's logical display coordinates for HiDPI correctness.
+void imgui_osk_render();
 
 // Process joystick/D-pad input for keyboard navigation.
 // state: bitmask of VKBD_UP/DOWN/LEFT/RIGHT/BUTTON
@@ -48,6 +48,7 @@ bool imgui_osk_hit_test(float screen_x, float screen_y);
 // Configuration
 void imgui_osk_set_transparency(float alpha); // 0.0 = fully transparent, 1.0 = opaque
 void imgui_osk_set_language(const char* lang); // "US", "UK", "DE", "FR"
+void imgui_osk_set_numpad(bool enabled);
 
 // Direct gamepad control (called from SDL event handler).
 // x/y: direction (-1,0,1). button: bit index. buttonstate: 0/1.

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -1642,10 +1642,8 @@ void OpenGLRenderer::render_vkbd(int monid)
 {
 	if (vkbd_allowed(monid) && imgui_osk_should_render())
 	{
-		int dw, dh;
-		get_drawable_size(AMonitors[monid].amiga_window, &dw, &dh);
 		imgui_overlay_begin_frame();
-		imgui_osk_render(dw, dh);
+		imgui_osk_render();
 		imgui_overlay_end_frame();
 	}
 }

--- a/src/osdep/sdl_renderer.cpp
+++ b/src/osdep/sdl_renderer.cpp
@@ -336,11 +336,8 @@ void SDLRenderer::render_vkbd(int monid)
 	{
 		AmigaMonitor* mon = &AMonitors[monid];
 		if (!mon->amiga_renderer) return;
-		int dw = 0, dh = 0;
-		SDL_GetCurrentRenderOutputSize(mon->amiga_renderer, &dw, &dh);
-		if (dw <= 0 || dh <= 0) return;
 		imgui_overlay_begin_frame();
-		imgui_osk_render(dw, dh);
+		imgui_osk_render();
 		imgui_overlay_end_frame();
 	}
 }

--- a/src/osdep/vulkan_renderer.cpp
+++ b/src/osdep/vulkan_renderer.cpp
@@ -1707,7 +1707,7 @@ void VulkanRenderer::record_and_submit(uint32_t slot_index)
 	if (vkbd_allowed(slot.monid) && imgui_osk_should_render() && imgui_overlay_is_vulkan())
 	{
 		imgui_overlay_begin_frame();
-		imgui_osk_render(drawable_w, drawable_h);
+		imgui_osk_render();
 		imgui_overlay_end_frame(); // calls ImGui::Render() but skips RenderDrawData for Vulkan
 		ImDrawData* draw_data = imgui_overlay_get_draw_data();
 		if (draw_data)


### PR DESCRIPTION
## Summary

- add an optional 18-key Amiga numeric keypad to the ImGui on-screen keyboard
- preserve the larger compact layout by keeping the keypad disabled by default
- expose the option in the native ImGui panel and Android Compose settings
- persist and propagate the setting through native configs, Android launches, and WHDLoad setup
- use ImGui logical coordinates so keyboard hotkeys render the overlay correctly on HiDPI displays

The assigned keyboard toggle was reaching the OSK visibility handler, but on Retina displays the layout used drawable pixels while ImGui clipped in logical window coordinates. The overlay is now laid out and touch-tested in the same logical coordinate space.

## Validation

- `cmake --build build -j8`
- `cd android && ./gradlew test --rerun-tasks` — 424 tests
- manually verified compact and full-keypad layouts on macOS OpenGL/Retina using a keyboard-assigned toggle
- `git diff --check`

Closes #2162
