### PR TITLE
Fix libretro OSK link failures

### DIFF
--- a/.agents/skills/troubleshoot-amiberry/SKILL.md
+++ b/.agents/skills/troubleshoot-amiberry/SKILL.md
@@ -177,7 +177,7 @@ Before editing, decide whether the bug is in a shared subsystem or only one rend
 - Libretro is headless and does not link host GUI implementations. It compiles shared `src/osdep/` callers against replacements such as `libretro/libretro_gui_stubs.cpp` and `libretro/libretro_stubs.cpp`.
 - Whenever a shared declaration gains a function or changes its signature, search the libretro stubs for the old contract and update them in the same change.
 - Do not solve missing symbols by adding host GUI sources to the libretro build; provide a no-op or headless implementation instead.
-- Run a clean standalone libretro build. Do not accept a permissive Linux shared-library link as proof that all symbols resolve; keep `-Wl,--no-undefined` enabled.
+- Run a clean standalone libretro build. Do not accept a permissive Linux shared-library link as proof that all symbols resolve; keep `-Wl,--no-undefined` enabled for normal builds. `SANITIZE=1` must omit it because Clang ASan shared libraries intentionally defer runtime symbols to the frontend.
 
 ### Phase 5: Report
 

--- a/.agents/skills/troubleshoot-amiberry/SKILL.md
+++ b/.agents/skills/troubleshoot-amiberry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: troubleshoot-amiberry
-description: Use when investigating, reproducing, or fixing Amiberry bugs, especially renderer or input regressions, RTG/Picasso96 pixel-format or presentation bugs, HiDPI or SDL3 logical-presentation bugs, Vulkan capability or swapchain failures, MHI/audio playback regressions, threaded device shutdown hangs, OS4 filesystem packet fallback issues, PPC/QEMU runtime performance regressions, crash regressions, or behavior regressions. Follow an edit-build-run-test-fix cycle, using Amiberry MCP runtime-control tools when they are configured and falling back to normal process, log, screenshot, and debugger tools otherwise.
+description: Use when investigating, reproducing, or fixing Amiberry bugs, especially renderer or input regressions, RTG/Picasso96 pixel-format or presentation bugs, HiDPI or SDL3 logical-presentation bugs, Vulkan capability or swapchain failures, libretro headless stub or link regressions, MHI/audio playback regressions, threaded device shutdown hangs, OS4 filesystem packet fallback issues, PPC/QEMU runtime performance regressions, crash regressions, or behavior regressions. Follow an edit-build-run-test-fix cycle, using Amiberry MCP runtime-control tools when they are configured and falling back to normal process, log, screenshot, and debugger tools otherwise.
 ---
 
 # Amiberry Autonomous Troubleshooting
@@ -57,6 +57,20 @@ ninja -j12
 - `write_log()` is silent unless `--log` flag or `write_logfile` config is set
 - x86-64 JIT is supported on Windows; for high-natmem, pointer-width, or performance regressions use the `amiberry-x86-jit` skill
 - PowerShell `$env:` variables get stripped in bash inline commands; use `.ps1` files with `-File`
+
+### Libretro standalone core
+
+The standalone Makefile does not track header dependencies. Use a clean build after changing shared headers, function signatures, or `src/osdep/` call sites.
+
+```bash
+# Linux
+make -C libretro clean
+make -C libretro platform=unix ARCH="$(uname -m)" -j"$(nproc)"
+
+# macOS
+make -C libretro clean
+make -C libretro platform=osx ARCH="$(uname -m)" -j"$(sysctl -n hw.logicalcpu)"
+```
 
 ## Troubleshooting Workflow
 
@@ -158,6 +172,13 @@ Before editing, decide whether the bug is in a shared subsystem or only one rend
 - Prefer "probe, then enable" over hardcoding spec-preferred flags.
 - If the bug involves presentation or scaling, verify both startup and post-resize behavior.
 
+### Phase 4b: Libretro Contract Verification
+
+- Libretro is headless and does not link host GUI implementations. It compiles shared `src/osdep/` callers against replacements such as `libretro/libretro_gui_stubs.cpp` and `libretro/libretro_stubs.cpp`.
+- Whenever a shared declaration gains a function or changes its signature, search the libretro stubs for the old contract and update them in the same change.
+- Do not solve missing symbols by adding host GUI sources to the libretro build; provide a no-op or headless implementation instead.
+- Run a clean standalone libretro build. Do not accept a permissive Linux shared-library link as proof that all symbols resolve; keep `-Wl,--no-undefined` enabled.
+
 ### Phase 5: Report
 
 Summarize:
@@ -251,6 +272,8 @@ To send a keypress, call `send_key` twice: once with state=1 (press), then state
 | `src/osdep/amiberry_input.cpp` | Input handling |
 | `src/osdep/amiberry.cpp` | Core platform layer |
 | `src/osdep/macos_bookmarks.h/.mm` | macOS security-scoped bookmarks (App Store) |
+| `libretro/libretro_gui_stubs.cpp` | Headless replacements for host GUI and overlay APIs |
+| `libretro/Makefile` | Standalone libretro source list and platform link rules |
 
 ## macOS Path Notes
 
@@ -268,6 +291,7 @@ To send a keypress, call `send_key` twice: once with state=1 (press), then state
 - If a fix touches input coordinates, explicitly note which coordinate space each variable is in
 - If a fix touches rendering quality, verify OSD, main frame, and external shader paths independently
 - If a fix touches RTG/P96 presentation, check guest pixel format metadata and host SDL surface format separately
+- If a fix changes shared OS-dependent APIs, update libretro stubs and run a clean standalone libretro build
 - For timing-sensitive bugs, use `runtime_set_config` to change CPU speed or floppy speed
 - For crashes, the signal name in `get_crash_info` tells you a lot: SIGSEGV = null pointer/bad memory, SIGABRT = assertion/abort, SIGBUS = alignment
 - Build with Debug type (`-DCMAKE_BUILD_TYPE=Debug`) for better crash info

--- a/.agents/skills/winuae-amiberry-merge/SKILL.md
+++ b/.agents/skills/winuae-amiberry-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: winuae-amiberry-merge
-description: Use when merging or analyzing upstream WinUAE changes for Amiberry's SDL3/CMake codebase across Linux, macOS, Android, Windows, FreeBSD, Haiku, and iOS work-in-progress targets. Covers porting Win32 GUI dialogs to Dear ImGui, mapping Windows controls to ImGui equivalents, adapting platform-specific code, preserving upstream-sync safety for local Amiberry divergences, handling `#ifdef AMIBERRY` splits, and verifying feature parity.
+description: Use when merging or analyzing upstream WinUAE changes for Amiberry's SDL3/CMake codebase across Linux, macOS, Android, Windows, FreeBSD, Haiku, iOS work-in-progress, and the headless libretro core. Covers porting Win32 GUI dialogs to Dear ImGui, mapping Windows controls to ImGui equivalents, adapting platform-specific code, preserving upstream-sync safety for local Amiberry divergences, handling `#ifdef AMIBERRY` splits, and verifying feature parity.
 ---
 
 # WinUAE to Amiberry Merge Assistant
@@ -20,7 +20,7 @@ WinUAE is the upstream Windows-based Amiga emulator. Amiberry is a cross-platfor
 - **Threading:** WinUAE uses Win32 threads; Amiberry uses SDL3 threading primitives where possible
 - **GUI:** WinUAE uses Win32 dialogs; Amiberry uses Dear ImGui (in `src/osdep/imgui/`)
 - **Build:** WinUAE uses Visual Studio; Amiberry uses CMake (+ Gradle for Android)
-- **Platforms:** Amiberry targets Linux, macOS, Android, Windows, FreeBSD, Haiku, and iOS work-in-progress targets using SDL3
+- **Platforms:** Amiberry targets Linux, macOS, Android, Windows, FreeBSD, Haiku, and iOS work-in-progress targets using SDL3, plus a headless libretro core with platform stubs
 - **CI/CD:** GitHub Actions builds all platforms on each commit
 
 ## Merge Workflow
@@ -153,6 +153,14 @@ After applying changes:
 - Check that GUI changes match WinUAE behavior
 - Confirm no Windows-specific code leaked through
 - Test with different configurations if relevant
+- If shared headers, function signatures, or `src/osdep/` call sites changed, update matching replacements in `libretro/libretro_gui_stubs.cpp` or `libretro/libretro_stubs.cpp`.
+- Run a clean standalone libretro build because its Makefile does not track header dependencies:
+  ```bash
+  make -C libretro clean
+  make -C libretro platform=unix ARCH="$(uname -m)" -j"$(nproc)"       # Linux
+  make -C libretro platform=osx ARCH="$(uname -m)" -j"$(sysctl -n hw.logicalcpu)"  # macOS
+  ```
+- Keep libretro headless: stub host-only GUI behavior instead of adding host GUI sources to its Makefile.
 
 ## GUI Synchronization Guide
 

--- a/libretro/AGENTS.md
+++ b/libretro/AGENTS.md
@@ -45,6 +45,7 @@ libretro/
 | Graphics output | `src/osdep/libretro/gfx_platform_internal.h` | `video_cb()` callback |
 | Core options | `core-options.h` | RetroArch UI settings |
 | Platform stubs | `src/osdep/libretro/` | Complete replacement of host platform |
+| Host GUI API stubs | `libretro_gui_stubs.cpp` | No-op replacements for GUI, overlay, OSK, and touch APIs used by shared `src/osdep/` code |
 
 ## CONVENTIONS
 
@@ -53,9 +54,25 @@ libretro/
 - Platform files live in `src/osdep/libretro/`, NOT in `libretro/`
 - Fake 1920x1080 display enumerated for resolution selection
 - `libretro-common/` is shared upstream code — minimize modifications
+- The standalone Makefile does not track header dependencies; use a clean build after changing shared declarations
+- Linux links with `--no-undefined` so missing headless stubs fail consistently across platforms
+
+## BUILD
+
+```bash
+# Linux
+make -C libretro clean
+make -C libretro platform=unix ARCH="$(uname -m)" -j"$(nproc)"
+
+# macOS
+make -C libretro clean
+make -C libretro platform=osx ARCH="$(uname -m)" -j"$(sysctl -n hw.logicalcpu)"
+```
 
 ## ANTI-PATTERNS
 
 - **DO NOT** enable JIT in x86_64 libretro builds
 - **DO NOT** add GUI elements — libretro is headless, use core options instead
+- **DO NOT** change a shared host API without updating its libretro stub signature and adding stubs for new functions
+- **DO NOT** add host GUI implementation files to resolve missing symbols — extend the headless stub layer
 - Unit tests in `libretro-common/test/` exist but are **NOT executed in CI**

--- a/libretro/AGENTS.md
+++ b/libretro/AGENTS.md
@@ -55,7 +55,7 @@ libretro/
 - Fake 1920x1080 display enumerated for resolution selection
 - `libretro-common/` is shared upstream code — minimize modifications
 - The standalone Makefile does not track header dependencies; use a clean build after changing shared declarations
-- Linux links with `--no-undefined` so missing headless stubs fail consistently across platforms
+- Normal Linux builds link with `--no-undefined` so missing headless stubs fail consistently across platforms; `SANITIZE=1` omits it because Clang ASan shared libraries intentionally defer runtime symbols to the frontend
 
 ## BUILD
 

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -48,6 +48,13 @@ ifeq ($(ARCH),)
    ARCH = $(shell uname -m)
 endif
 
+# Clang leaves ASan runtime references unresolved in shared libraries so the
+# frontend executable can provide the runtime. Keep strict symbol checking for
+# normal builds, but do not make sanitizer builds reject those references.
+ifneq ($(SANITIZE), 1)
+   NO_UNDEFINED := -Wl,--no-undefined
+endif
+
 ifeq ($(platform), unix)
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
@@ -57,9 +64,9 @@ ifeq ($(platform), unix)
    CHD_PTTY := $(AMIBERRY_DIR)/src/archivers/chd/posixptty.cpp
    CHD_SOCKET := $(AMIBERRY_DIR)/src/archivers/chd/posixsocket.cpp
    ifeq ($(DEBUG), 1)
-   SHARED := -shared -Wl,--no-undefined -Wl,-Bsymbolic-functions
+   SHARED := -shared $(NO_UNDEFINED) -Wl,-Bsymbolic-functions
    else
-   SHARED := -shared -Wl,--no-undefined -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,-Bsymbolic-functions
+   SHARED := -shared $(NO_UNDEFINED) -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,-Bsymbolic-functions
    endif
 else ifeq ($(platform), osx)
    TARGET := $(TARGET_NAME)_libretro.dylib

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -57,9 +57,9 @@ ifeq ($(platform), unix)
    CHD_PTTY := $(AMIBERRY_DIR)/src/archivers/chd/posixptty.cpp
    CHD_SOCKET := $(AMIBERRY_DIR)/src/archivers/chd/posixsocket.cpp
    ifeq ($(DEBUG), 1)
-   SHARED := -shared -Wl,-Bsymbolic-functions
+   SHARED := -shared -Wl,--no-undefined -Wl,-Bsymbolic-functions
    else
-   SHARED := -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,-Bsymbolic-functions
+   SHARED := -shared -Wl,--no-undefined -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,-Bsymbolic-functions
    endif
 else ifeq ($(platform), osx)
    TARGET := $(TARGET_NAME)_libretro.dylib

--- a/libretro/libretro_gui_stubs.cpp
+++ b/libretro/libretro_gui_stubs.cpp
@@ -58,7 +58,7 @@ void imgui_osk_shutdown() {}
 void imgui_osk_toggle() {}
 bool imgui_osk_is_active() { return false; }
 bool imgui_osk_should_render() { return false; }
-void imgui_osk_render(int dw, int dh) { (void)dw; (void)dh; }
+void imgui_osk_render() {}
 bool imgui_osk_process(int state, int* keycode, int* pressed)
 {
 	(void)state;
@@ -72,6 +72,7 @@ bool imgui_osk_handle_finger_motion(float x, float y, int id) { (void)x; (void)y
 bool imgui_osk_hit_test(float x, float y) { (void)x; (void)y; return false; }
 void imgui_osk_set_transparency(float alpha) { (void)alpha; }
 void imgui_osk_set_language(const char* lang) { (void)lang; }
+void imgui_osk_set_numpad(bool enabled) { (void)enabled; }
 
 // On-screen joystick stubs (not used in libretro builds)
 void on_screen_joystick_init(SDL_Renderer* renderer) { (void)renderer; }


### PR DESCRIPTION
## Summary

- update the headless libretro OSK stubs for the API introduced by #2163
- make Linux libretro reject unresolved symbols with `--no-undefined`
- document the clean libretro build and shared-API stub requirements
- add the same checks to the troubleshooting and WinUAE merge skills

## Root cause

The on-screen keyboard render signature changed and a numpad setter was added, but `libretro_gui_stubs.cpp` still implemented the old contract. macOS and Windows therefore failed at the final link step. Linux linked successfully only because its shared-library flags permitted unresolved symbols.

## Validation

- `make -C libretro clean`
- `make -C libretro platform=osx ARCH="$(uname -m)" -j"$(sysctl -n hw.logicalcpu)"`
- verified the resulting core had no unresolved OSK, overlay, or on-screen joystick symbols
- validated both modified skills with `quick_validate.py`
- `git diff --check`

Refs #2163
