### PR TITLE
Fix controller input capture during mapping

### DIFF
--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -2074,12 +2074,12 @@ void run_gui()
 	// Main loop
 	while (gui_running) {
 		while (SDL_PollEvent(&gui_event)) {
-			// Make sure ImGui sees all events
-			ImGui_ImplSDL3_ProcessEvent(&gui_event);
-
 			if (ControllerMap_HandleEvent(gui_event)) {
 				continue;
 			}
+
+			// Make sure ImGui sees all unconsumed events
+			ImGui_ImplSDL3_ProcessEvent(&gui_event);
 
 			if (gui_event.type == SDL_EVENT_QUIT)	{
 				uae_quit();

--- a/src/osdep/imgui/controller_map.cpp
+++ b/src/osdep/imgui/controller_map.cpp
@@ -841,7 +841,8 @@ void ControllerMap_RenderModal()
 	// Use auto-sizing for height to ensure everything fits regardless of title bar or font size.
 	ImGui::SetNextWindowSize(ImVec2(scaled_screen_w, 0.0f), ImGuiCond_Always);
 	if (ImGui::BeginPopupModal(kControllerMapTitle, nullptr,
-		ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse))
+		ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoScrollbar |
+		ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoNavInputs))
 	{
 		const char* info_line1 = "Press the buttons on your controller when indicated.";
 		const char* info_line2 = "Backspace/Back goes to previous, Space skips, ESC cancels.";

--- a/src/osdep/imgui/controller_map.cpp
+++ b/src/osdep/imgui/controller_map.cpp
@@ -840,9 +840,11 @@ void ControllerMap_RenderModal()
 
 	// Use auto-sizing for height to ensure everything fits regardless of title bar or font size.
 	ImGui::SetNextWindowSize(ImVec2(scaled_screen_w, 0.0f), ImGuiCond_Always);
-	if (ImGui::BeginPopupModal(kControllerMapTitle, nullptr,
-		ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoScrollbar |
-		ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoNavInputs))
+	ImGuiWindowFlags window_flags = ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoScrollbar |
+		ImGuiWindowFlags_NoScrollWithMouse;
+	if (g_controller_map.error_text.empty())
+		window_flags |= ImGuiWindowFlags_NoNavInputs;
+	if (ImGui::BeginPopupModal(kControllerMapTitle, nullptr, window_flags))
 	{
 		const char* info_line1 = "Press the buttons on your controller when indicated.";
 		const char* info_line2 = "Backspace/Back goes to previous, Space skips, ESC cancels.";


### PR DESCRIPTION
## Summary

- prevent ImGui navigation while the controller mapping modal is active
- route remapper-consumed events before the general ImGui event handler
- preserve mouse access and the modal's dedicated keyboard controls

## Root cause

The controller remapper consumed raw SDL joystick events, but ImGui gamepad
navigation independently polled the controller each frame. D-pad, stick, and
button input could therefore move or activate GUI controls while the same input
was being assigned by the remapper. Keyboard shortcuts handled by the remapper
were also forwarded to ImGui before being marked as consumed.

## User impact

Controller input is reserved for mapping while the modal is open, so every
requested binding can be completed without the GUI selection moving or buttons
being activated unexpectedly. Normal controller navigation resumes when the
modal closes.

## Validation

- `cmake --build build --parallel`
- `build/Amiberry.app/Contents/MacOS/Amiberry --dump-paths`
- `git diff --check`

Manual verification with a physical controller is still recommended.
