### PR TITLE
Fix configuration naming for loaded media

### DIFF
--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -8089,24 +8089,28 @@ int parse_cmdline_option (struct uae_prefs *p, TCHAR c, const TCHAR *arg)
 		cmdpath (p->floppyslots[0].df, arg, 255);
 #ifdef AMIBERRY
 		target_addtorecent(arg, 0);
+		set_last_active_config_from_media(arg);
 #endif
 		break;
 	case '1':
 		cmdpath (p->floppyslots[1].df, arg, 255);
 #ifdef AMIBERRY
 		target_addtorecent(arg, 0);
+		set_last_active_config_from_media(arg);
 #endif
 		break;
 	case '2':
 		cmdpath (p->floppyslots[2].df, arg, 255);
 #ifdef AMIBERRY
 		target_addtorecent(arg, 0);
+		set_last_active_config_from_media(arg);
 #endif
 		break;
 	case '3':
 		cmdpath (p->floppyslots[3].df, arg, 255);
 #ifdef AMIBERRY
 		target_addtorecent(arg, 0);
+		set_last_active_config_from_media(arg);
 #endif
 		break;
 

--- a/src/disk.cpp
+++ b/src/disk.cpp
@@ -3368,6 +3368,9 @@ void disk_insert (int num, const TCHAR *name, bool forcedwriteprotect)
 {
 	set_config_changed ();
 	target_addtorecent (name, 0);
+#ifdef AMIBERRY
+	set_last_active_config_from_media(name);
+#endif
 	disk_insert_2 (num, name, 0, forcedwriteprotect);
 }
 
@@ -3375,6 +3378,9 @@ void disk_insert (int num, const TCHAR *name)
 {
 	set_config_changed ();
 	target_addtorecent (name, 0);
+#ifdef AMIBERRY
+	set_last_active_config_from_media(name);
+#endif
 	disk_insert_2 (num, name, 0, false);
 }
 void disk_insert_force (int num, const TCHAR *name, bool forcedwriteprotect)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1177,6 +1177,7 @@ std::string get_filename_extension(const TCHAR* filename)
 }
 
 extern void set_last_active_config(const char* filename);
+extern void set_last_active_config_from_media(const char* filename);
 
 static bool cmdline_started;
 
@@ -1372,6 +1373,7 @@ static void parse_cmdline (int argc, TCHAR **argv)
 				if (_tcsrchr(txt2, ',') == nullptr)
 					_tcscat(txt2, _T(",image"));
 				cfgfile_parse_option(&currprefs, _T("cdimage0"), txt2, 0);
+				set_last_active_config_from_media(txt);
 				xfree(txt2);
 				xfree(txt);
 			}
@@ -1398,7 +1400,6 @@ static void parse_cmdline (int argc, TCHAR **argv)
 				add_file_to_mru_list(lstMRUWhdloadList, std::string(txt));
 				whdload_prefs.whdload_filename = std::string(txt);
 				whdload_auto_prefs(&currprefs, txt);
-				set_last_active_config(txt);
 			}
 			else if (_tcscmp(txt2.c_str(), ".uss") == 0)
 			{
@@ -1425,7 +1426,6 @@ static void parse_cmdline (int argc, TCHAR **argv)
 				write_log("CDTV/CD32... %s\n", txt);
 				add_file_to_mru_list(lstMRUCDList, std::string(txt));
 				cd_auto_prefs(&currprefs, txt);
-				set_last_active_config(txt);
 			}
 			else if (_tcscmp(txt2.c_str(), ".adf") == 0
 				|| _tcscmp(txt2.c_str(), ".adz") == 0
@@ -1468,7 +1468,7 @@ static void parse_cmdline (int argc, TCHAR **argv)
 				{
 					write_log("No configuration file found for %s, inserting disk in DF0: with default settings\n", txt);
 					disk_insert(0, txt);
-					set_last_active_config(txt);
+					set_last_active_config_from_media(txt);
 					currprefs.start_gui = false;
 				}
 			}

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -738,6 +738,13 @@ void set_last_active_config(const char* filename)
 	remove_file_extension(last_active_config);
 }
 
+void set_last_active_config_from_media(const char* filename)
+{
+	// Media names are save-as defaults; they must not replace an explicitly loaded configuration.
+	if (filename && filename[0] && !last_loaded_config[0])
+		set_last_active_config(filename);
+}
+
 int getdpiformonitor(SDL_DisplayID displayID)
 {
 	float scale = SDL_GetDisplayContentScale(displayID);
@@ -3143,6 +3150,7 @@ static void handle_drop_file_event(const SDL_Event& event)
 	{
 		// Insert floppy image
 		disk_insert(0, dropped_file);
+		set_last_active_config_from_media(dropped_file);
 	}
 	else if (strcasecmp(ext.c_str(), ".lha") == 0)
 	{
@@ -10202,6 +10210,7 @@ void target_getdate(int* y, int* m, int* d)
 void target_addtorecent(const TCHAR* name, int t)
 {
 	add_file_to_mru_list(lstMRUDiskList, std::string(name));
+	set_last_active_config_from_media(name);
 }
 
 void target_reset()

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -738,10 +738,23 @@ void set_last_active_config(const char* filename)
 	remove_file_extension(last_active_config);
 }
 
+static bool is_physical_media_device(const char* filename)
+{
+	if (strncmp(filename, "/dev/", 5) == 0)
+		return true;
+
+	const char drive_letter = filename[0];
+	return ((drive_letter >= 'A' && drive_letter <= 'Z') || (drive_letter >= 'a' && drive_letter <= 'z'))
+		&& filename[1] == ':'
+		&& (filename[2] == '\\' || filename[2] == '/')
+		&& (filename[3] == '\0' || filename[3] == ',');
+}
+
 void set_last_active_config_from_media(const char* filename)
 {
-	// Media names are save-as defaults; they must not replace an explicitly loaded configuration.
-	if (filename && filename[0] && !last_loaded_config[0])
+	// Media names are save-as defaults; they must not replace an explicitly loaded configuration
+	// or use a physical device path as a configuration name.
+	if (filename && filename[0] && !last_loaded_config[0] && !is_physical_media_device(filename))
 		set_last_active_config(filename);
 }
 
@@ -6036,13 +6049,10 @@ std::string extract_path(const std::string& filename)
 
 void remove_file_extension(char* filename)
 {
-	auto* p = filename + strlen(filename) - 1;
-	while (p >= filename && *p != '.')
-	{
-		*p = '\0';
-		--p;
-	}
-	*p = '\0';
+	if (!filename)
+		return;
+	if (auto* const extension = strrchr(filename, '.'))
+		*extension = '\0';
 }
 
 std::string remove_file_extension(const std::string& filename)

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -6031,11 +6031,22 @@ int check_configfile(const char* file)
 
 void extract_filename(const char* str, char* buffer)
 {
-	const auto* p = str + strlen(str) - 1;
-	while (*p != '/' && p >= str)
-		p--;
-	p++;
-	strncpy(buffer, p, MAX_DPATH - 1);
+	if (!buffer)
+		return;
+	if (!str)
+	{
+		buffer[0] = '\0';
+		return;
+	}
+
+	const char* filename = str;
+	for (const char* p = str; *p; ++p)
+	{
+		if (*p == '/' || *p == '\\')
+			filename = p + 1;
+	}
+	strncpy(buffer, filename, MAX_DPATH - 1);
+	buffer[MAX_DPATH - 1] = '\0';
 }
 
 std::string extract_filename(const std::string& path)

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -10243,7 +10243,6 @@ void target_getdate(int* y, int* m, int* d)
 void target_addtorecent(const TCHAR* name, int t)
 {
 	add_file_to_mru_list(lstMRUDiskList, std::string(name));
-	set_last_active_config_from_media(name);
 }
 
 void target_reset()

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -742,8 +742,17 @@ void set_last_active_config(const char* filename)
 
 static bool is_physical_media_device(const char* filename)
 {
+#ifndef _WIN32
 	if (strncmp(filename, "/dev/", 5) == 0)
-		return true;
+	{
+		std::string device_path(filename);
+		if (const auto options = device_path.find(','); options != std::string::npos)
+			device_path.resize(options);
+
+		struct stat st{};
+		return stat(device_path.c_str(), &st) == 0 && (S_ISBLK(st.st_mode) || S_ISCHR(st.st_mode));
+	}
+#endif
 
 	const char drive_letter = filename[0];
 	return ((drive_letter >= 'A' && drive_letter <= 'Z') || (drive_letter >= 'a' && drive_letter <= 'z'))

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -662,6 +662,7 @@ static bool legacy_cleanup_prompt_enabled = false;
 
 char last_loaded_config[MAX_DPATH] = {};
 char last_active_config[MAX_DPATH] = {};
+static bool last_loaded_config_is_automatic_default = false;
 
 int max_uae_width;
 int max_uae_height;
@@ -726,10 +727,11 @@ static std::string get_bootstrap_destination_label(const legacy_migration_state_
 	return {};
 }
 
-void set_last_loaded_config(const char* filename)
+void set_last_loaded_config(const char* filename, const bool automatic_default)
 {
 	extract_filename(filename, last_loaded_config);
 	remove_file_extension(last_loaded_config);
+	last_loaded_config_is_automatic_default = automatic_default;
 }
 
 void set_last_active_config(const char* filename)
@@ -754,7 +756,8 @@ void set_last_active_config_from_media(const char* filename)
 {
 	// Media names are save-as defaults; they must not replace an explicitly loaded configuration
 	// or use a physical device path as a configuration name.
-	if (filename && filename[0] && !last_loaded_config[0] && !is_physical_media_device(filename))
+	const bool explicit_config_loaded = last_loaded_config[0] && !last_loaded_config_is_automatic_default;
+	if (filename && filename[0] && !explicit_config_loaded && !is_physical_media_device(filename))
 		set_last_active_config(filename);
 }
 
@@ -5985,7 +5988,7 @@ int target_cfgfile_load(uae_prefs* p, const char* filename, int type, const int 
 		if (strlen(p->floppyslots[i].df) > 0)
 			add_file_to_mru_list(lstMRUDiskList, std::string(p->floppyslots[i].df));
 	}
-	set_last_loaded_config(filename);
+	set_last_loaded_config(filename, isdefault != 0);
 	set_last_active_config(filename);
 	return result;
 }

--- a/src/osdep/amiberry_dbus.cpp
+++ b/src/osdep/amiberry_dbus.cpp
@@ -277,6 +277,7 @@ static void HandleInsertFloppy(DBusMessage* msg)
 		{
 			_tcsncpy(changed_prefs.floppyslots[drivenum].df, diskpathstr, MAX_DPATH);
 			changed_prefs.floppyslots[drivenum].df[MAX_DPATH - 1] = 0;
+			set_last_active_config_from_media(diskpathstr);
 			set_config_changed();
 		}
 		else
@@ -311,6 +312,7 @@ static void HandleInsertCD(DBusMessage* msg)
 		_tcsncpy(changed_prefs.cdslots[0].name, diskpathstr, MAX_DPATH);
 		changed_prefs.cdslots[0].name[MAX_DPATH - 1] = 0;
 		changed_prefs.cdslots[0].inuse = true;
+		set_last_active_config_from_media(diskpathstr);
 
 		std::cout << "CD Type: " << changed_prefs.cdslots[0].type << "\n";
 		set_config_changed();

--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -647,6 +647,7 @@ void disk_selection(const int shortcut, uae_prefs* prefs)
 				strncpy(prefs->floppyslots[shortcut].df, tmp.c_str(), MAX_DPATH);
 				disk_insert(shortcut, tmp.c_str());
 				add_file_to_mru_list(lstMRUDiskList, tmp);
+				set_last_active_config_from_media(tmp.c_str());
 			}
 		}
 	}
@@ -720,6 +721,7 @@ void disk_selection(const int shortcut, uae_prefs* prefs)
 				changed_prefs.cdslots[0].inuse = true;
 				changed_prefs.cdslots[0].type = SCSI_UNIT_DEFAULT;
 				add_file_to_mru_list(lstMRUCDList, tmp);
+				set_last_active_config_from_media(tmp.c_str());
 			}
 		}
 	}

--- a/src/osdep/amiberry_ipc_socket.cpp
+++ b/src/osdep/amiberry_ipc_socket.cpp
@@ -263,6 +263,7 @@ static std::string HandleInsertFloppy(const std::vector<std::string>& args)
 
 	_tcsncpy(changed_prefs.floppyslots[drivenum].df, args[0].c_str(), MAX_DPATH);
 	changed_prefs.floppyslots[drivenum].df[MAX_DPATH - 1] = 0;
+	set_last_active_config_from_media(args[0].c_str());
 	set_config_changed();
 
 	return make_response(true);
@@ -278,6 +279,7 @@ static std::string HandleInsertCD(const std::vector<std::string>& args)
 	_tcsncpy(changed_prefs.cdslots[0].name, args[0].c_str(), MAX_DPATH);
 	changed_prefs.cdslots[0].name[MAX_DPATH - 1] = 0;
 	changed_prefs.cdslots[0].inuse = true;
+	set_last_active_config_from_media(args[0].c_str());
 	set_config_changed();
 
 	return make_response(true);

--- a/src/osdep/amiberry_whdbooter.cpp
+++ b/src/osdep/amiberry_whdbooter.cpp
@@ -31,9 +31,8 @@
 #include "zfile.h"
 #include "zarchive.h"
 
-extern void set_last_active_config(const char* filename);
+extern void set_last_active_config_from_media(const char* filename);
 extern std::string current_dir;
-extern char last_loaded_config[MAX_DPATH];
 
 // Use configs with 8MB Fast RAM, to make it likely
 // that WHDLoad preload will cache everything.
@@ -387,7 +386,6 @@ void symlink_roms(struct uae_prefs* prefs)
 
 std::string get_game_filename(const char* filepath)
 {
-	extract_filename(filepath, last_loaded_config);
 	const std::string game_name = extract_filename(filepath);
 	return remove_file_extension(game_name);
 }
@@ -428,6 +426,7 @@ void cd_auto_prefs(uae_prefs* prefs, char* filepath)
 	TCHAR tmp[MAX_DPATH];
 
 	write_log("\nCD Autoload: %s  \n\n", filepath);
+	set_last_active_config_from_media(filepath);
 
 	conf_path = get_configuration_path();
 	whdload_prefs.filename = get_game_filename(filepath);
@@ -1605,6 +1604,8 @@ void whdload_auto_prefs(uae_prefs* prefs, const char* filepath, const bool prese
 	const bool android_vkbd_numpad = prefs->vkbd_numpad;
 	const bool android_input_default_osk = prefs->input_default_onscreen_keyboard;
 #endif
+
+	set_last_active_config_from_media(filepath);
 
 	config_loaded = false;
 

--- a/src/osdep/gui/gui_handling.h
+++ b/src/osdep/gui/gui_handling.h
@@ -537,6 +537,7 @@ extern void rebuild_gui_fonts();
 
 extern void SetLastLoadedConfig(const char* filename);
 extern void set_last_active_config(const char* filename);
+extern void set_last_active_config_from_media(const char* filename);
 extern void disk_selection(const int shortcut, uae_prefs* prefs);
 extern int disk_swap(int entry, int mode);
 extern int disk_in_drive(int entry);

--- a/src/osdep/imgui/floppy.cpp
+++ b/src/osdep/imgui/floppy.cpp
@@ -232,6 +232,7 @@ static void RenderDriveSlot(const int i)
                  changed_prefs.floppyslots[i].df[MAX_DPATH - 1] = '\0';
                  disk_insert(i, changed_prefs.floppyslots[i].df);
                  DISK_history_add(changed_prefs.floppyslots[i].df, -1, HISTORY_FLOPPY, 0);
+                 set_last_active_config_from_media(changed_prefs.floppyslots[i].df);
                  invalidate_wp_cache(i);
             }
 
@@ -542,11 +543,13 @@ void render_panel_floppy()
                          disk_insert(drive_idx, changed_prefs.floppyslots[drive_idx].df);
                          DISK_history_add(changed_prefs.floppyslots[drive_idx].df, -1, HISTORY_FLOPPY, 0);
                          add_file_to_mru_list(lstMRUDiskList, std::string(changed_prefs.dfxlist[0]));
+                         set_last_active_config_from_media(changed_prefs.floppyslots[drive_idx].df);
                      } else {
                          strncpy(changed_prefs.floppyslots[drive_idx].df, result_path.c_str(), MAX_DPATH - 1);
                          changed_prefs.floppyslots[drive_idx].df[MAX_DPATH - 1] = '\0';
                          disk_insert(drive_idx, result_path.c_str());
                          DISK_history_add(result_path.c_str(), -1, HISTORY_FLOPPY, 0);
+                         set_last_active_config_from_media(result_path.c_str());
                      }
                      invalidate_wp_cache(drive_idx);
                 }

--- a/src/osdep/imgui/hd.cpp
+++ b/src/osdep/imgui/hd.cpp
@@ -156,12 +156,18 @@ static int cached_get_filesys_unitconfig(struct uae_prefs *p, int row, struct mo
 
 static bool IsCdDevicePath(const char* path)
 {
-    return path && std::strncmp(path, "/dev/", 5) == 0;
+	if (!path)
+		return false;
+	if (std::strncmp(path, "/dev/", 5) == 0)
+		return true;
+
+	const auto cd_drives = get_cd_drives();
+	return std::find(cd_drives.begin(), cd_drives.end(), path) != cd_drives.end();
 }
 
 static bool IsCdDevicePath(const std::string& path)
 {
-    return path.rfind("/dev/", 0) == 0;
+	return IsCdDevicePath(path.c_str());
 }
 
 static bool ValidatePhysicalDriveSelection(const uaedev_config_info& ci, std::string& error, bool* out_readonly = nullptr)

--- a/src/osdep/imgui/hd.cpp
+++ b/src/osdep/imgui/hd.cpp
@@ -540,6 +540,7 @@ static void RenderCDSection()
                 changed_prefs.cdslots[0].inuse = true;
                 changed_prefs.cdslots[0].type = SCSI_UNIT_DEFAULT;
                 AddToMruCdList(path);
+                set_last_active_config_from_media(path.c_str());
             }
             if (is_selected) ImGui::SetItemDefaultFocus();
             ImGui::PopID();
@@ -586,6 +587,7 @@ static void RenderCDSection()
              changed_prefs.cdslots[0].inuse = true;
              changed_prefs.cdslots[0].type = SCSI_UNIT_DEFAULT;
              AddToMruCdList(result_path);
+             set_last_active_config_from_media(result_path.c_str());
         }
     }
 
@@ -1392,8 +1394,10 @@ static void ShowEditCDDriveModal()
                 au_copy(changed_prefs.cdslots[0].name, MAX_DPATH, path_buf);
                 changed_prefs.cdslots[0].inuse = true;
                 changed_prefs.cdslots[0].type = IsCdDevicePath(path_buf) ? SCSI_UNIT_IOCTL : SCSI_UNIT_DEFAULT;
-                if (!IsCdDevicePath(path_buf))
+                if (!IsCdDevicePath(path_buf)) {
                     AddToMruCdList(path_buf);
+                    set_last_active_config_from_media(path_buf);
+                }
             }
 
             new_cddrive(edit_entry_index);

--- a/src/osdep/imgui/hd.cpp
+++ b/src/osdep/imgui/hd.cpp
@@ -536,6 +536,7 @@ static void RenderCDSection()
             ImGui::PopID();
         }
 
+        std::string selected_mru_path;
         for (const auto& path : lstMRUCDList) {
             if (path.empty()) continue;
             ImGui::PushID(id_counter++);
@@ -545,11 +546,15 @@ static void RenderCDSection()
                 au_copy(changed_prefs.cdslots[0].name, MAX_DPATH, path.c_str());
                 changed_prefs.cdslots[0].inuse = true;
                 changed_prefs.cdslots[0].type = SCSI_UNIT_DEFAULT;
-                AddToMruCdList(path);
-                set_last_active_config_from_media(path.c_str());
+                selected_mru_path = path;
             }
             if (is_selected) ImGui::SetItemDefaultFocus();
             ImGui::PopID();
+        }
+
+        if (!selected_mru_path.empty()) {
+            AddToMruCdList(selected_mru_path);
+            set_last_active_config_from_media(selected_mru_path.c_str());
         }
 
         if (!current_in_list && cd_name && *cd_name) {

--- a/src/osdep/imgui/play.cpp
+++ b/src/osdep/imgui/play.cpp
@@ -520,7 +520,7 @@ bool apply_floppy_content()
 			changed_prefs.dfxlist[0]);
 		disk_insert(0, changed_prefs.floppyslots[0].df);
 		add_file_to_mru_list(lstMRUDiskList, std::string(changed_prefs.dfxlist[0]));
-		set_last_active_config(changed_prefs.dfxlist[0]);
+		set_last_active_config_from_media(changed_prefs.dfxlist[0]);
 		mark_content_applied();
 		return true;
 	}
@@ -529,7 +529,7 @@ bool apply_floppy_content()
 		selected_content.original_path);
 	disk_insert(0, changed_prefs.floppyslots[0].df);
 	add_file_to_mru_list(lstMRUDiskList, selected_content.original_path);
-	set_last_active_config(selected_content.original_path.c_str());
+	set_last_active_config_from_media(selected_content.original_path.c_str());
 	mark_content_applied();
 	return true;
 }
@@ -542,7 +542,6 @@ bool apply_whdload_content()
 	add_file_to_mru_list(lstMRUWhdloadList, whdload_prefs.whdload_filename);
 	whdload_auto_prefs(&changed_prefs, whdload_prefs.whdload_filename.c_str(), manual_quickstart_override);
 	apply_display_defaults_to_changed_prefs();
-	set_last_active_config(whdload_prefs.whdload_filename.c_str());
 	mark_content_applied();
 	return true;
 }
@@ -554,7 +553,7 @@ bool apply_hardfile_content()
 	if (!attach_selected_hardfile())
 		return false;
 
-	set_last_active_config(selected_content.original_path.c_str());
+	set_last_active_config_from_media(selected_content.original_path.c_str());
 	mark_content_applied();
 	return true;
 }
@@ -564,6 +563,7 @@ void mount_selected_cd_image(const char* path)
 	copy_path_to_buffer(changed_prefs.cdslots[0].name, sizeof changed_prefs.cdslots[0].name, path);
 	changed_prefs.cdslots[0].inuse = true;
 	changed_prefs.cdslots[0].type = SCSI_UNIT_DEFAULT;
+	set_last_active_config_from_media(path);
 }
 
 bool apply_cd_content()
@@ -579,7 +579,6 @@ bool apply_cd_content()
 		cd_auto_prefs(&changed_prefs, path);
 	apply_display_defaults_to_changed_prefs();
 	add_file_to_mru_list(lstMRUCDList, selected_content.original_path);
-	set_last_active_config(selected_content.original_path.c_str());
 	mark_content_applied();
 	return true;
 }

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -199,9 +199,9 @@ static void clear_play_content_if_quickstart_source() {
 }
 
 void render_panel_quickstart() {
-    // Check if we need to apply Quickstart defaults on first show
+    // Apply defaults on first show only when no configuration or media setup is active.
     static bool initial_sync_done = false;
-    if (!initial_sync_done && !emulating && !last_loaded_config[0]) {
+    if (!initial_sync_done && !emulating && !last_loaded_config[0] && !last_active_config[0]) {
         Quickstart_ApplyDefaults();
         initial_sync_done = true;
     }

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -526,8 +526,7 @@ void render_panel_quickstart() {
                             DISK_history_add(changed_prefs.floppyslots[i].df, -1, HISTORY_FLOPPY, 0);
                             disk_insert(i, changed_prefs.floppyslots[i].df);
                             qs_invalidate_wp_cache(i);
-                            if (!last_loaded_config[0])
-                                set_last_active_config(element.c_str());
+                            set_last_active_config_from_media(element.c_str());
                         }
                     }
                 }
@@ -646,8 +645,7 @@ void render_panel_quickstart() {
                                 DISK_history_add(changed_prefs.cdslots[0].name, -1, HISTORY_CD, 0);
                                 changed_prefs.cdslots[0].inuse = true;
                                 changed_prefs.cdslots[0].type = SCSI_UNIT_DEFAULT;
-                                if (!last_loaded_config[0])
-                                    set_last_active_config(element.c_str());
+                                set_last_active_config_from_media(element.c_str());
                             }
                         }
                     }
@@ -717,7 +715,6 @@ void render_panel_quickstart() {
                         add_file_to_mru_list(lstMRUWhdloadList, whdload_prefs.whdload_filename);
                     }
                     whdload_auto_prefs(&changed_prefs, whdload_prefs.whdload_filename.c_str());
-                    set_last_active_config(whdload_prefs.whdload_filename.c_str());
                 }
             }
             if (is_selected) {
@@ -764,16 +761,14 @@ void render_panel_quickstart() {
                         disk_insert(i, changed_prefs.floppyslots[i].df);
                         add_file_to_mru_list(lstMRUDiskList, std::string(changed_prefs.dfxlist[0]));
                         qs_invalidate_wp_cache(i);
-                        if (!last_loaded_config[0])
-                            set_last_active_config(changed_prefs.dfxlist[0]);
+                        set_last_active_config_from_media(changed_prefs.dfxlist[0]);
                     } else if (std::strncmp(changed_prefs.floppyslots[i].df, filePath.c_str(), MAX_DPATH) != 0) {
                         std::strncpy(changed_prefs.floppyslots[i].df, filePath.c_str(), MAX_DPATH - 1);
                         changed_prefs.floppyslots[i].df[MAX_DPATH - 1] = '\0';
                         disk_insert(i, filePath.c_str());
                         add_file_to_mru_list(lstMRUDiskList, filePath);
                         qs_invalidate_wp_cache(i);
-                        if (!last_loaded_config[0])
-                            set_last_active_config(filePath.c_str());
+                        set_last_active_config_from_media(filePath.c_str());
                     }
                 }
             } else if (qs_pending_cd) {
@@ -783,8 +778,7 @@ void render_panel_quickstart() {
                         changed_prefs.cdslots[0].inuse = true;
                         changed_prefs.cdslots[0].type = SCSI_UNIT_DEFAULT;
                         add_file_to_mru_list(lstMRUCDList, filePath);
-                        if (!last_loaded_config[0])
-                            set_last_active_config(filePath.c_str());
+                        set_last_active_config_from_media(filePath.c_str());
                     }
                 }
             } else if (qs_pending_whd) {
@@ -792,7 +786,6 @@ void render_panel_quickstart() {
                     whdload_prefs.whdload_filename = filePath;
                     add_file_to_mru_list(lstMRUWhdloadList, whdload_prefs.whdload_filename);
                     whdload_auto_prefs(&changed_prefs, whdload_prefs.whdload_filename.c_str());
-                    set_last_active_config(whdload_prefs.whdload_filename.c_str());
                 }
             }
 

--- a/src/osdep/imgui/whdload.cpp
+++ b/src/osdep/imgui/whdload.cpp
@@ -125,8 +125,6 @@ void render_panel_whdload()
              whdload_prefs.whdload_filename = result_path;
              add_file_to_mru_list(lstMRUWhdloadList, whdload_prefs.whdload_filename);
              whdload_auto_prefs(&changed_prefs, whdload_prefs.whdload_filename.c_str());
-             if (!last_loaded_config[0])
-                 set_last_active_config(whdload_prefs.whdload_filename.c_str());
         }
     }
 
@@ -167,8 +165,6 @@ void render_panel_whdload()
         if (current_whd_idx >= 0 && current_whd_idx < (int)whd_paths.size()) {
              whdload_prefs.whdload_filename = whd_paths[current_whd_idx];
              whdload_auto_prefs(&changed_prefs, whdload_prefs.whdload_filename.c_str());
-             if (!last_loaded_config[0])
-                 set_last_active_config(whdload_prefs.whdload_filename.c_str());
         }
     }
     AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());

--- a/src/osdep/target.h
+++ b/src/osdep/target.h
@@ -230,6 +230,7 @@ extern void extract_path(const char* str, char* buffer);
 extern std::string extract_path(const std::string& filename);
 extern void remove_file_extension(char* filename);
 extern std::string remove_file_extension(const std::string& filename);
+extern void set_last_active_config_from_media(const char* filename);
 extern void ReadConfigFileList();
 extern void configurations_panel_reset();
 extern void read_rom_list(bool);


### PR DESCRIPTION
## Summary

- centralize media-derived configuration naming behind a loaded-config guard
- apply the same behavior to floppy, CD, WHDLoad, and hardfile loading paths
- cover GUI panels, Quickstart, Play, CLI, drag-and-drop, IPC, and DBus
- keep physical CD device selection from deriving a configuration name

## Root cause

WHDLoad filename extraction incorrectly populated `last_loaded_config`, so the WHDLoad panel believed a real UAE configuration had already been loaded. Other media paths either skipped configuration-name autofill or set it unconditionally, which could replace the name of an explicitly loaded configuration.

## Impact

Media filenames are used as convenient save-as defaults only when no UAE configuration was loaded. Explicitly loaded configuration names remain unchanged across subsequent media insertion.

## Validation

- `cmake --build build --parallel`
- clean macOS libretro build
- DBus-enabled handler compile with `USE_DBUS=ON`
- runtime debugger checks for CD `--autoload`, `--cdimage`, and `-0` floppy loading
- runtime verification that an existing configuration name is preserved
- `git diff --check`