### PR TITLE
Fix host-only cursor alignment across native and P96 modes

### DIFF
--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -4413,9 +4413,11 @@ static void cursorsprite(struct sprite *s)
 	if (sprres == 0) {
 		sprite_0_doubled = 1;
 	}
-	if (spr[0].dblscan) {
-		sprite_0_height /= 2;
-	}
+	// SPRxPOS bit 7 only enables alternate-line sprite DMA when FMODE.SSCAN2
+	// is active. Without that gate it is also an ordinary vertical position
+	// bit, and halving here squashes the host cursor as it crosses line 128.
+	sprite_0_height = amiberry_input_native_cursor_height(sprite_0_height,
+		spr[0].dblscan, (fmode & 0x8000) != 0);
 	if (aga_mode) {
 		int sbasecol = ((bplcon4 >> 4) & 15) << 4;
 		sprite_0_colors[1] = agnus_colors.color_regs_aga[sbasecol + 1] & 0xffffff;
@@ -4898,6 +4900,7 @@ static void vsync_handler_render(void)
 #endif
 
 #ifdef PICASSO96
+	picasso_update_native_cursor(0);
 	if (isvsync_rtg() >= 0) {
 		rtg_vsync();
 	}

--- a/src/include/amiberry_cursor.h
+++ b/src/include/amiberry_cursor.h
@@ -25,6 +25,21 @@ static inline std::uint32_t amiberry_cursor_rgba32_from_rgb24(std::uint32_t rgb)
 #endif
 }
 
+static inline int amiberry_cursor_hotspot_from_offset(int hotspot_offset, int extent)
+{
+	if (extent <= 0) {
+		return 0;
+	}
+
+	if (hotspot_offset < 0) {
+		return 0;
+	}
+	if (hotspot_offset >= extent) {
+		return extent - 1;
+	}
+	return hotspot_offset;
+}
+
 static inline bool amiberry_cursor_host_only_enabled(int input_tablet,
 	int input_magic_mouse_cursor, int host_only_cursor_value, bool host_cursor_available)
 {

--- a/src/include/xwin.h
+++ b/src/include/xwin.h
@@ -77,6 +77,7 @@ extern int target_get_display_scanline(int displayindex);
 extern void target_spin(int);
 
 void getgfxoffset(int monid, float *dxp, float *dyp, float *mxp, float *myp);
+void getgfxsourceorigin(int monid, int *xp, int *yp);
 float target_getcurrentvblankrate(int monid);
 
 extern int debuggable(void);

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -2736,12 +2736,6 @@ static bool get_mouse_position(int *xp, int *yp, int inx, int iny)
 		int origin_x = 0;
 		int origin_y = 0;
 		getgfxsourceorigin(monid, &origin_x, &origin_y);
-		// Interlaced long fields report the raw source top one field line lower.
-		// Normalize it before conversion or a stationary absolute Y coordinate
-		// alternates by two Amiga lines on every field.
-		origin_y = amiberry_input_native_interlace_origin(origin_y,
-			interlace_seen > 0, lof_display,
-			1 << std::clamp(currprefs.gfx_vresolution, 0, VRES_MAX));
 		// The source crop is the native screen origin. Destination centering is
 		// already part of fdx/fdy and must not move that origin (notably when a
 		// PAL laced image is letterboxed). Match the existing vertical input bias.
@@ -3078,8 +3072,12 @@ static void inputdevice_mh_abs (int x, int y, uae_u32 buttonbits, bool position_
 	const uaecptr intuition_base = get_intuitionbase();
 	const bool screen_offset_valid = intuition_base && intuition_base != 0xffffffff;
 	if (screen_offset_valid) {
-		screen_offset_x = static_cast<uae_s16>(get_word(intuition_base + 34 + 14)) * 2;
-		screen_offset_y = static_cast<uae_s16>(get_word(intuition_base + 34 + 12)) * 2;
+		// IntuitionBase embeds ViewLord immediately after its 34-byte Library.
+		// Offset 34 is ViewLord.ViewPort; DxOffset and DyOffset are later fields
+		// in the embedded View, matching the existing filesys.asm mousehack path.
+		const uaecptr viewlord = intuition_base + 34;
+		screen_offset_x = static_cast<uae_s16>(get_word(viewlord + 14)) * 2;
+		screen_offset_y = static_cast<uae_s16>(get_word(viewlord + 12)) * 2;
 	}
 	if (mousehack_host_cursor_uses_hotspot && mousehack_position_is_native && screen_offset_valid) {
 		x += amiberry_input_native_mousehack_origin_compensation(

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -2456,6 +2456,8 @@ static bool mousehack_host_cursor_uses_hotspot;
 static int mousehack_host_cursor_residual_x, mousehack_host_cursor_residual_y;
 static int mousehack_last_abs_x, mousehack_last_abs_y;
 static bool mousehack_last_abs_valid;
+static int mousehack_native_origin_x, mousehack_native_origin_y;
+static bool mousehack_position_is_native;
 static int tablet_maxx, tablet_maxy, tablet_maxz;
 static int tablet_resx, tablet_resy;
 static int tablet_maxax, tablet_maxay, tablet_maxaz;
@@ -2585,6 +2587,8 @@ static void mousehack_reset (void)
 	mousehack_host_cursor_residual_x = mousehack_host_cursor_residual_y = 0;
 	mousehack_last_abs_x = mousehack_last_abs_y = 0;
 	mousehack_last_abs_valid = false;
+	mousehack_native_origin_x = mousehack_native_origin_y = 0;
+	mousehack_position_is_native = false;
 	dimensioninfo_dbl = 0;
 	mousehack_alive_cnt = 0;
 	vp_xoffset = vp_yoffset = 0;
@@ -2709,6 +2713,7 @@ static bool get_mouse_position(int *xp, int *yp, int inx, int iny)
 
 #ifdef PICASSO96
 	if (ad->picasso_on) {
+		mousehack_position_is_native = false;
 		x -= state->XOffset;
 		y -= state->YOffset;
 		x = (int)(x * fmx);
@@ -2719,6 +2724,7 @@ static bool get_mouse_position(int *xp, int *yp, int inx, int iny)
 #endif
 	{
 		if (vidinfo->outbuffer == NULL) {
+			mousehack_position_is_native = false;
 			*xp = 0;
 			*yp = 0;
 			return false;
@@ -2727,20 +2733,42 @@ static bool get_mouse_position(int *xp, int *yp, int inx, int iny)
 		y = (int)(y * fmy);
 		x -= (int)(fdx * 1.0) - 0;
 		y -= (int)(fdy * 1.0) - 2;
+		int origin_x = 0;
+		int origin_y = 0;
+		getgfxsourceorigin(monid, &origin_x, &origin_y);
+		// Interlaced long fields report the raw source top one field line lower.
+		// Normalize it before conversion or a stationary absolute Y coordinate
+		// alternates by two Amiga lines on every field.
+		origin_y = amiberry_input_native_interlace_origin(origin_y,
+			interlace_seen > 0, lof_display,
+			1 << std::clamp(currprefs.gfx_vresolution, 0, VRES_MAX));
+		// The source crop is the native screen origin. Destination centering is
+		// already part of fdx/fdy and must not move that origin (notably when a
+		// PAL laced image is letterboxed). Match the existing vertical input bias.
+		origin_y += 2;
 		bool axis_ob = false;
 		x = amiberry_input_clamp_native_axis(x, vidinfo->outbuffer->outwidth, &axis_ob);
 		ob |= axis_ob;
 		y = amiberry_input_clamp_native_axis(y, vidinfo->outbuffer->outheight, &axis_ob);
 		ob |= axis_ob;
+		origin_x = amiberry_input_clamp_native_axis(origin_x, vidinfo->outbuffer->outwidth, nullptr);
+		origin_y = amiberry_input_clamp_native_axis(origin_y, vidinfo->outbuffer->outheight, nullptr);
 		if (currprefs.gfx_resolution == RES_LORES) {
 			x *= 2;
+			origin_x *= 2;
 		} else if (currprefs.gfx_resolution == RES_SUPERHIRES) {
 			x /= 2;
+			origin_x /= 2;
 		}
 		x = coord_native_to_amiga_x(x);
+		origin_x = coord_native_to_amiga_x(origin_x);
 		if (y >= 0) {
 			y = coord_native_to_amiga_y(y) * 2;
 		}
+		origin_y = coord_native_to_amiga_y(origin_y) * 2;
+		mousehack_native_origin_x = origin_x;
+		mousehack_native_origin_y = origin_y;
+		mousehack_position_is_native = true;
 	}
 	*xp = x;
 	*yp = y;
@@ -3045,9 +3073,25 @@ static void inputdevice_mh_abs (int x, int y, uae_u32 buttonbits, bool position_
 		x -= mouseoffset_x + 1;
 		y -= mouseoffset_y + 2;
 	}
+	int screen_offset_x = 0;
+	int screen_offset_y = 0;
+	const uaecptr intuition_base = get_intuitionbase();
+	const bool screen_offset_valid = intuition_base && intuition_base != 0xffffffff;
+	if (screen_offset_valid) {
+		screen_offset_x = static_cast<uae_s16>(get_word(intuition_base + 34 + 14)) * 2;
+		screen_offset_y = static_cast<uae_s16>(get_word(intuition_base + 34 + 12)) * 2;
+	}
+	if (mousehack_host_cursor_uses_hotspot && mousehack_position_is_native && screen_offset_valid) {
+		x += amiberry_input_native_mousehack_origin_compensation(
+			screen_offset_x, mousehack_native_origin_x);
+		y += amiberry_input_native_mousehack_origin_compensation(
+			screen_offset_y, mousehack_native_origin_y);
+	}
 
 	mousehack_enable ();
-	// Keep the Amiga coordinate actually delivered after host-hotspot compensation.
+	// Keep the coordinate delivered after native screen-origin and host-hotspot
+	// compensation. The guest positions its native sprite from this coordinate,
+	// so their delta is the cursor hotspot.
 	mousehack_last_abs_x = x;
 	mousehack_last_abs_y = y;
 	mousehack_last_abs_valid = position_valid && mousehack_address;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -706,6 +706,26 @@ void getgfxoffset(const int monid, float* dxp, float* dyp, float* mxp, float* my
 	*myp = 1.0f / my;
 }
 
+void getgfxsourceorigin(const int monid, int* xp, int* yp)
+{
+	*xp = 0;
+	*yp = 0;
+#ifdef AMIBERRY
+	const amigadisplay* ad = &adisplays[monid];
+	if (currprefs.gfx_auto_crop && !ad->picasso_on) {
+		int width = 0;
+		int height = 0;
+		int real_height = 0;
+		int hres = currprefs.gfx_resolution;
+		int vres = currprefs.gfx_vresolution;
+		// Mousehack needs the native display origin before auto-crop policy
+		// expansion. The final renderer crop may include extra guard area,
+		// which is presentation padding rather than part of the Amiga screen.
+		get_custom_limits(&width, &height, xp, yp, &real_height, &hres, &vres);
+	}
+#endif
+}
+
 
 bool render_screen(const int monid, const int mode, const bool immediate)
 {

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -61,6 +61,7 @@
 #include "gfx_prefs_check.h"
 #include "display_modes.h"
 #include "renderer_factory.h"
+#include "amiberry_input_helpers.h"
 
 #ifdef USE_OPENGL
 #include "gl_platform.h"
@@ -120,6 +121,10 @@ constexpr int auto_crop_guard_top_base_tolerance = 8;
 constexpr int auto_crop_wide_aspect_w = 21;
 constexpr int auto_crop_wide_aspect_h = 9;
 constexpr int auto_crop_shrink_stable_frames = 6;
+
+static int auto_crop_source_origin_x;
+static int auto_crop_source_origin_y;
+static bool auto_crop_source_origin_valid;
 
 static int auto_crop_rect_right(const SDL_Rect& rect)
 {
@@ -712,16 +717,13 @@ void getgfxsourceorigin(const int monid, int* xp, int* yp)
 	*yp = 0;
 #ifdef AMIBERRY
 	const amigadisplay* ad = &adisplays[monid];
-	if (currprefs.gfx_auto_crop && !ad->picasso_on) {
-		int width = 0;
-		int height = 0;
-		int real_height = 0;
-		int hres = currprefs.gfx_resolution;
-		int vres = currprefs.gfx_vresolution;
+	if (monid == 0 && currprefs.gfx_auto_crop && !ad->picasso_on
+		&& auto_crop_source_origin_valid) {
 		// Mousehack needs the native display origin before auto-crop policy
 		// expansion. The final renderer crop may include extra guard area,
 		// which is presentation padding rather than part of the Amiga screen.
-		get_custom_limits(&width, &height, xp, yp, &real_height, &hres, &vres);
+		*xp = auto_crop_source_origin_x;
+		*yp = auto_crop_source_origin_y;
 	}
 #endif
 }
@@ -1966,6 +1968,13 @@ void auto_crop_image()
 		int hres = currprefs.gfx_resolution;
 		int vres = currprefs.gfx_vresolution;
 		get_custom_limits(&cw, &ch, &cx, &cy, &crealh, &hres, &vres);
+		// Cache the raw source origin at render cadence. Input must not call
+		// get_custom_limits(), which advances its interlace sampling state.
+		auto_crop_source_origin_x = cx;
+		auto_crop_source_origin_y = amiberry_input_native_interlace_origin(cy,
+			interlace_seen > 0, lof_display,
+			1 << std::clamp(vres, 0, VRES_MAX));
+		auto_crop_source_origin_valid = cw > 0 && ch > 0;
 
 		// Detect NTSC from actual display timing — more reliable than
 		// currprefs.ntscmode which may not reflect the chipset state

--- a/src/osdep/amiberry_input_helpers.h
+++ b/src/osdep/amiberry_input_helpers.h
@@ -86,19 +86,54 @@ static inline int amiberry_input_native_sprite_y(uae_u16 pos, uae_u16 ctl, bool 
 	return y << 1;
 }
 
+static inline int amiberry_input_native_cursor_height(int sprite_height,
+	bool double_scan_position_bit, bool sscan2_enabled)
+{
+	return double_scan_position_bit && sscan2_enabled ? sprite_height / 2 : sprite_height;
+}
+
+static inline int amiberry_input_native_mousehack_origin_compensation(
+	int guest_screen_offset, int transformed_native_origin)
+{
+	return guest_screen_offset - transformed_native_origin;
+}
+
+static inline int amiberry_input_native_interlace_origin(
+	int source_origin, bool interlaced, bool long_field, int field_line_height)
+{
+	if (interlaced && long_field && field_line_height > 0) {
+		return source_origin - field_line_height;
+	}
+	return source_origin;
+}
+
 struct amiberry_input_cursor_hotspot_tracker
 {
 	bool have_sample = false;
 	bool learned = false;
-	int last_pointer_x = 0;
-	int last_pointer_y = 0;
-	int last_sprite_x = 0;
-	int last_sprite_y = 0;
 	int candidate_x = 0;
 	int candidate_y = 0;
 	int stable_samples = 0;
 	int hotspot_x = 0;
 	int hotspot_y = 0;
+};
+
+constexpr int AMIBERRY_INPUT_CURSOR_HOTSPOT_TRACKER_CACHE_SIZE = 4;
+
+struct amiberry_input_cursor_hotspot_tracker_cache_entry
+{
+	bool valid = false;
+	int cursor_width = 0;
+	int cursor_height = 0;
+	unsigned int last_used = 0;
+	amiberry_input_cursor_hotspot_tracker tracker;
+};
+
+struct amiberry_input_cursor_hotspot_tracker_cache
+{
+	unsigned int use_sequence = 0;
+	amiberry_input_cursor_hotspot_tracker_cache_entry
+		entries[AMIBERRY_INPUT_CURSOR_HOTSPOT_TRACKER_CACHE_SIZE];
 };
 
 static inline void amiberry_input_cursor_hotspot_tracker_reset(
@@ -107,6 +142,47 @@ static inline void amiberry_input_cursor_hotspot_tracker_reset(
 	if (tracker) {
 		*tracker = {};
 	}
+}
+
+static inline void amiberry_input_cursor_hotspot_tracker_cache_reset(
+	amiberry_input_cursor_hotspot_tracker_cache* cache)
+{
+	if (cache) {
+		*cache = {};
+	}
+}
+
+static inline amiberry_input_cursor_hotspot_tracker*
+amiberry_input_cursor_hotspot_tracker_cache_acquire(
+	amiberry_input_cursor_hotspot_tracker_cache* cache, int cursor_width, int cursor_height)
+{
+	if (!cache || cursor_width <= 0 || cursor_height <= 0) {
+		return nullptr;
+	}
+
+	cache->use_sequence++;
+	amiberry_input_cursor_hotspot_tracker_cache_entry* available = nullptr;
+	amiberry_input_cursor_hotspot_tracker_cache_entry* oldest = &cache->entries[0];
+	for (auto& entry : cache->entries) {
+		if (entry.valid && entry.cursor_width == cursor_width && entry.cursor_height == cursor_height) {
+			entry.last_used = cache->use_sequence;
+			return &entry.tracker;
+		}
+		if (!entry.valid && !available) {
+			available = &entry;
+		}
+		if (entry.last_used < oldest->last_used) {
+			oldest = &entry;
+		}
+	}
+
+	auto* entry = available ? available : oldest;
+	*entry = {};
+	entry->valid = true;
+	entry->cursor_width = cursor_width;
+	entry->cursor_height = cursor_height;
+	entry->last_used = cache->use_sequence;
+	return &entry->tracker;
 }
 
 static inline bool amiberry_input_cursor_hotspot_tracker_sample(
@@ -126,17 +202,11 @@ static inline bool amiberry_input_cursor_hotspot_tracker_sample(
 		&& candidate_y >= 0 && candidate_y < cursor_height;
 
 	if (candidate_valid) {
-		const bool stationary = tracker->have_sample
-			&& pointer_x == tracker->last_pointer_x && pointer_y == tracker->last_pointer_y
-			&& sprite_x == tracker->last_sprite_x && sprite_y == tracker->last_sprite_y
+		const bool stable = tracker->have_sample
 			&& candidate_x == tracker->candidate_x && candidate_y == tracker->candidate_y;
 
-		tracker->stable_samples = stationary ? tracker->stable_samples + 1 : 1;
+		tracker->stable_samples = stable ? tracker->stable_samples + 1 : 1;
 		tracker->have_sample = true;
-		tracker->last_pointer_x = pointer_x;
-		tracker->last_pointer_y = pointer_y;
-		tracker->last_sprite_x = sprite_x;
-		tracker->last_sprite_y = sprite_y;
 		tracker->candidate_x = candidate_x;
 		tracker->candidate_y = candidate_y;
 
@@ -159,6 +229,24 @@ static inline bool amiberry_input_cursor_hotspot_tracker_sample(
 		}
 	}
 	return tracker->learned;
+}
+
+static inline bool amiberry_input_cursor_snap_hotspot_to_dense_crossing(
+	int candidate_x, int candidate_y, int dense_x, int dense_y, int maximum_distance,
+	int* hotspot_x, int* hotspot_y)
+{
+	if (maximum_distance < 0
+		|| candidate_x < dense_x - maximum_distance || candidate_x > dense_x + maximum_distance
+		|| candidate_y < dense_y - maximum_distance || candidate_y > dense_y + maximum_distance) {
+		return false;
+	}
+	if (hotspot_x) {
+		*hotspot_x = dense_x;
+	}
+	if (hotspot_y) {
+		*hotspot_y = dense_y;
+	}
+	return true;
 }
 
 #endif

--- a/src/osdep/amiberry_input_helpers.h
+++ b/src/osdep/amiberry_input_helpers.h
@@ -125,6 +125,7 @@ struct amiberry_input_cursor_hotspot_tracker_cache_entry
 	bool valid = false;
 	int cursor_width = 0;
 	int cursor_height = 0;
+	uae_u64 cursor_signature = 0;
 	unsigned int last_used = 0;
 	amiberry_input_cursor_hotspot_tracker tracker;
 };
@@ -152,9 +153,27 @@ static inline void amiberry_input_cursor_hotspot_tracker_cache_reset(
 	}
 }
 
+static inline uae_u64 amiberry_input_cursor_bitmap_signature(
+	const uae_u8* image, int image_size, const uae_u32* colors, int color_count)
+{
+	uae_u64 signature = 14695981039346656037ULL;
+	for (int i = 0; image && i < image_size; i++) {
+		signature ^= image[i];
+		signature *= 1099511628211ULL;
+	}
+	for (int i = 0; colors && i < color_count; i++) {
+		for (int shift = 0; shift < 32; shift += 8) {
+			signature ^= (colors[i] >> shift) & 0xff;
+			signature *= 1099511628211ULL;
+		}
+	}
+	return signature;
+}
+
 static inline amiberry_input_cursor_hotspot_tracker*
 amiberry_input_cursor_hotspot_tracker_cache_acquire(
-	amiberry_input_cursor_hotspot_tracker_cache* cache, int cursor_width, int cursor_height)
+	amiberry_input_cursor_hotspot_tracker_cache* cache, int cursor_width, int cursor_height,
+	uae_u64 cursor_signature)
 {
 	if (!cache || cursor_width <= 0 || cursor_height <= 0) {
 		return nullptr;
@@ -164,7 +183,8 @@ amiberry_input_cursor_hotspot_tracker_cache_acquire(
 	amiberry_input_cursor_hotspot_tracker_cache_entry* available = nullptr;
 	amiberry_input_cursor_hotspot_tracker_cache_entry* oldest = &cache->entries[0];
 	for (auto& entry : cache->entries) {
-		if (entry.valid && entry.cursor_width == cursor_width && entry.cursor_height == cursor_height) {
+		if (entry.valid && entry.cursor_width == cursor_width && entry.cursor_height == cursor_height
+			&& entry.cursor_signature == cursor_signature) {
 			entry.last_used = cache->use_sequence;
 			return &entry.tracker;
 		}
@@ -181,6 +201,7 @@ amiberry_input_cursor_hotspot_tracker_cache_acquire(
 	entry->valid = true;
 	entry->cursor_width = cursor_width;
 	entry->cursor_height = cursor_height;
+	entry->cursor_signature = cursor_signature;
 	entry->last_used = cache->use_sequence;
 	return &entry->tracker;
 }

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -2363,9 +2363,11 @@ static int createwindowscursor(int monid, int set, int chipset)
 
 	if (chipset) {
 		input_mousehack_cursor_hotspot(w, h, &hotspot_x, &hotspot_y, &residual_x, &residual_y);
+		const uae_u64 cursor_signature = amiberry_input_cursor_bitmap_signature(
+			image, datasize, ct, 4);
 
 		auto* hotspot_tracker = amiberry_input_cursor_hotspot_tracker_cache_acquire(
-			&native_cursor_hotspot_tracker_cache, w, h);
+			&native_cursor_hotspot_tracker_cache, w, h, cursor_signature);
 
 		// Native pointer and sprite positions both use hires coordinate units.
 		// Decoded low-res cursor pixels use those same units on both axes.

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -180,7 +180,7 @@ uae_u32 p96_rgbx16[65536];
 uae_u32 p96rc[256], p96gc[256], p96bc[256];
 
 static int newcursor_x, newcursor_y;
-static int cursorwidth, cursorheight, cursorok;
+static int cursorwidth, cursorheight, cursorxoffset, cursoryoffset, cursorok;
 static uae_u8 *cursordata;
 static uae_u32 cursorrgb[4], cursorrgbn[4];
 static int cursordeactivate, setupcursor_needed;
@@ -202,15 +202,21 @@ static int interrupt_enabled;
 float p96vblank;
 
 #ifdef AMIBERRY
-static amiberry_input_cursor_hotspot_tracker native_cursor_hotspot_tracker;
-static int native_cursor_tracker_width = -1;
-static int native_cursor_tracker_height = -1;
+static amiberry_input_cursor_hotspot_tracker_cache native_cursor_hotspot_tracker_cache;
+static amiberry_input_cursor_hotspot_tracker p96_cursor_hotspot_tracker;
+static int p96_cursor_tracker_width = -1;
+static int p96_cursor_tracker_height = -1;
 
 static void reset_native_cursor_hotspot_tracker()
 {
-	amiberry_input_cursor_hotspot_tracker_reset(&native_cursor_hotspot_tracker);
-	native_cursor_tracker_width = -1;
-	native_cursor_tracker_height = -1;
+	amiberry_input_cursor_hotspot_tracker_cache_reset(&native_cursor_hotspot_tracker_cache);
+}
+
+static void reset_p96_cursor_hotspot_tracker()
+{
+	amiberry_input_cursor_hotspot_tracker_reset(&p96_cursor_hotspot_tracker);
+	p96_cursor_tracker_width = -1;
+	p96_cursor_tracker_height = -1;
 }
 
 static void clear_host_cursor_hotspot_compensation()
@@ -218,10 +224,11 @@ static void clear_host_cursor_hotspot_compensation()
 	input_mousehack_set_host_cursor_uses_hotspot(false, 0, 0);
 }
 
-static void destroy_p96_host_cursor(bool restore_normal_cursor)
+static void destroy_p96_host_cursor()
 {
 	if (p96_cursor) {
-		if (restore_normal_cursor && SDL_GetCursor() == p96_cursor) {
+		// SDL cursors must not be destroyed while they are still current.
+		if (SDL_GetCursor() == p96_cursor) {
 			SDL_SetCursor(normalcursor);
 		}
 		SDL_DestroyCursor(p96_cursor);
@@ -229,6 +236,7 @@ static void destroy_p96_host_cursor(bool restore_normal_cursor)
 	}
 	clear_host_cursor_hotspot_compensation();
 	reset_native_cursor_hotspot_tracker();
+	reset_p96_cursor_hotspot_tracker();
 }
 #endif
 
@@ -1018,7 +1026,7 @@ static void setupcursor()
 		update_cursor_overlay_surface();
 		
 		// Ensure any native SDL cursor is hidden/freed so it doesn't conflict
-		destroy_p96_host_cursor(false);
+		destroy_p96_host_cursor();
 
 		setupcursor_needed = 0;
 		P96TRACE_SPR((_T("cursorsurface3d updated (overlay)\n")));
@@ -1071,7 +1079,7 @@ static void disablemouse ()
 	if (!hwsprite)
 		return;
 #ifdef AMIBERRY
-	destroy_p96_host_cursor(false);
+	destroy_p96_host_cursor();
 #else
 	D3D_setcursor(0, 0, 0, 0, 0, 0, 0, false, true);
 #endif
@@ -1615,15 +1623,18 @@ static int p96hsync;
 
 void picasso_handle_vsync()
 {
-	struct AmigaMonitor *mon = &AMonitors[currprefs.rtgboards[0].monitor_id];
-	const struct amigadisplay *ad = &adisplays[currprefs.rtgboards[0].monitor_id];
-	const bool uaegfx_active = is_uaegfx_active();
-
-	if (uaegfx_active) {
-		if (!ad->picasso_on) {
-			createwindowscursor(mon->monitor_id, 0, 1);
-		}
+	const int monid = currprefs.rtgboards[0].monitor_id;
+#ifdef AMIBERRY
+	if (monid < 0 || monid >= MAX_AMIGAMONITORS) {
+		return;
 	}
+	if (mouse_monid == monid && adisplays[monid].picasso_on) {
+		// P96 does not consistently expose cursor offsets, so sample the live
+		// pointer-to-sprite displacement while the RTG display is active.
+		createwindowscursor(monid, 0, 0);
+	}
+#endif
+	struct AmigaMonitor *mon = &AMonitors[monid];
 	int vsync = isvsync_rtg();
 	if (vsync < 0) {
 		p96hsync = 0;
@@ -1631,6 +1642,18 @@ void picasso_handle_vsync()
 	} else if (currprefs.rtgvblankrate == 0) {
 		picasso_handle_vsync2(mon);
 	}
+}
+
+void picasso_update_native_cursor(const int monid)
+{
+#ifdef AMIBERRY
+	if (monid < 0 || monid >= MAX_AMIGAMONITORS || mouse_monid != monid
+		|| adisplays[monid].picasso_on) {
+		return;
+	}
+	// Native cursor sampling must run even when no RTG board is configured.
+	createwindowscursor(monid, 0, 1);
+#endif
 }
 
 static void picasso_handle_hsync()
@@ -2232,15 +2255,25 @@ static int createwindowscursor(int monid, int set, int chipset)
 	int datasize;
 	int hotspot_x = 0, hotspot_y = 0;
 	int residual_x = 0, residual_y = 0;
+	int pointer_x = 0, pointer_y = 0;
+	const bool pointer_valid = input_mousehack_get_last_abs_position(&pointer_x, &pointer_y);
 	bool cursor_cache_matches = false;
+	int densest_column = 0;
+	int densest_column_pixels = 0;
+	int densest_row = 0;
+	int densest_row_pixels = 0;
+	int column_pixels[CURSORMAXWIDTH] = {};
 
 	wincursor_shown = 0;
 
-	if (isfullscreen() > 0 || !magic_mouse_host_only_enabled()) {
+	if (!amiberry_cursor_host_only_enabled(currprefs.input_tablet,
+		currprefs.input_magic_mouse_cursor, MAGICMOUSE_HOST_ONLY,
+		isfullscreen() <= 0)) {
 		goto exit;
 	}
 
 	if (chipset) {
+		reset_p96_cursor_hotspot_tracker();
 		w = sprite_0_width;
 		h = sprite_0_height;
 		uaecptr src = sprite_0;
@@ -2292,9 +2325,33 @@ static int createwindowscursor(int monid, int set, int chipset)
 		h = cursorheight;
 		ct = cursorrgb;
 		image = cursordata;
+		if (!image || w <= 0 || h <= 0 || w > CURSORMAXWIDTH || h > CURSORMAXHEIGHT) {
+			goto exit;
+		}
 	}
 
-	datasize = h * ((w + 15) / 16) * 16;
+	// Both native and P96 cursor images are tightly packed after decoding.
+	datasize = w * h;
+	for (int y = 0; y < h; y++) {
+		int row_pixels = 0;
+		for (int x = 0; x < w; x++) {
+			if (image[y * w + x] == 0) {
+				continue;
+			}
+			row_pixels++;
+			column_pixels[x]++;
+		}
+		if (row_pixels > densest_row_pixels) {
+			densest_row_pixels = row_pixels;
+			densest_row = y;
+		}
+	}
+	for (int x = 0; x < w; x++) {
+		if (column_pixels[x] > densest_column_pixels) {
+			densest_column_pixels = column_pixels[x];
+			densest_column = x;
+		}
+	}
 	cursor_cache_matches = p96_cursor
 		&& w == tmp_sprite_w && h == tmp_sprite_h && chipset == tmp_sprite_chipset
 		&& !memcmp(tmp_sprite_data, image, datasize)
@@ -2303,38 +2360,47 @@ static int createwindowscursor(int monid, int set, int chipset)
 	if (chipset) {
 		input_mousehack_cursor_hotspot(w, h, &hotspot_x, &hotspot_y, &residual_x, &residual_y);
 
-		if (native_cursor_tracker_width != w || native_cursor_tracker_height != h || !cursor_cache_matches) {
-			amiberry_input_cursor_hotspot_tracker_reset(&native_cursor_hotspot_tracker);
-			native_cursor_tracker_width = w;
-			native_cursor_tracker_height = h;
-		}
+		auto* hotspot_tracker = amiberry_input_cursor_hotspot_tracker_cache_acquire(
+			&native_cursor_hotspot_tracker_cache, w, h);
 
-		int pointer_x = 0;
-		int pointer_y = 0;
-		const bool position_valid = input_mousehack_get_last_abs_position(&pointer_x, &pointer_y);
-		const bool was_learned = native_cursor_hotspot_tracker.learned;
-		const int previous_hotspot_x = native_cursor_hotspot_tracker.hotspot_x;
-		const int previous_hotspot_y = native_cursor_hotspot_tracker.hotspot_y;
-		// Delivered mousehack coordinates and sprite DMA coordinates share the same Amiga space.
-		if (amiberry_input_cursor_hotspot_tracker_sample(&native_cursor_hotspot_tracker,
-			position_valid, pointer_x, pointer_y, sprite_0_x, sprite_0_y, w, h, 3,
-			&hotspot_x, &hotspot_y)) {
+		// Native pointer and sprite positions both use hires coordinate units.
+		// Decoded low-res cursor pixels use those same units on both axes.
+		if (amiberry_input_cursor_hotspot_tracker_sample(hotspot_tracker,
+			pointer_valid, pointer_x, pointer_y, sprite_0_x, sprite_0_y,
+			w, h, 3, &hotspot_x, &hotspot_y)) {
+			// The pointer-to-sprite delta contains small native positioning biases.
+			// If it lands at a decoded row/column crossing, prefer the bitmap's
+			// actual intersection so crosshair cursors use their visual center.
+			amiberry_input_cursor_snap_hotspot_to_dense_crossing(hotspot_x, hotspot_y,
+				densest_column, densest_row, 3, &hotspot_x, &hotspot_y);
 			residual_x = 0;
 			residual_y = 0;
-			if (!was_learned || hotspot_x != previous_hotspot_x || hotspot_y != previous_hotspot_y) {
-				write_log(_T("Native host cursor hotspot learned: %dx%d hotspot=%d,%d pointer=%d,%d sprite=%d,%d\n"),
-					w, h, hotspot_x, hotspot_y, pointer_x, pointer_y, sprite_0_x, sprite_0_y);
-			}
 		}
 	} else {
 		reset_native_cursor_hotspot_tracker();
+		hotspot_x = amiberry_cursor_hotspot_from_offset(cursorxoffset, w);
+		hotspot_y = amiberry_cursor_hotspot_from_offset(cursoryoffset, h);
+
+		if (p96_cursor_tracker_width != w || p96_cursor_tracker_height != h) {
+			amiberry_input_cursor_hotspot_tracker_reset(&p96_cursor_hotspot_tracker);
+			p96_cursor_tracker_width = w;
+			p96_cursor_tracker_height = h;
+		}
+
+		if (amiberry_input_cursor_hotspot_tracker_sample(&p96_cursor_hotspot_tracker,
+			pointer_valid, pointer_x, pointer_y,
+			newcursor_x, newcursor_y, w, h, 3, &hotspot_x, &hotspot_y)) {
+			residual_x = 0;
+			residual_y = 0;
+		}
 	}
 
 	if (cursor_cache_matches && hotspot_x == tmp_sprite_hotspot_x && hotspot_y == tmp_sprite_hotspot_y) {
 		if (SDL_GetCursor() == p96_cursor) {
+			SDL_ShowCursor();
 			tmp_sprite_residual_x = residual_x;
 			tmp_sprite_residual_y = residual_y;
-			input_mousehack_set_host_cursor_uses_hotspot(chipset != 0, residual_x, residual_y);
+			input_mousehack_set_host_cursor_uses_hotspot(true, residual_x, residual_y);
 			wincursor_shown = 1;
 			return 1;
 		}
@@ -2388,7 +2454,8 @@ end:
 
 	if (p96_cursor) {
 		SDL_SetCursor(p96_cursor);
-		input_mousehack_set_host_cursor_uses_hotspot(chipset != 0, residual_x, residual_y);
+		SDL_ShowCursor();
+		input_mousehack_set_host_cursor_uses_hotspot(true, residual_x, residual_y);
 		wincursor_shown = 1;
 	} else {
 		clear_host_cursor_hotspot_compensation();
@@ -2406,7 +2473,7 @@ end:
 	return ret;
 
 exit:
-	destroy_p96_host_cursor(true);
+	destroy_p96_host_cursor();
 
 	return ret;
 #else
@@ -2592,7 +2659,8 @@ int picasso_setwincursor(int monid)
 #ifdef AMIBERRY
 	if (p96_cursor) {
 		SDL_SetCursor(p96_cursor);
-		input_mousehack_set_host_cursor_uses_hotspot(tmp_sprite_chipset != 0,
+		SDL_ShowCursor();
+		input_mousehack_set_host_cursor_uses_hotspot(true,
 			tmp_sprite_residual_x, tmp_sprite_residual_y);
 		return 1;
 	} else if (!ad->picasso_on) {
@@ -2627,6 +2695,10 @@ static uae_u32 setspriteimage(TrapContext *ctx, uaecptr bi)
 	bpp = 4;
 	w = trap_get_byte(ctx, bi + PSSO_BoardInfo_MouseWidth);
 	h = trap_get_byte(ctx, bi + PSSO_BoardInfo_MouseHeight);
+	// P96 declares these BoardInfo fields as UBYTE. Some versions leave them
+	// zero, in which case the live pointer-to-sprite tracker supplies the hotspot.
+	cursorxoffset = trap_get_byte(ctx, bi + PSSO_BoardInfo_MouseXOffset);
+	cursoryoffset = trap_get_byte(ctx, bi + PSSO_BoardInfo_MouseYOffset);
 	flags = trap_get_long(ctx, bi + PSSO_BoardInfo_Flags);
 	hiressprite = 1;
 	doubledsprite = 0;

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -206,6 +206,8 @@ static amiberry_input_cursor_hotspot_tracker_cache native_cursor_hotspot_tracker
 static amiberry_input_cursor_hotspot_tracker p96_cursor_hotspot_tracker;
 static int p96_cursor_tracker_width = -1;
 static int p96_cursor_tracker_height = -1;
+static int p96_cursor_tracker_xoffset = -1;
+static int p96_cursor_tracker_yoffset = -1;
 
 static void reset_native_cursor_hotspot_tracker()
 {
@@ -217,6 +219,8 @@ static void reset_p96_cursor_hotspot_tracker()
 	amiberry_input_cursor_hotspot_tracker_reset(&p96_cursor_hotspot_tracker);
 	p96_cursor_tracker_width = -1;
 	p96_cursor_tracker_height = -1;
+	p96_cursor_tracker_xoffset = -1;
+	p96_cursor_tracker_yoffset = -1;
 }
 
 static void clear_host_cursor_hotspot_compensation()
@@ -2381,10 +2385,18 @@ static int createwindowscursor(int monid, int set, int chipset)
 		hotspot_x = amiberry_cursor_hotspot_from_offset(cursorxoffset, w);
 		hotspot_y = amiberry_cursor_hotspot_from_offset(cursoryoffset, h);
 
-		if (p96_cursor_tracker_width != w || p96_cursor_tracker_height != h) {
+		// A same-sized P96 cursor can use a different bitmap or declared hotspot.
+		// Discard the previous cursor's learned displacement before it can
+		// override the new cursor's BoardInfo offsets.
+		if (!cursor_cache_matches
+			|| p96_cursor_tracker_width != w || p96_cursor_tracker_height != h
+			|| p96_cursor_tracker_xoffset != cursorxoffset
+			|| p96_cursor_tracker_yoffset != cursoryoffset) {
 			amiberry_input_cursor_hotspot_tracker_reset(&p96_cursor_hotspot_tracker);
 			p96_cursor_tracker_width = w;
 			p96_cursor_tracker_height = h;
+			p96_cursor_tracker_xoffset = cursorxoffset;
+			p96_cursor_tracker_yoffset = cursoryoffset;
 		}
 
 		if (amiberry_input_cursor_hotspot_tracker_sample(&p96_cursor_hotspot_tracker,

--- a/src/osdep/picasso96.h
+++ b/src/osdep/picasso96.h
@@ -652,6 +652,7 @@ extern struct picasso96_state_struct picasso96_state[MAX_AMIGAMONITORS];
 extern void picasso_enablescreen(int monid, int on);
 extern void picasso_refresh(int monid);
 extern void init_hz_p96(int monid);
+extern void picasso_update_native_cursor(int monid);
 extern void picasso_handle_vsync();
 extern void picasso_trigger_vblank();
 extern bool picasso_is_active(int monid);

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -71,6 +71,18 @@ static void test_rgba32_cursor_pixels_use_raw_rgb_order()
 		"pure blue must not become red in RGBA32 cursor memory");
 }
 
+static void test_rtg_cursor_hotspot_uses_pointer_offset()
+{
+	expect_int_eq(amiberry_cursor_hotspot_from_offset(25, 51), 25,
+		"centered P96 cursor x offset must become the SDL hotspot");
+	expect_int_eq(amiberry_cursor_hotspot_from_offset(30, 61), 30,
+		"centered P96 cursor y offset must become the SDL hotspot");
+	expect_int_eq(amiberry_cursor_hotspot_from_offset(-4, 16), 0,
+		"negative P96 cursor offset must clamp to the first pixel");
+	expect_int_eq(amiberry_cursor_hotspot_from_offset(80, 16), 15,
+		"oversized P96 cursor offset must clamp to the last pixel");
+}
+
 static void test_host_only_forces_separate_rtg_sprite()
 {
 	const int host_only = 2;
@@ -169,7 +181,37 @@ static void test_native_sprite_position_decoding()
 		"ECS sprite y must include the extended high bit");
 }
 
-static void test_native_cursor_hotspot_learning_requires_stationary_samples()
+static void test_native_cursor_height_requires_sscan2()
+{
+	expect_int_eq(amiberry_input_native_cursor_height(27, false, false), 27,
+		"normal native cursor height must remain unchanged");
+	expect_int_eq(amiberry_input_native_cursor_height(27, true, false), 27,
+		"vertical position bit 7 must not squash the cursor when SSCAN2 is disabled");
+	expect_int_eq(amiberry_input_native_cursor_height(27, true, true), 13,
+		"active SSCAN2 must halve the extracted cursor data height");
+}
+
+static void test_native_mousehack_compensates_cropped_screen_origin()
+{
+	expect_int_eq(amiberry_input_native_mousehack_origin_compensation(258, 204), 54,
+		"native mousehack must compensate the cropped horizontal screen origin");
+	expect_int_eq(amiberry_input_native_mousehack_origin_compensation(88, 90), -2,
+		"native mousehack must compensate the cropped vertical screen origin");
+	expect_int_eq(amiberry_input_native_mousehack_origin_compensation(128, 128), 0,
+		"matching native and guest origins must not move the pointer");
+}
+
+static void test_native_mousehack_normalizes_interlace_field_origin()
+{
+	expect_int_eq(amiberry_input_native_interlace_origin(38, true, false, 2), 38,
+		"short interlace field must retain the native source origin");
+	expect_int_eq(amiberry_input_native_interlace_origin(40, true, true, 2), 38,
+		"long interlace field must normalize to the short-field source origin");
+	expect_int_eq(amiberry_input_native_interlace_origin(40, false, true, 2), 40,
+		"non-interlaced display must ignore the field flag");
+}
+
+static void test_native_cursor_hotspot_learning_accepts_moving_samples()
 {
 	amiberry_input_cursor_hotspot_tracker tracker;
 	int hotspot_x = -1;
@@ -180,15 +222,57 @@ static void test_native_cursor_hotspot_learning_requires_stationary_samples()
 		"first hotspot sample must not be trusted immediately");
 	expect_true(!amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
 		304, 224, 279, 194, 51, 61, 3, &hotspot_x, &hotspot_y),
-		"matching pointer and sprite movement must not count as stationary");
-	expect_true(!amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
-		304, 224, 279, 194, 51, 61, 3, &hotspot_x, &hotspot_y),
-		"second stationary sample must still wait for confirmation");
+		"second matching hotspot sample must still wait for confirmation");
 	expect_true(amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
-		304, 224, 279, 194, 51, 61, 3, &hotspot_x, &hotspot_y),
-		"third stationary sample must learn the hotspot");
+		308, 228, 283, 198, 51, 61, 3, &hotspot_x, &hotspot_y),
+		"matching pointer and sprite movement must allow the hotspot to be learned");
 	expect_int_eq(hotspot_x, 25, "learned cross cursor hotspot x must use the live sprite displacement");
 	expect_int_eq(hotspot_y, 30, "learned cross cursor hotspot y must use the live sprite displacement");
+}
+
+static void test_native_cursor_hotspot_uses_hires_y_units()
+{
+	amiberry_input_cursor_hotspot_tracker tracker;
+	int hotspot_x = -1;
+	int hotspot_y = -1;
+
+	for (int i = 0; i < 3; i++) {
+		amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+			400 + i * 2, 300 + i * 2, 384 + i * 2, 286 + i * 2,
+			32, 54, 3, &hotspot_x, &hotspot_y);
+	}
+	expect_int_eq(hotspot_x, 16,
+		"doubled native cursor x hotspot must stay in hires pixel units");
+	expect_int_eq(hotspot_y, 14,
+		"doubled native cursor y hotspot must stay in hires pixel units");
+}
+
+static void test_native_cursor_hotspot_cache_keeps_interleaved_sizes()
+{
+	amiberry_input_cursor_hotspot_tracker_cache cache;
+	int hotspot_x = -1;
+	int hotspot_y = -1;
+
+	for (int i = 0; i < 3; i++) {
+		auto* tall = amiberry_input_cursor_hotspot_tracker_cache_acquire(&cache, 32, 54);
+		amiberry_input_cursor_hotspot_tracker_sample(tall, true,
+			400 + i * 2, 300 + i * 2, 384 + i * 2, 286 + i * 2,
+			32, 54, 3, &hotspot_x, &hotspot_y);
+
+		auto* short_cursor = amiberry_input_cursor_hotspot_tracker_cache_acquire(&cache, 32, 26);
+		amiberry_input_cursor_hotspot_tracker_sample(short_cursor, true,
+			500 + i * 2, 200 + i * 2, 484 + i * 2, 188 + i * 2,
+			32, 26, 3, &hotspot_x, &hotspot_y);
+	}
+
+	auto* tall = amiberry_input_cursor_hotspot_tracker_cache_acquire(&cache, 32, 54);
+	auto* short_cursor = amiberry_input_cursor_hotspot_tracker_cache_acquire(&cache, 32, 26);
+	expect_true(tall->learned, "interleaved tall cursor must retain its hotspot samples");
+	expect_int_eq(tall->hotspot_x, 16, "interleaved tall cursor hotspot x must be retained");
+	expect_int_eq(tall->hotspot_y, 14, "interleaved tall cursor hotspot y must be retained");
+	expect_true(short_cursor->learned, "interleaved short cursor must retain its hotspot samples");
+	expect_int_eq(short_cursor->hotspot_x, 16, "interleaved short cursor hotspot x must be retained");
+	expect_int_eq(short_cursor->hotspot_y, 12, "interleaved short cursor hotspot y must be retained");
 }
 
 static void test_native_cursor_hotspot_learning_keeps_last_valid_result()
@@ -214,17 +298,43 @@ static void test_native_cursor_hotspot_learning_keeps_last_valid_result()
 	expect_true(!tracker.learned, "reset must discard a hotspot learned for old cursor dimensions");
 }
 
+static void test_native_crosshair_hotspot_snaps_to_bitmap_intersection()
+{
+	int hotspot_x = -1;
+	int hotspot_y = -1;
+	expect_true(amiberry_input_cursor_snap_hotspot_to_dense_crossing(
+		17, 14, 14, 14, 3, &hotspot_x, &hotspot_y),
+		"native hotspot near a dense crossing must snap to the visual intersection");
+	expect_int_eq(hotspot_x, 14, "crosshair hotspot x must use the decoded intersection");
+	expect_int_eq(hotspot_y, 14, "crosshair hotspot y must use the decoded intersection");
+
+	hotspot_x = 1;
+	hotspot_y = 0;
+	expect_true(!amiberry_input_cursor_snap_hotspot_to_dense_crossing(
+		1, 0, 8, 8, 3, &hotspot_x, &hotspot_y),
+		"arrow hotspot far from a dense crossing must not be changed");
+	expect_int_eq(hotspot_x, 1, "unrelated arrow hotspot x must remain unchanged");
+	expect_int_eq(hotspot_y, 0, "unrelated arrow hotspot y must remain unchanged");
+}
+
 int main()
 {
 	test_rgb12_expands_to_rgb24();
 	test_rgba32_cursor_pixels_are_opaque();
 	test_rgba32_cursor_pixels_use_raw_rgb_order();
+	test_rtg_cursor_hotspot_uses_pointer_offset();
 	test_host_only_forces_separate_rtg_sprite();
 	test_rtg_cursor_keeps_softsprite_fallback_disabled();
 	test_native_axis_clamp_uses_native_extent();
 	test_mousehack_hotspot_matches_pointer_offset();
 	test_native_sprite_position_decoding();
-	test_native_cursor_hotspot_learning_requires_stationary_samples();
+	test_native_cursor_height_requires_sscan2();
+	test_native_mousehack_compensates_cropped_screen_origin();
+	test_native_mousehack_normalizes_interlace_field_origin();
+	test_native_cursor_hotspot_learning_accepts_moving_samples();
+	test_native_cursor_hotspot_uses_hires_y_units();
+	test_native_cursor_hotspot_cache_keeps_interleaved_sizes();
 	test_native_cursor_hotspot_learning_keeps_last_valid_result();
+	test_native_crosshair_hotspot_snaps_to_bitmap_intersection();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -2,8 +2,10 @@
 #include <cstring>
 #include <iostream>
 
+typedef std::uint8_t uae_u8;
 typedef std::uint16_t uae_u16;
 typedef std::uint32_t uae_u32;
+typedef std::uint64_t uae_u64;
 
 #include "amiberry_cursor.h"
 #include "amiberry_input_helpers.h"
@@ -252,27 +254,78 @@ static void test_native_cursor_hotspot_cache_keeps_interleaved_sizes()
 	amiberry_input_cursor_hotspot_tracker_cache cache;
 	int hotspot_x = -1;
 	int hotspot_y = -1;
+	const uae_u64 tall_signature = 0x12345678;
+	const uae_u64 short_signature = 0x87654321;
 
 	for (int i = 0; i < 3; i++) {
-		auto* tall = amiberry_input_cursor_hotspot_tracker_cache_acquire(&cache, 32, 54);
+		auto* tall = amiberry_input_cursor_hotspot_tracker_cache_acquire(
+			&cache, 32, 54, tall_signature);
 		amiberry_input_cursor_hotspot_tracker_sample(tall, true,
 			400 + i * 2, 300 + i * 2, 384 + i * 2, 286 + i * 2,
 			32, 54, 3, &hotspot_x, &hotspot_y);
 
-		auto* short_cursor = amiberry_input_cursor_hotspot_tracker_cache_acquire(&cache, 32, 26);
+		auto* short_cursor = amiberry_input_cursor_hotspot_tracker_cache_acquire(
+			&cache, 32, 26, short_signature);
 		amiberry_input_cursor_hotspot_tracker_sample(short_cursor, true,
 			500 + i * 2, 200 + i * 2, 484 + i * 2, 188 + i * 2,
 			32, 26, 3, &hotspot_x, &hotspot_y);
 	}
 
-	auto* tall = amiberry_input_cursor_hotspot_tracker_cache_acquire(&cache, 32, 54);
-	auto* short_cursor = amiberry_input_cursor_hotspot_tracker_cache_acquire(&cache, 32, 26);
+	auto* tall = amiberry_input_cursor_hotspot_tracker_cache_acquire(
+		&cache, 32, 54, tall_signature);
+	auto* short_cursor = amiberry_input_cursor_hotspot_tracker_cache_acquire(
+		&cache, 32, 26, short_signature);
 	expect_true(tall->learned, "interleaved tall cursor must retain its hotspot samples");
 	expect_int_eq(tall->hotspot_x, 16, "interleaved tall cursor hotspot x must be retained");
 	expect_int_eq(tall->hotspot_y, 14, "interleaved tall cursor hotspot y must be retained");
 	expect_true(short_cursor->learned, "interleaved short cursor must retain its hotspot samples");
 	expect_int_eq(short_cursor->hotspot_x, 16, "interleaved short cursor hotspot x must be retained");
 	expect_int_eq(short_cursor->hotspot_y, 12, "interleaved short cursor hotspot y must be retained");
+}
+
+static void test_native_cursor_hotspot_cache_separates_same_size_bitmaps()
+{
+	amiberry_input_cursor_hotspot_tracker_cache cache;
+	int hotspot_x = -1;
+	int hotspot_y = -1;
+	const uae_u64 arrow_signature = 0x11111111;
+	const uae_u64 crosshair_signature = 0x22222222;
+
+	for (int i = 0; i < 3; i++) {
+		auto* arrow = amiberry_input_cursor_hotspot_tracker_cache_acquire(
+			&cache, 32, 32, arrow_signature);
+		amiberry_input_cursor_hotspot_tracker_sample(arrow, true,
+			200 + i, 160 + i, 199 + i, 158 + i,
+			32, 32, 3, &hotspot_x, &hotspot_y);
+	}
+
+	auto* crosshair = amiberry_input_cursor_hotspot_tracker_cache_acquire(
+		&cache, 32, 32, crosshair_signature);
+	expect_true(!crosshair->learned,
+		"same-sized cursor bitmap must not inherit a previously learned hotspot");
+
+	auto* arrow = amiberry_input_cursor_hotspot_tracker_cache_acquire(
+		&cache, 32, 32, arrow_signature);
+	expect_true(arrow->learned, "original same-sized bitmap must retain its own hotspot");
+	expect_int_eq(arrow->hotspot_x, 1, "original same-sized bitmap hotspot x must be retained");
+	expect_int_eq(arrow->hotspot_y, 2, "original same-sized bitmap hotspot y must be retained");
+}
+
+static void test_native_cursor_bitmap_signature_includes_pixels_and_colors()
+{
+	const uae_u8 arrow[] = { 0, 1, 1, 0 };
+	const uae_u8 crosshair[] = { 1, 0, 0, 1 };
+	const uae_u32 colors[] = { 0, 0xffffff, 0x555555, 0xaaaaaa };
+	const uae_u32 changed_colors[] = { 0, 0xff0000, 0x555555, 0xaaaaaa };
+
+	const uae_u64 arrow_signature = amiberry_input_cursor_bitmap_signature(
+		arrow, sizeof arrow, colors, 4);
+	expect_true(arrow_signature != amiberry_input_cursor_bitmap_signature(
+		crosshair, sizeof crosshair, colors, 4),
+		"same-sized cursor bitmaps must have distinct cache signatures");
+	expect_true(arrow_signature != amiberry_input_cursor_bitmap_signature(
+		arrow, sizeof arrow, changed_colors, 4),
+		"cursor color changes must have distinct cache signatures");
 }
 
 static void test_native_cursor_hotspot_learning_keeps_last_valid_result()
@@ -334,6 +387,8 @@ int main()
 	test_native_cursor_hotspot_learning_accepts_moving_samples();
 	test_native_cursor_hotspot_uses_hires_y_units();
 	test_native_cursor_hotspot_cache_keeps_interleaved_sizes();
+	test_native_cursor_hotspot_cache_separates_same_size_bitmaps();
+	test_native_cursor_bitmap_signature_includes_pixels_and_colors();
 	test_native_cursor_hotspot_learning_keeps_last_valid_result();
 	test_native_crosshair_hotspot_snaps_to_bitmap_intersection();
 	return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

- honor declared P96 cursor hotspots and learn live pointer-to-sprite displacement when applications leave them unset
- align native absolute mouse coordinates with the raw auto-cropped Amiga source origin
- normalize interlaced field origins and gate native cursor height changes on `FMODE.SSCAN2`
- refresh native and P96 host cursors continuously while retaining learned hotspots across cursor sizes
- add focused coverage for hotspot tracking, source-origin compensation, interlace normalization, and sprite-height handling

## Root cause

Host-only cursor creation assumed top-left or creation-time hotspots, while native input mixed renderer presentation offsets with Amiga source coordinates. Native sprite extraction also treated `SPRxPOS` bit 7 as double-scan unconditionally, and interlaced long fields shifted the raw source Y origin by one field line.

## Manual verification

Personal Paint was checked with host-only cursors in:

- P96 mode
- PAL LowRes (320x256)
- PAL LowRes Laced (320x512)
- PAL HighRes Laced (640x512), including straight horizontal dragging without vertical jitter

## Automated verification

- `bash tests/test_cursor_pixel_format.sh`
- `cmake --build cmake-build-debug --parallel`
- clean standalone macOS libretro build and link

Refs #2135
