### PR TITLE
Fix LSI DMA crash without queued request

### DIFF
--- a/src/qemuvga/lsi53c710.cpp
+++ b/src/qemuvga/lsi53c710.cpp
@@ -500,8 +500,7 @@ static void lsi_do_dma(LSIState710 *s, int out)
     dma_addr_t addr;
     SCSIDevice *dev;
 
-    assert(s->current);
-    if (!s->current->dma_len) {
+    if (!s->current || !s->current->dma_len) {
         /* Wait until data is available.  */
         DPRINTF("DMA no data available\n");
         return;

--- a/src/qemuvga/lsi53c895a.cpp
+++ b/src/qemuvga/lsi53c895a.cpp
@@ -547,8 +547,7 @@ static void lsi_do_dma(LSIState *s, int out)
     dma_addr_t addr;
     SCSIDevice *dev;
 
-    assert(s->current);
-    if (!s->current->dma_len) {
+    if (!s->current || !s->current->dma_len) {
         /* Wait until data is available.  */
         DPRINTF("DMA no data available\n");
         return;


### PR DESCRIPTION
## Summary

- wait when an LSI DMA operation starts before a SCSI request has queued data
- apply the safeguard to both the NCR 53C710 and 53C895A implementations
- prevent debug assertions and release-build null dereferences from guest SCRIPTS

Closes #2170.

## Root cause

`lsi_do_dma()` asserted that `s->current` was always present before checking
whether DMA data was available. Guest-controlled SCRIPTS can enter a data phase
without a current request, so Debug builds aborted and Release builds
dereferenced a null request.

This ports the behavior from QEMU commit
[`4051a1f062c9`](https://github.com/qemu/qemu/commit/4051a1f062c9b336343e22efa291ed15d235cd4f): treat a missing request like other
temporarily unavailable DMA data and wait for data to be queued.

The attached issue reproducer also programs its DSP address with reversed byte
significance, but malformed guest SCRIPTS must not be able to crash the host.

## Validation

- built the macOS Debug target with `cmake --build build --parallel 14`
- reproduced the pre-fix assertion at `lsi53c710.cpp:503` using the issue package
  with `-G`
- reran the package with its live HDF: Amiberry remained alive at the DMA wait
- reran with the HDF absent: Amiberry remained alive without an assertion
- corrected the reproducer's DSP value to its intended `$001EEA32`: bare SELECT
  and SIR variants completed without a crash
- `git diff --check`
- `ctest --test-dir build --output-on-failure` (no tests are currently defined)
