### PR TITLE
fix(android): sync SDL Java shim with 3.4.12

### DIFF
--- a/.agents/skills/troubleshoot-amiberry/SKILL.md
+++ b/.agents/skills/troubleshoot-amiberry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: troubleshoot-amiberry
-description: Use when investigating, reproducing, or fixing Amiberry bugs, especially renderer or input regressions, RTG/Picasso96 pixel-format or presentation bugs, HiDPI or SDL3 logical-presentation bugs, Vulkan capability or swapchain failures, libretro headless stub or link regressions, MHI/audio playback regressions, threaded device shutdown hangs, OS4 filesystem packet fallback issues, PPC/QEMU runtime performance regressions, crash regressions, or behavior regressions. Follow an edit-build-run-test-fix cycle, using Amiberry MCP runtime-control tools when they are configured and falling back to normal process, log, screenshot, and debugger tools otherwise.
+description: Use when investigating, reproducing, or fixing Amiberry bugs, especially renderer or input regressions, RTG/Picasso96 pixel-format or presentation bugs, HiDPI or SDL3 logical-presentation bugs, Android SDL Java/JNI version mismatches, Vulkan capability or swapchain failures, libretro headless stub or link regressions, MHI/audio playback regressions, threaded device shutdown hangs, OS4 filesystem packet fallback issues, PPC/QEMU runtime performance regressions, crash regressions, or behavior regressions. Follow an edit-build-run-test-fix cycle, using Amiberry MCP runtime-control tools when they are configured and falling back to normal process, log, screenshot, and debugger tools otherwise.
 ---
 
 # Amiberry Autonomous Troubleshooting
@@ -95,6 +95,7 @@ Read one of these references when the bug matches its trigger. Do not load all r
 | [references/threaded-device-shutdown.md](references/threaded-device-shutdown.md) | Shutdown hangs, joinable worker threads, PCAP/uaenet teardown, or PCem Voodoo FIFO/render thread bugs |
 | [references/os4-filesystem-packets.md](references/os4-filesystem-packets.md) | OS4 filesystem packet compatibility, `filesys.cpp`, `ACTION_EXAMINEDATA*`, or unknown DOS packet fallback bugs |
 | [references/ppc-qemu-runtime.md](references/ppc-qemu-runtime.md) | QEMU-UAE PPC runtime behavior, plugin JIT flush, spinlock, execute-loop, or PPC slowdown bugs |
+| [references/android-sdl-shim.md](references/android-sdl-shim.md) | Android SDL updates, C/Java version mismatch, JNI shim drift, or changes under `org/libsdl/app` |
 
 ### Phase 2: Reproduce
 

--- a/.agents/skills/troubleshoot-amiberry/references/android-sdl-shim.md
+++ b/.agents/skills/troubleshoot-amiberry/references/android-sdl-shim.md
@@ -1,0 +1,27 @@
+# Android SDL Java/JNI Shim Synchronization
+
+Android builds native SDL from the tag pinned in `cmake/Dependencies.cmake`, while Amiberry checks SDL's Java glue into `android/app/src/main/java/org/libsdl/app/`. SDL validates these halves at runtime. If their versions differ, launching the emulator GUI reports `SDL C/Java version mismatch`.
+
+## Updating SDL
+
+1. Read the old and new `sdl3` `GIT_TAG` values in `cmake/Dependencies.cmake`.
+2. Obtain both upstream SDL tags with the authenticated `gh` CLI.
+3. Diff `android-project/app/src/main/java/org/libsdl/app` between those tags. Inspect version constants, JNI signatures, and behavioral fixes.
+4. Review every upstream Java delta and port the applicable changes into Amiberry's checked-in sources in the same change as the native tag bump. Version constants and JNI contract changes are mandatory.
+5. Preserve Amiberry-specific Java changes, especially physical mouse transitions, pen device types, Android Back handling, test visibility, and other input fixes. Do not replace the whole directory blindly.
+6. Update `SDLActivity`'s `SDL_MAJOR_VERSION`, `SDL_MINOR_VERSION`, and `SDL_MICRO_VERSION` to match the fetched tag.
+7. Update `SDLJavaShimSignatureTest` for any JNI contract changes. Keep its version assertion derived from the `sdl3` tag in `Dependencies.cmake`; do not hard-code the expected SDL version in the test.
+
+Do not trust an existing `android/app/.cxx/**/_deps/sdl3-src` checkout until Gradle/CMake has reconfigured it. Those directories can retain a previous FetchContent tag.
+
+## Verification
+
+Run the focused Java/JNI contract test, then build the complete APK for both configured ABIs:
+
+```bash
+cd android
+./gradlew :app:testDebugUnitTest --tests com.blitterstudio.amiberry.ui.SDLJavaShimSignatureTest
+./gradlew :app:assembleDebug
+```
+
+On an Android device, launch **Advanced Options** and confirm that SDL starts without a C/Java version mismatch. Treat the native SDL tag and checked-in Java glue as one atomic dependency update.

--- a/android/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -56,7 +56,7 @@ class HIDDeviceUSB implements HIDDevice {
             try {
                 result = mDevice.getSerialNumber();
             }
-            catch (SecurityException exception) {
+            catch (Exception exception) {
                 //Log.w(TAG, "App permissions mean we cannot get serial number for device " + getDeviceName() + " message: " + exception.getMessage());
             }
         }

--- a/android/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -61,7 +61,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     private static final String TAG = "SDL";
     private static final int SDL_MAJOR_VERSION = 3;
     private static final int SDL_MINOR_VERSION = 4;
-    private static final int SDL_MICRO_VERSION = 10;
+    private static final int SDL_MICRO_VERSION = 12;
 /*
     // Display InputType.SOURCE/CLASS of events and devices
     //

--- a/android/app/src/main/java/org/libsdl/app/SDLSensorManager.java
+++ b/android/app/src/main/java/org/libsdl/app/SDLSensorManager.java
@@ -1,0 +1,73 @@
+package org.libsdl.app;
+
+import android.hardware.Sensor;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+import android.util.Log;
+
+// This class coordinates synchronized access to sensor manager registration
+//
+// This prevents a java.util.ConcurrentModificationException exception on
+// Android 16, specifically on the Samsung Tab S9 Ultra.
+
+class SDLSensorManager
+{
+    static private SDLSensorManager mManager = new SDLSensorManager();
+
+    static final int RETRY_COUNT = 3;
+
+    public static void registerListener(SensorManager manager, SensorEventListener listener, Sensor sensor, int samplingPeriodUs) {
+        mManager.RegisterListener(manager, listener, sensor, samplingPeriodUs);
+    }
+
+    public static void unregisterListener(SensorManager manager, SensorEventListener listener, Sensor sensor) {
+        mManager.UnregisterListener(manager, listener, sensor);
+    }
+
+    private synchronized void RegisterListener(SensorManager manager, SensorEventListener listener, Sensor sensor, int samplingPeriodUs) {
+        int retries = 0;
+        boolean complete = false;
+        while (!complete) {
+            try {
+                manager.registerListener(listener, sensor, samplingPeriodUs, null);
+                complete = true;
+            } catch (java.util.ConcurrentModificationException e) {
+                ++retries;
+                if (retries <= RETRY_COUNT) {
+                    // Sleep a bit and try again
+                    try {
+                        Thread.sleep(1);
+                    } catch (Exception e2) {
+                    }
+                } else {
+                    Log.v("SDL", "Multiple ConcurrentModificationException caught while registering sensor listener, canceling operation");
+                    complete = true;
+                }
+            }
+        }
+    }
+
+    private synchronized void UnregisterListener(SensorManager manager, SensorEventListener listener, Sensor sensor) {
+        int retries = 0;
+        boolean complete = false;
+        while (!complete) {
+            try {
+                manager.unregisterListener(listener, sensor);
+                complete = true;
+            } catch (java.util.ConcurrentModificationException e) {
+                ++retries;
+                if (retries <= RETRY_COUNT) {
+                    // Sleep a bit and try again
+                    try {
+                        Thread.sleep(1);
+                    } catch (Exception e2) {
+                    }
+                } else {
+                    Log.v("SDL", "Multiple ConcurrentModificationException caught while unregistering sensor listener, canceling operation");
+                    complete = true;
+                }
+            }
+        }
+    }
+}
+

--- a/android/app/src/main/java/org/libsdl/app/SDLSurface.java
+++ b/android/app/src/main/java/org/libsdl/app/SDLSurface.java
@@ -364,11 +364,11 @@ public class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
     public void enableSensor(int sensortype, boolean enabled) {
         // TODO: This uses getDefaultSensor - what if we have >1 accels?
         if (enabled) {
-            mSensorManager.registerListener(this,
+            SDLSensorManager.registerListener(mSensorManager, this,
                             mSensorManager.getDefaultSensor(sensortype),
-                            SensorManager.SENSOR_DELAY_GAME, null);
+                            SensorManager.SENSOR_DELAY_GAME);
         } else {
-            mSensorManager.unregisterListener(this,
+            SDLSensorManager.unregisterListener(mSensorManager, this,
                             mSensorManager.getDefaultSensor(sensortype));
         }
     }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
@@ -208,4 +208,32 @@ class AndroidRuntimeControlsArchitectureTest {
 			activity.contains("mMotionListener = new SDLGenericMotionListener_API29();")
 		)
 	}
+
+	@Test
+	fun `Android SDL Java shim includes SDL 3_4_12 reliability fixes`() {
+		val hidDeviceUsb = File("src/main/java/org/libsdl/app/HIDDeviceUSB.java").readText()
+		val surface = File("src/main/java/org/libsdl/app/SDLSurface.java").readText()
+		val sensorManager = File("src/main/java/org/libsdl/app/SDLSensorManager.java").readText()
+
+		assertTrue(
+			"USB serial lookup should tolerate every exception handled by SDL 3.4.12.",
+			hidDeviceUsb.contains("catch (Exception exception)")
+		)
+		assertFalse(
+			"USB serial lookup should not remain limited to SecurityException.",
+			hidDeviceUsb.contains("catch (SecurityException exception)")
+		)
+		assertTrue(
+			"SDLSurface should route sensor registration through SDL's synchronized retry wrapper.",
+			surface.contains("SDLSensorManager.registerListener(mSensorManager, this,") &&
+				surface.contains("SDLSensorManager.unregisterListener(mSensorManager, this,")
+		)
+		assertTrue(
+			"The SDL sensor wrapper should retry both registration paths after ConcurrentModificationException.",
+			sensorManager.contains("static final int RETRY_COUNT = 3;") &&
+				Regex("""catch \(java\.util\.ConcurrentModificationException e\)""")
+					.findAll(sensorManager)
+					.count() == 2
+		)
+	}
 }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/SDLJavaShimSignatureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/SDLJavaShimSignatureTest.kt
@@ -9,6 +9,7 @@ import org.libsdl.app.SDLAudioManager
 import org.libsdl.app.SDLActivity
 import org.libsdl.app.SDLControllerManager
 import org.libsdl.app.SDLInputConnection
+import java.io.File
 
 class SDLJavaShimSignatureTest {
 	@Test
@@ -19,10 +20,15 @@ class SDLJavaShimSignatureTest {
 	}
 
 	@Test
-	fun sdlActivityVersionMatchesVendoredSdl() {
-		assertEquals(3, SDLActivity::class.java.getPrivateInt("SDL_MAJOR_VERSION"))
-		assertEquals(4, SDLActivity::class.java.getPrivateInt("SDL_MINOR_VERSION"))
-		assertEquals(10, SDLActivity::class.java.getPrivateInt("SDL_MICRO_VERSION"))
+	fun sdlActivityVersionMatchesFetchedSdl() {
+		val dependencies = File("../../cmake/Dependencies.cmake").readText()
+		val version = Regex(
+			"""FetchContent_Declare\(\s*sdl3\b[\s\S]*?GIT_TAG\s+release-(\d+)\.(\d+)\.(\d+)"""
+		).find(dependencies) ?: error("Could not find the SDL3 release tag in cmake/Dependencies.cmake")
+
+		assertEquals(version.groupValues[1].toInt(), SDLActivity::class.java.getPrivateInt("SDL_MAJOR_VERSION"))
+		assertEquals(version.groupValues[2].toInt(), SDLActivity::class.java.getPrivateInt("SDL_MINOR_VERSION"))
+		assertEquals(version.groupValues[3].toInt(), SDLActivity::class.java.getPrivateInt("SDL_MICRO_VERSION"))
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- sync the checked-in SDL Java shim version with native SDL 3.4.12
- derive the Java shim regression test from the SDL FetchContent tag
- document the Android SDL Java/JNI lockstep workflow in the troubleshooting skill

## Root cause

Commit `c54a58326` updated the native SDL FetchContent tag from 3.4.10 to 3.4.12 without updating `SDLActivity`'s Java-side version constants. SDL rejected the mismatched halves when Advanced Options launched the emulator GUI.

## Validation

- `./gradlew :app:testDebugUnitTest --tests com.blitterstudio.amiberry.ui.SDLJavaShimSignatureTest`
- troubleshooting skill validation via `quick_validate.py`
- debug APK build reached successful Java and arm64 native compilation; the remaining x86_64 dependency checkout was canceled at the maintainer's request

Closes #2173
