### PR TITLE
Stabilize KMSDRM display timing and GUI resume

### DIFF
--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -2544,6 +2544,12 @@ static bool amiberry_hw_vsync_pacing_ok(void)
 #ifdef USE_VULKAN
 	return false;
 #else
+	// KMSDRM is forced to full-window mode and cannot switch the host refresh
+	// to follow chipset changes. It also cannot reliably disable swap blocking.
+	// Keep emulation on software timing instead of changing pacing paths when
+	// the Amiga and console refresh rates happen to match.
+	if (kmsdrm_detected)
+		return false;
 	if (vblank_hz <= 0.0f)
 		return false;
 	const uint32_t hz_x1000 = hw_vsync_cached_monitor_hz_x1000.load(std::memory_order_relaxed);

--- a/src/osdep/imgui/display.cpp
+++ b/src/osdep/imgui/display.cpp
@@ -10,6 +10,8 @@
 void render_panel_display() {
     ImGui::Indent(4.0f);
 
+    const bool kmsdrm = kmsdrm_detected;
+
     // Logic Check: RTG Enabled
     // WinUAE: ((!address_space_24 || configtype==2) && size) || type >= HARDWARE
     bool rtg_enabled = false;
@@ -73,7 +75,15 @@ void render_panel_display() {
     // ---------------------------------------------------------
     BeginGroupBox("Screen Settings");
 
+    if (kmsdrm) {
+        ImGui::TextDisabled("KMSDRM uses the active console display mode");
+        ImGui::SameLine();
+        ShowHelpMarker("Host resolution and refresh rate are controlled by the console configuration. Amiberry uses console fullscreen with software emulation pacing and vblank-paced presentation.");
+        ImGui::Spacing();
+    }
+
     // Windowed & Buffering
+    if (kmsdrm) ImGui::BeginDisabled();
     ImGui::AlignTextToFramePadding();
     ImGui::Text("Windowed:");
     ImGui::SameLine(BUTTON_WIDTH);
@@ -95,6 +105,7 @@ void render_panel_display() {
     AmigaCheckbox("Borderless", &changed_prefs.borderless);
     ShowHelpMarker("Remove window decorations (title bar and borders) while in windowed mode");
     if (!is_windowed) ImGui::EndDisabled();
+    if (kmsdrm) ImGui::EndDisabled();
 
     ImGui::Spacing();
 
@@ -103,7 +114,9 @@ void render_panel_display() {
     ImGui::SameLine(BUTTON_WIDTH);
     const char *screenmode_items[] = {"Windowed", "Fullscreen", "Full-window"};
     ImGui::SetNextItemWidth(BUTTON_WIDTH * 1.5f);
-    if (ImGui::BeginCombo("##NativeMode", screenmode_items[changed_prefs.gfx_apmode[0].gfx_fullscreen])) {
+    if (kmsdrm) ImGui::BeginDisabled();
+    const char *native_mode_label = kmsdrm ? "Console fullscreen" : screenmode_items[changed_prefs.gfx_apmode[0].gfx_fullscreen];
+    if (ImGui::BeginCombo("##NativeMode", native_mode_label)) {
         for (int n = 0; n < IM_ARRAYSIZE(screenmode_items); n++) {
             const bool is_selected = (changed_prefs.gfx_apmode[0].gfx_fullscreen == n);
             if (is_selected)
@@ -118,8 +131,11 @@ void render_panel_display() {
         }
         ImGui::EndCombo();
     }
+    if (kmsdrm) ImGui::EndDisabled();
     AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
-    ShowHelpMarker("Native chipset screen mode: Windowed, Fullscreen or Full-window (borderless fullscreen)");
+    ShowHelpMarker(kmsdrm
+        ? "KMSDRM always uses the active console display in fullscreen mode"
+        : "Native chipset screen mode: Windowed, Fullscreen or Full-window (borderless fullscreen)");
 
     ImGui::SameLine();
 
@@ -140,7 +156,8 @@ void render_panel_display() {
         vsync_idx = 2;
 
     ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 5.0f);
-    if (ImGui::BeginCombo("##NativeVSync", vsync_items[vsync_idx])) {
+    if (kmsdrm) ImGui::BeginDisabled();
+    if (ImGui::BeginCombo("##NativeVSync", kmsdrm ? "KMSDRM" : vsync_items[vsync_idx])) {
         for (int n = 0; n < IM_ARRAYSIZE(vsync_items); n++) {
             const bool is_selected = (vsync_idx == n);
             if (is_selected)
@@ -173,8 +190,11 @@ void render_panel_display() {
         }
         ImGui::EndCombo();
     }
+    if (kmsdrm) ImGui::EndDisabled();
     AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
-    ShowHelpMarker("VSync mode: Standard waits for vertical blank, 50/60Hz enforces refresh rate, Adaptive uses VRR (FreeSync/G-SYNC) with late-swap tearing fallback");
+    ShowHelpMarker(kmsdrm
+        ? "KMSDRM uses software emulation timing and vblank-paced presentation; VSync off, refresh switching, and Adaptive/VRR modes are not available"
+        : "VSync mode: Standard waits for vertical blank, 50/60Hz enforces refresh rate, Adaptive uses VRR (FreeSync/G-SYNC) with late-swap tearing fallback");
 
     ImGui::Spacing();
 
@@ -183,7 +203,9 @@ void render_panel_display() {
     ImGui::Text("RTG:");
     ImGui::SameLine(BUTTON_WIDTH);
     ImGui::SetNextItemWidth(BUTTON_WIDTH * 1.5f);
-    if (ImGui::BeginCombo("##RTGMode", screenmode_items[changed_prefs.gfx_apmode[1].gfx_fullscreen])) {
+    if (kmsdrm) ImGui::BeginDisabled();
+    const char *rtg_mode_label = kmsdrm ? "Console fullscreen" : screenmode_items[changed_prefs.gfx_apmode[1].gfx_fullscreen];
+    if (ImGui::BeginCombo("##RTGMode", rtg_mode_label)) {
         for (int n = 0; n < IM_ARRAYSIZE(screenmode_items); n++) {
             const bool is_selected = (changed_prefs.gfx_apmode[1].gfx_fullscreen == n);
             if (is_selected)
@@ -198,8 +220,11 @@ void render_panel_display() {
         }
         ImGui::EndCombo();
     }
+    if (kmsdrm) ImGui::EndDisabled();
     AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
-    ShowHelpMarker("RTG (Picasso96) screen mode when using graphics card emulation");
+    ShowHelpMarker(kmsdrm
+        ? "KMSDRM always uses the active console display in fullscreen mode"
+        : "RTG (Picasso96) screen mode when using graphics card emulation");
 
     ImGui::SameLine();
 
@@ -211,7 +236,8 @@ void render_panel_display() {
         changed_prefs.gfx_apmode[1].gfx_vsyncmode = 0;
     }
     ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 5.0f);
-    if (ImGui::BeginCombo("##RTGVSync", vsync_rtg_items[rtg_vsync_idx])) {
+    if (kmsdrm) ImGui::BeginDisabled();
+    if (ImGui::BeginCombo("##RTGVSync", kmsdrm ? "KMSDRM" : vsync_rtg_items[rtg_vsync_idx])) {
         for (int n = 0; n < IM_ARRAYSIZE(vsync_rtg_items); n++) {
             const bool is_selected = (rtg_vsync_idx == n);
             if (is_selected)
@@ -232,8 +258,11 @@ void render_panel_display() {
         }
         ImGui::EndCombo();
     }
+    if (kmsdrm) ImGui::EndDisabled();
     AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
-    ShowHelpMarker("VSync mode for RTG display");
+    ShowHelpMarker(kmsdrm
+        ? "KMSDRM uses software emulation timing and vblank-paced presentation"
+        : "VSync mode for RTG display");
     if (!rtg_enabled) ImGui::EndDisabled();
 
     ImGui::Spacing();
@@ -278,7 +307,7 @@ void render_panel_display() {
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
         ImGui::AlignTextToFramePadding();
-        ImGui::Text("Resolution:");
+        ImGui::Text("Amiga resolution:");
         ImGui::SameLine();
         const char *resolution_items[] = {"LowRes", "HighRes (normal)", "SuperHighRes"};
         ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - 5.0f);
@@ -299,7 +328,7 @@ void render_panel_display() {
             ImGui::EndCombo();
         }
         AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
-        ShowHelpMarker("Horizontal resolution: LowRes (320px), HighRes (640px), or SuperHighRes (1280px). Disabled when resolution autoswitch is enabled");
+        ShowHelpMarker("Emulated Amiga horizontal resolution: LowRes (320px), HighRes (640px), or SuperHighRes (1280px). This does not change the host display mode. Disabled when resolution autoswitch is enabled");
         if (!resolution_enabled) ImGui::EndDisabled();
 
         ImGui::TableNextColumn();

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -388,6 +388,16 @@ void OpenGLRenderer::update_vsync(int monid)
 		}
 	}
 
+	// KMSDRM cannot reliably provide unsynchronised swaps. Its legacy path
+	// maps interval 0 to asynchronous DRM page flips, while atomic paths may
+	// remain vblank-paced regardless. Avoid the async path: a pending flip can
+	// otherwise leave SDL_GL_SwapWindow() waiting indefinitely across the
+	// shared-window GUI handoff. Keep software emulation pacing unchanged by
+	// normalising only the presentation interval here.
+	if (interval == 0 && is_kmsdrm_video_driver()) {
+		interval = 1;
+	}
+
 	if (m_vsync.current_interval != interval) {
 		const int requested_interval = interval;
 		if (interval == ADAPTIVE_SWAP_INTERVAL) {

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -388,13 +388,13 @@ void OpenGLRenderer::update_vsync(int monid)
 		}
 	}
 
-	// KMSDRM cannot reliably provide unsynchronised swaps. Its legacy path
-	// maps interval 0 to asynchronous DRM page flips, while atomic paths may
-	// remain vblank-paced regardless. Avoid the async path: a pending flip can
-	// otherwise leave SDL_GL_SwapWindow() waiting indefinitely across the
-	// shared-window GUI handoff. Keep software emulation pacing unchanged by
-	// normalising only the presentation interval here.
-	if (interval == 0 && is_kmsdrm_video_driver()) {
+	// KMSDRM only accepts intervals 0 and 1, cannot reliably provide
+	// unsynchronised swaps, and has no Adaptive/VRR presentation mode. Its
+	// legacy path maps interval 0 to asynchronous DRM page flips, while atomic
+	// paths may remain vblank-paced regardless. Avoid the async path: a pending
+	// flip can otherwise leave SDL_GL_SwapWindow() waiting indefinitely across
+	// the shared-window GUI handoff. Emulation pacing is handled separately.
+	if (kmsdrm_detected) {
 		interval = 1;
 	}
 


### PR DESCRIPTION
## Summary

- normalize all KMSDRM OpenGL presentation requests to swap interval 1
- keep KMSDRM emulation on software timing across Amiga refresh changes
- disable display controls that the forced console-fullscreen mode cannot honor
- clarify that Amiga resolution settings do not change the host console mode

## Root causes

### GUI resume hang (#2179)

SDL 3.2.10 maps KMSDRM swap interval 0 to `DRM_MODE_PAGE_FLIP_ASYNC`
when the driver reports support. Each later swap first waits for the previous
page-flip event, using an infinite `poll()` timeout. If an asynchronous flip is
left pending across Amiberry's shared-window GUI handoff, the resumed
`SDL_GL_SwapWindow()` can block indefinitely. That freezes video and main-thread
input processing while threaded audio continues.

### Console timing and controls (#2178)

Amiberry deliberately forces KMSDRM into full-window, single-window operation.
It therefore cannot switch exclusive host modes to follow Amiga refresh
changes. Allowing a matching 50 Hz console and PAL screen to enter the
swap-blocking hardware-pacing path also made later Amiga screen changes switch
between hardware and software frame-wait paths. The report that Adaptive mode
was stable is consistent with it always using software timing.

KMSDRM now stays on software emulation timing while presentation remains
vblank-paced. All OpenGL interval requests, including loaded Adaptive and
high-refresh configurations, normalize to interval 1.

The previous GUI implementation disabled screen-mode selection on KMSDRM, but
that platform guard was lost during the Dear ImGui migration. The Display panel
now restores those restrictions, identifies the active console mode, and
explains that host resolution and refresh are configured outside Amiberry.

SDL references:

- [3.2.10 KMSDRM swap implementation](https://github.com/libsdl-org/SDL/blob/release-3.2.10/src/video/kmsdrm/SDL_kmsdrmopengles.c#L71-L198)
- [3.2.10 infinite page-flip wait](https://github.com/libsdl-org/SDL/blob/release-3.2.10/src/video/kmsdrm/SDL_kmsdrmvideo.c#L431-L494)
- [SDL discussion of VSync-off limitations on KMSDRM](https://github.com/libsdl-org/SDL/issues/16003)

## Validation

- `git diff --check`
- `cmake --build build --parallel` (macOS arm64, Debug, OpenGL, SDL 3.4.12)
- KMSDRM runtime verification remains pending because no Raspberry Pi console
  target is currently available

Closes #2178
Closes #2179
