### PR TITLE
fix(scsi): match SDMAC register behavior

### DIFF
--- a/src/a2091.cpp
+++ b/src/a2091.cpp
@@ -1603,9 +1603,18 @@ static void scsi_hsync(void)
 
 static int writeonlyreg (int reg)
 {
-	if (reg == WD_SCSI_STATUS)
+	if (reg == WD_SCSI_STATUS || reg == WD_AUXILIARY_STATUS)
 		return 1;
 	return 0;
+}
+
+static bool invalidreg (struct wd_chip_state *wd, int reg)
+{
+	// Registers after queue tag and before auxiliary status are undriven.
+	if (reg > WD_QUEUE_TAG && reg < WD_AUXILIARY_STATUS)
+		return true;
+	// queue tag is B revision only
+	return reg == WD_QUEUE_TAG && wd->wd33c93_ver < 2;
 }
 
 static void writewdreg (struct wd_chip_state *wd, int sasr, uae_u8 val)
@@ -1619,10 +1628,7 @@ static void writewdreg (struct wd_chip_state *wd, int sasr, uae_u8 val)
 			val &= ~0x20;
 		break;
 	}
-	if (sasr > WD_QUEUE_TAG && sasr < WD_AUXILIARY_STATUS)
-		return;
-	// queue tag is B revision only
-	if (sasr == WD_QUEUE_TAG && wd->wd33c93_ver < 2)
+	if (invalidreg(wd, sasr))
 		return;
 	wd->wdregs[sasr] = val;
 }
@@ -1699,7 +1705,7 @@ uae_u8 wdscsi_get (struct wd_chip_state *wd, struct wd_state *wds)
 	uae_u8 osasr = wd->sasr;
 #endif
 
-	v = wd->wdregs[wd->sasr];
+	v = invalidreg(wd, wd->sasr) ? 0xff : wd->wdregs[wd->sasr];
 	if (wd->sasr == WD_DATA) {
 		if (!wd->wd_data_avail) {
 			write_log (_T("%s WD_DATA READ without data request!? %08x\n"), WD33C93, M68K_GETPC);
@@ -3601,12 +3607,18 @@ static const addrbank gvp_bank = {
 
 /* SUPERDMAC (A3000 mainboard built-in) */
 
+static uae_u32 mbdmac_reg_address (uae_u32 addr)
+{
+	// The SDMAC register file is mirrored at +0x100.
+	return addr & 0xfeff;
+}
+
 static void mbdmac_write_word (struct wd_state *wd, uae_u32 addr, uae_u32 val)
 {
 #if A3000_DEBUG_IO > 1
 	write_log (_T("DMAC_WWRITE %08X=%04X PC=%08X\n"), addr, val & 0xffff, M68K_GETPC);
 #endif
-	addr &= 0xfffe;
+	addr = mbdmac_reg_address(addr) & 0xfffe;
 	switch (addr)
 	{
 	case 0x02:
@@ -3677,7 +3689,7 @@ static void mbdmac_write_byte (struct wd_state *wd, uae_u32 addr, uae_u32 val)
 #if A3000_DEBUG_IO > 1
 	write_log (_T("DMAC_BWRITE %08X=%02X PC=%08X\n"), addr, val & 0xff, M68K_GETPC);
 #endif
-	addr &= 0xffff;
+	addr = mbdmac_reg_address(addr);
 	switch (addr)
 	{
 
@@ -3712,7 +3724,7 @@ static uae_u32 mbdmac_read_word (struct wd_state *wd, uae_u32 addr)
 #endif
 	uae_u32 v = 0xffffffff;
 
-	addr &= 0xfffe;
+	addr = mbdmac_reg_address(addr) & 0xfffe;
 	switch (addr)
 	{
 	case 0x02:
@@ -3795,7 +3807,7 @@ static uae_u32 mbdmac_read_byte (struct wd_state *wd, uae_u32 addr)
 #endif
 	uae_u32 v = 0xffffffff;
 
-	addr &= 0xffff;
+	addr = mbdmac_reg_address(addr);
 	switch (addr)
 	{
 	case 0x41:
@@ -3853,7 +3865,7 @@ static uae_u32 REGPARAM2 mbdmac_bget (uaecptr addr)
 }
 static void REGPARAM2 mbdmac_lput (uaecptr addr, uae_u32 l)
 {
-	if ((addr & 0xffff) == 0x40) {
+	if (mbdmac_reg_address(addr) == 0x40) {
 		// long write to 0x40 = write byte to SASR
 		mbdmac_write_byte (wd_a3000, 0x41, l);
 	} else {

--- a/src/a2091.cpp
+++ b/src/a2091.cpp
@@ -3610,7 +3610,9 @@ static const addrbank gvp_bank = {
 static uae_u32 mbdmac_reg_address (uae_u32 addr)
 {
 	// The SDMAC register file is mirrored at +0x100.
-	return addr & 0xfeff;
+	addr &= 0xffff;
+	addr &= ~0x100u;
+	return addr;
 }
 
 static void mbdmac_write_word (struct wd_state *wd, uae_u32 addr, uae_u32 val)


### PR DESCRIPTION
## Summary

- mirror the Super DMAC register file at `$DD0100-$DD01FF` onto `$DD0000-$DD00FF`
- make undefined WD33C93 registers float high instead of exposing zero-filled backing storage
- keep WD33C93 Auxiliary Status explicitly read-only while preserving Queue Tag on B revisions

## Root cause

The `sdmac` diagnostic uses the Super DMAC's `+$100` register mirror to avoid the 68030 write-allocation cache bug. Amiberry only decoded the primary register addresses, so cache-safe writes to the mirror were ignored and the controller was misidentified.

The diagnostic also probes undefined WD33C93 register `$1E`. Real hardware leaves this register undriven, producing `$FF`, while Amiberry returned its zero-initialized register-array entry.

Together these mismatches caused the Ramsey, SDMAC, and WDC checks to fail before the reported Guru.

## Validation

- `cmake --build build --parallel` (macOS ARM64 Debug build)
- `git diff --check`

Fixes #2180
