### PR TITLE
Fix IPC debugger control after breakpoints

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -13,6 +13,9 @@
 
 #include <ctype.h>
 #include <signal.h>
+#ifdef AMIBERRY
+#include <atomic>
+#endif
 
 #include "options.h"
 #include "uae.h"
@@ -54,6 +57,9 @@
 #include "ini.h"
 #include "readcpu.h"
 #include "keybuf.h"
+#if defined(AMIBERRY) && defined(USE_IPC_SOCKET)
+#include "amiberry_ipc.h"
+#endif
 #ifdef WITH_SOFTFLOAT
 #include "softfloat/softfloat.h"
 #endif
@@ -86,6 +92,10 @@ static int last_hpos1, last_hpos2;
 static int last_vpos1, last_vpos2;
 static int last_frame = -1;
 static evt_t last_cycles1, last_cycles2;
+#ifdef AMIBERRY
+static std::atomic<bool> debugger_stopped{false};
+static std::atomic<bool> debugger_external_control_pending{false};
+#endif
 
 static uaecptr processptr;
 static uae_char *processname;
@@ -94,6 +104,36 @@ static uaecptr debug_copper_pc;
 
 extern int audio_channel_mask;
 extern int inputdevice_logging;
+
+#ifdef AMIBERRY
+bool debugger_is_stopped(void)
+{
+	return debugger_stopped.load(std::memory_order_acquire);
+}
+
+bool debugger_external_control_available(void)
+{
+#ifdef USE_IPC_SOCKET
+	return Amiberry::IPC::IPCIsActive();
+#else
+	return false;
+#endif
+}
+
+bool debugger_poll_external_control(void)
+{
+	if (debugger_external_control_pending.load(std::memory_order_acquire))
+		return true;
+#ifdef USE_IPC_SOCKET
+	Amiberry::IPC::IPCHandle();
+#endif
+	if (quit_program) {
+		debugger_stopped.store(false, std::memory_order_release);
+		return true;
+	}
+	return debugger_external_control_pending.load(std::memory_order_acquire);
+}
+#endif
 
 static void debug_cycles(int mode)
 {
@@ -105,6 +145,9 @@ static void debug_cycles(int mode)
 
 void deactivate_debugger (void)
 {
+#ifdef AMIBERRY
+	debugger_stopped.store(false, std::memory_order_release);
+#endif
 	inside_debugger = 0;
 	debugger_active = 0;
 	debugging = 0;
@@ -122,12 +165,19 @@ void activate_debugger (void)
 {
 	disasm_init();
 
-	if (!is_interactive_console() || isfullscreen() > 0) {
+	const bool local_debugger_available = is_interactive_console() && isfullscreen() <= 0;
+#ifdef AMIBERRY
+	const bool remote_debugger_available = debugger_external_control_available();
+#else
+	const bool remote_debugger_available = false;
+#endif
+	if (!local_debugger_available && !remote_debugger_available) {
 		return;
 	}
 
 	debugger_load_libraries();
-	open_console();
+	if (local_debugger_available)
+		open_console();
 
 	debugger_used = 1;
 	inside_debugger = 1;
@@ -164,6 +214,30 @@ static void debug_continue(void)
 {
 	set_special(SPCFLAG_BRK);
 }
+
+#ifdef AMIBERRY
+void debugger_breakpoints_changed(void)
+{
+	bool enabled = false;
+	for (int i = 0; i < BREAKPOINT_TOTAL; i++) {
+		if (bpnodes[i].enabled) {
+			enabled = true;
+			break;
+		}
+	}
+
+	if (enabled) {
+		if (!debugger_is_stopped() && trace_mode == 0) {
+			trace_mode = TRACE_CHECKONLY;
+			debugging = -1;
+			set_special(SPCFLAG_BRK);
+		}
+	} else if (!debugger_is_stopped() && trace_mode == TRACE_CHECKONLY) {
+		trace_mode = 0;
+		debugging = 0;
+	}
+}
+#endif
 
 bool debug_enforcer(void)
 {
@@ -6253,6 +6327,52 @@ static struct regstruct trace_prev_regs;
 #endif
 static uaecptr nextpc;
 
+#ifdef AMIBERRY
+bool debugger_request_step(const int count)
+{
+	if (!debugger_is_stopped() || count < 1 || count > 10000)
+		return false;
+
+	no_trace_exceptions = 0;
+	debug_cycles(2);
+	trace_param[0] = count;
+	trace_param[1] = 0;
+	trace_mode = TRACE_SKIP_INS;
+	exception_debugging = 1;
+	debugger_stopped.store(false, std::memory_order_relaxed);
+	debugger_external_control_pending.store(true, std::memory_order_release);
+	return true;
+}
+
+bool debugger_request_step_over(void)
+{
+	if (!debugger_is_stopped())
+		return false;
+
+	TCHAR disassembly[256];
+	uaecptr next_address = M68K_GETPC;
+	m68k_disasm_2(disassembly, sizeof(disassembly) / sizeof(TCHAR), next_address, nullptr, 0, &next_address, 1,
+		nullptr, nullptr, 0xffffffff, 0);
+	trace_mode = TRACE_MATCH_PC;
+	trace_param[0] = next_address;
+	exception_debugging = 1;
+	debug_cycles(2);
+	debugger_stopped.store(false, std::memory_order_relaxed);
+	debugger_external_control_pending.store(true, std::memory_order_release);
+	return true;
+}
+
+bool debugger_request_continue(void)
+{
+	if (!debugger_is_stopped())
+		return false;
+
+	deactivate_debugger();
+	debugger_external_control_pending.store(true, std::memory_order_release);
+	return true;
+}
+#endif
+
 static void check_breakpoint_extra(TCHAR **c, struct breakpoint_node *bpn)
 {
 	bpn->cnt = 0;
@@ -8059,29 +8179,46 @@ static TCHAR input[MAX_LINEWIDTH];
 static void debug_1 (void)
 {
 	draw_denise_line_queue_flush();
-	open_console();
+	if (is_interactive_console() && isfullscreen() <= 0)
+		open_console();
 	custom_dumpstate(0);
 	m68k_dumpstate(&nextpc, debug_pc);
 	debug_pc = 0xffffffff;
 	nxdis = nextpc; nxmem = 0;
 	debugger_active = 1;
+#ifdef AMIBERRY
+	debugger_external_control_pending.store(false, std::memory_order_relaxed);
+	debugger_stopped.store(true, std::memory_order_release);
+#endif
 
 	for (;;) {
 		int v;
 
-		if (!debugger_active)
+		if (!debugger_active) {
+#ifdef AMIBERRY
+			debugger_stopped.store(false, std::memory_order_release);
+#endif
 			return;
+		}
 		update_debug_info ();
 		console_out (_T(">"));
 		console_flush ();
 		debug_linecounter = 0;
 		v = console_get (input, MAX_LINEWIDTH);
-		if (v < 0)
+		if (v < 0) {
+#ifdef AMIBERRY
+			debugger_stopped.store(false, std::memory_order_release);
+#endif
 			return;
+		}
 		if (v == 0)
 			continue;
-		if (debug_line (input))
+		if (debug_line (input)) {
+#ifdef AMIBERRY
+			debugger_stopped.store(false, std::memory_order_release);
+#endif
 			return;
+		}
 	}
 }
 

--- a/src/include/debug.h
+++ b/src/include/debug.h
@@ -45,6 +45,15 @@ extern void activate_debugger(void);
 extern void activate_debugger_new(void);
 extern void activate_debugger_new_pc(uaecptr pc, int len);
 extern void deactivate_debugger (void);
+#ifdef AMIBERRY
+extern bool debugger_is_stopped(void);
+extern bool debugger_external_control_available(void);
+extern bool debugger_poll_external_control(void);
+extern bool debugger_request_step(int count);
+extern bool debugger_request_step_over(void);
+extern bool debugger_request_continue(void);
+extern void debugger_breakpoints_changed(void);
+#endif
 extern const TCHAR *debuginfo (int);
 extern void record_copper (uaecptr addr, uaecptr nextaddr, uae_u16 word1, uae_u16 word2, int hpos, int vpos);
 extern void record_copper_blitwait (uaecptr addr, int hpos, int vpos);

--- a/src/osdep/amiberry_ipc_socket.cpp
+++ b/src/osdep/amiberry_ipc_socket.cpp
@@ -32,6 +32,7 @@
 #include <cstring>
 #include <map>
 #include <algorithm>
+#include <mutex>
 
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -52,6 +53,7 @@ static int server_socket = -1;
 static std::string socket_path;
 static bool ipc_active = false;
 static bool ipc_quit_requested = false;
+static std::mutex ipc_handle_mutex;
 
 // Command handler type
 typedef std::function<std::string(const std::vector<std::string>&)> CommandHandler;
@@ -1932,6 +1934,7 @@ static std::string HandleDebugStatus(const std::vector<std::string>& args)
 
 	std::vector<std::string> responses;
 	responses.push_back("active=" + std::to_string(debugger_active ? 1 : 0));
+	responses.push_back("stopped=" + std::to_string(debugger_is_stopped() ? 1 : 0));
 	responses.push_back("debugging=" + std::to_string(debugging ? 1 : 0));
 	responses.push_back("exception_debugging=" + std::to_string(exception_debugging ? 1 : 0));
 
@@ -1942,24 +1945,43 @@ static std::string HandleDebugStep(const std::vector<std::string>& args)
 {
 	std::cout << "IPC: Received DEBUG_STEP" << std::endl;
 
-	if (!debugger_active) {
-		return make_response(false, {"Debugger not active - use DEBUG_ACTIVATE first"});
+	int count = 1;
+	if (!args.empty()) {
+		try {
+			count = std::stoi(args[0]);
+		} catch (...) {
+			return make_response(false, {"Invalid instruction count"});
+		}
+	}
+	if (count < 1 || count > 10000) {
+		return make_response(false, {"Instruction count must be 1-10000"});
+	}
+	if (!debugger_request_step(count)) {
+		return make_response(false, {"Debugger is not stopped"});
 	}
 
-	// Single step mode - execute one instruction
-	set_special(SPCFLAG_BRK);
-	return make_response(true, {"Single step executed"});
+	return make_response(true, {"Stepping " + std::to_string(count) + " instruction(s)"});
+}
+
+static std::string HandleDebugStepOver(const std::vector<std::string>& args)
+{
+	std::cout << "IPC: Received DEBUG_STEP_OVER" << std::endl;
+
+	if (!debugger_request_step_over()) {
+		return make_response(false, {"Debugger is not stopped"});
+	}
+
+	return make_response(true, {"Stepping over current instruction"});
 }
 
 static std::string HandleDebugContinue(const std::vector<std::string>& args)
 {
 	std::cout << "IPC: Received DEBUG_CONTINUE" << std::endl;
 
-	if (!debugger_active) {
-		return make_response(false, {"Debugger not active"});
+	if (!debugger_request_continue()) {
+		return make_response(false, {"Debugger is not stopped"});
 	}
 
-	deactivate_debugger();
 	return make_response(true, {"Execution continued"});
 }
 #endif
@@ -2079,8 +2101,11 @@ static std::string HandleDisassemble(const std::vector<std::string>& args)
 	// Use the disassembler
 	for (int i = 0; i < lines; i++) {
 		TCHAR buf[256];
-		addr = m68k_disasm_2(buf, sizeof(buf) / sizeof(TCHAR), addr, nullptr, 0xffffffff, nullptr, 1, nullptr, nullptr, 0, 1);
+		uaecptr next_addr = addr;
+		m68k_disasm_2(buf, sizeof(buf) / sizeof(TCHAR), addr, nullptr, 0, &next_addr, 1,
+			nullptr, nullptr, 0xffffffff, 0);
 		responses.emplace_back(buf);
+		addr = next_addr;
 	}
 #else
 	// Simple fallback - just show hex bytes
@@ -2140,9 +2165,15 @@ static std::string HandleSetBreakpoint(const std::vector<std::string>& args)
 
 	// Set the breakpoint
 	bpnodes[slot].value1 = addr;
+	bpnodes[slot].value2 = 0;
+	bpnodes[slot].mask = 0xffffffff;
 	bpnodes[slot].type = BREAKPOINT_REG_PC;
 	bpnodes[slot].oper = BREAKPOINT_CMP_EQUAL;
+	bpnodes[slot].opersigned = false;
+	bpnodes[slot].cnt = 0;
+	bpnodes[slot].chain = -1;
 	bpnodes[slot].enabled = 1;
+	debugger_breakpoints_changed();
 
 	char buf[64];
 	snprintf(buf, sizeof(buf), "Breakpoint set at %08X in slot %d", addr, slot);
@@ -2153,28 +2184,38 @@ static std::string HandleClearBreakpoint(const std::vector<std::string>& args)
 {
 	std::cout << "IPC: Received CLEAR_BREAKPOINT" << std::endl;
 
-	if (args.empty()) {
+	std::string selector = args.empty() ? "ALL" : args[0];
+	std::transform(selector.begin(), selector.end(), selector.begin(), ::toupper);
+	if (selector == "ALL") {
 		// Clear all breakpoints
 		for (int i = 0; i < BREAKPOINT_TOTAL; i++) {
 			bpnodes[i].enabled = 0;
 		}
+		debugger_breakpoints_changed();
 		return make_response(true, {"All breakpoints cleared"});
 	}
 
-	int slot;
+	uaecptr addr;
 	try {
-		slot = std::stoi(args[0]);
-		if (slot < 0 || slot >= BREAKPOINT_TOTAL) {
-			return make_response(false, {"Slot must be 0-" + std::to_string(BREAKPOINT_TOTAL - 1)});
-		}
+		addr = std::stoul(args[0], nullptr, 16);
 	} catch (...) {
-		return make_response(false, {"Invalid slot number"});
+		return make_response(false, {"Invalid address: " + args[0]});
 	}
 
-	bpnodes[slot].enabled = 0;
+	int cleared = 0;
+	for (int i = 0; i < BREAKPOINT_TOTAL; i++) {
+		if (bpnodes[i].enabled && bpnodes[i].type == BREAKPOINT_REG_PC && bpnodes[i].value1 == addr) {
+			bpnodes[i].enabled = 0;
+			cleared++;
+		}
+	}
+	if (cleared == 0) {
+		return make_response(false, {"No breakpoint at address " + args[0]});
+	}
+	debugger_breakpoints_changed();
 
 	char buf[64];
-	snprintf(buf, sizeof(buf), "Breakpoint %d cleared", slot);
+	snprintf(buf, sizeof(buf), "%d breakpoint(s) cleared at %08X", cleared, addr);
 	return make_response(true, {buf});
 }
 
@@ -2507,7 +2548,7 @@ static void InitHandlers()
 	command_handlers[CMD_DEBUG_DEACTIVATE] = HandleDebugDeactivate;
 	command_handlers[CMD_DEBUG_STATUS] = HandleDebugStatus;
 	command_handlers[CMD_DEBUG_STEP] = HandleDebugStep;
-	command_handlers[CMD_DEBUG_STEP_OVER] = HandleDebugStep;  // Same handler, step over logic handled internally
+	command_handlers[CMD_DEBUG_STEP_OVER] = HandleDebugStepOver;
 	command_handlers[CMD_DEBUG_CONTINUE] = HandleDebugContinue;
 	command_handlers[CMD_GET_CPU_REGS] = HandleGetCPURegs;
 	command_handlers[CMD_GET_CUSTOM_REGS] = HandleGetCustomRegs;
@@ -2817,6 +2858,9 @@ void Amiberry::IPC::IPCCleanUp()
 
 void Amiberry::IPC::IPCHandle()
 {
+	std::unique_lock<std::mutex> lock(ipc_handle_mutex, std::try_to_lock);
+	if (!lock.owns_lock()) return;
+
 	if (server_socket < 0) return;
 
 	// Check for incoming connections (non-blocking)

--- a/src/osdep/imgui_debugger_console.cpp
+++ b/src/osdep/imgui_debugger_console.cpp
@@ -591,6 +591,9 @@ int imgui_debugger_console_get(char* out, const int maxlen)
 		if (try_dequeue_line(out, maxlen, &len)) {
 			return len;
 		}
+		if (debugger_poll_external_control()) {
+			return -2;
+		}
 		if (should_exit_wait()) {
 			return -1;
 		}

--- a/src/osdep/macos_debugger_console.mm
+++ b/src/osdep/macos_debugger_console.mm
@@ -602,36 +602,25 @@ int macos_debugger_console_get(char* out, const int maxlen)
 		return -1;
 	}
 
-	if ([NSThread isMainThread]) {
-		for (;;) {
-			int len = 0;
-			if (try_dequeue_line(out, maxlen, &len)) {
-				return len;
-			}
-			if (debugger_console_should_exit_wait()) {
-				return -1;
-			}
+	for (;;) {
+		int len = 0;
+		if (try_dequeue_line(out, maxlen, &len)) {
+			return len;
+		}
+		if (debugger_poll_external_control()) {
+			return -2;
+		}
+		if (debugger_console_should_exit_wait()) {
+			return -1;
+		}
+
+		if ([NSThread isMainThread]) {
 			pump_debugger_window_events();
+		} else {
+			std::unique_lock<std::mutex> lock(debugger_console_mutex);
+			debugger_console_cv.wait_for(lock, std::chrono::milliseconds(50));
 		}
 	}
-
-	std::unique_lock<std::mutex> lock(debugger_console_mutex);
-	while (debugger_console_lines.empty() && !debugger_console_closed && debugger_active) {
-		debugger_console_cv.wait_for(lock, std::chrono::milliseconds(50));
-	}
-
-	if (debugger_console_lines.empty()) {
-		return -1;
-	}
-
-	std::string line = std::move(debugger_console_lines.front());
-	debugger_console_lines.pop_front();
-	lock.unlock();
-
-	const int len = std::min(maxlen - 1, static_cast<int>(line.size()));
-	std::memcpy(out, line.c_str(), len);
-	out[len] = 0;
-	return len;
 }
 
 #endif

--- a/src/osdep/writelog.cpp
+++ b/src/osdep/writelog.cpp
@@ -6,6 +6,7 @@
  * Copyright 2001 Bernd Schmidt
  */
 #include <cstdarg>
+#include <cerrno>
 #include <cstdio>
 #include <iostream>
 #include <clocale>
@@ -775,6 +776,51 @@ int console_get (TCHAR *out, int maxlen)
 		return debugger_window_get(out, maxlen);
 #endif
 	set_console_input_mode(1);
+#ifdef AMIBERRY
+	if (debugger_external_control_available()) {
+		while (debugger_active) {
+			if (debugger_poll_external_control())
+				return -2;
+
+#ifdef _WIN32
+			const HANDLE stdinput = GetStdHandle(STD_INPUT_HANDLE);
+			const DWORD wait_result = stdinput == INVALID_HANDLE_VALUE
+				? WAIT_FAILED : WaitForSingleObject(stdinput, 50);
+			if (wait_result != WAIT_OBJECT_0) {
+				Sleep(10);
+				continue;
+			}
+#else
+			struct pollfd pfd{};
+			pfd.fd = STDIN_FILENO;
+			pfd.events = POLLIN;
+			int result;
+			do {
+				result = poll(&pfd, 1, 50);
+			} while (result < 0 && errno == EINTR);
+			if (result <= 0 || !(pfd.revents & POLLIN)) {
+				if (result > 0 && (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)))
+					SDL_Delay(10);
+				continue;
+			}
+#endif
+
+			TCHAR *res = fgets(out, maxlen, stdin);
+			if (res == nullptr) {
+				clearerr(stdin);
+				SDL_Delay(10);
+				continue;
+			}
+			int len = strlen(out);
+			while (len > 0 && (out[len - 1] == '\r' || out[len - 1] == '\n')) {
+				out[len - 1] = 0;
+				len--;
+			}
+			return len;
+		}
+		return -1;
+	}
+#endif
 	TCHAR *res = fgets(out, maxlen, stdin);
 	if (res == nullptr) {
 		return -1;


### PR DESCRIPTION
## Summary

- Keep socket IPC responsive while execution is stopped in the terminal, ImGui, or Cocoa debugger console.
- Add an explicit stopped state plus working counted step, step-over, and continue operations.
- Initialize and arm IPC breakpoints correctly, and make CLEAR_BREAKPOINT honor address or ALL selectors.
- Fix sequential DISASSEMBLE output, serialize concurrent IPC polling, and let emulator quit escape a debugger stop.

## Root cause

The debugger blocks the emulation thread while waiting for local console input. Since the same thread normally services IPC, an MCP client could trigger a breakpoint but could not reliably send the command that resumes execution. Several adjacent IPC debugger handlers were also incomplete or mismatched with the exposed protocol: step-over was routed to ordinary step, new breakpoints were not fully initialized or armed while running, CLEAR_BREAKPOINT treated addresses as slot numbers, and DISASSEMBLE used flags as the next address.

## Validation

- Native macOS CMake build: cmake --build build --parallel
- Clean standalone libretro build: make -C libretro platform=osx ARCH=arm64 -j14
- A500 runtime IPC checks through tools/ipc_client.py in both terminal-backed and Cocoa debugger consoles
  - activate and inspect status/registers while stopped
  - counted DEBUG_STEP with PC advancement
  - DEBUG_STEP_OVER across a real BSR with stop at the sequential return address
  - set a breakpoint while running and stop at its PC
  - clear by address and with ALL
  - verify sequential disassembly addresses
  - continue and quit successfully while stopped
- git diff --check