### PR TITLE
Add RP9 package support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -75,6 +75,7 @@
                 <data android:pathPattern=".*\\.lzx" />
                 <data android:pathPattern=".*\\.lzh" />
                 <data android:pathPattern=".*\\.uae" />
+                <data android:pathPattern=".*\\.rp9" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -82,6 +83,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="content" />
                 <data android:mimeType="application/octet-stream" />
+                <data android:mimeType="application/vnd.cloanto.rp9" />
             </intent-filter>
         </activity>
 

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/EmulatorLauncher.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/EmulatorLauncher.kt
@@ -87,6 +87,14 @@ object EmulatorLauncher {
 		})
 	}
 
+	fun launchRp9(context: Context, path: String) {
+		launchRequest(context, LaunchRequest.Rp9(path))
+		AppPreferences.getInstance(context).addRecentLaunch(JSONObject().apply {
+			put("type", "rp9")
+			put("path", path)
+		})
+	}
+
 	/**
 	 * Open the full ImGui GUI, optionally loading a config file for editing.
 	 * Does NOT write a session marker or mark as emulator launch, since this

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/EmulatorLauncher.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/EmulatorLauncher.kt
@@ -87,8 +87,14 @@ object EmulatorLauncher {
 		})
 	}
 
-	fun launchRp9(context: Context, path: String) {
-		launchRequest(context, LaunchRequest.Rp9(path))
+	fun launchRp9(context: Context, path: String, controlSettings: EmulatorSettings? = null) {
+		launchRequest(
+			context,
+			LaunchRequest.Rp9(
+				path = path,
+				controlOverrides = controlSettings?.let { LaunchRequest.AndroidControlOverrides.fromSettings(it) }
+			)
+		)
 		AppPreferences.getInstance(context).addRecentLaunch(JSONObject().apply {
 			put("type", "rp9")
 			put("path", path)

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/IntentImport.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/IntentImport.kt
@@ -8,6 +8,7 @@ object IntentImport {
 		val safeName: String
 
 		data class Config(override val safeName: String) : Classification
+		data class Rp9(override val safeName: String) : Classification
 		data class Media(override val safeName: String, val category: FileCategory) : Classification
 		data class Unsupported(override val safeName: String, val extension: String) : Classification
 	}
@@ -17,6 +18,9 @@ object IntentImport {
 		val extension = safeName.substringAfterLast('.', missingDelimiterValue = "").lowercase()
 		if (extension == "uae") {
 			return Classification.Config(safeName)
+		}
+		if (extension == "rp9") {
+			return Classification.Rp9(safeName)
 		}
 
 		val category = FileCategory.fromExtension(extension)

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/IntentImport.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/IntentImport.kt
@@ -3,6 +3,7 @@ package com.blitterstudio.amiberry.data
 import com.blitterstudio.amiberry.data.model.FileCategory
 
 object IntentImport {
+	private const val RP9_MIME_TYPE = "application/vnd.cloanto.rp9"
 
 	sealed interface Classification {
 		val safeName: String
@@ -13,14 +14,16 @@ object IntentImport {
 		data class Unsupported(override val safeName: String, val extension: String) : Classification
 	}
 
-	fun classify(rawName: String?): Classification {
+	fun classify(rawName: String?, mimeType: String? = null): Classification {
 		val safeName = FileManager.safeImportFileName(rawName)
 		val extension = safeName.substringAfterLast('.', missingDelimiterValue = "").lowercase()
 		if (extension == "uae") {
 			return Classification.Config(safeName)
 		}
-		if (extension == "rp9") {
-			return Classification.Rp9(safeName)
+		val normalizedMimeType = mimeType?.substringBefore(';')?.trim()
+		if (extension == "rp9" || normalizedMimeType.equals(RP9_MIME_TYPE, ignoreCase = true)) {
+			val rp9Name = if (extension == "rp9") safeName else "$safeName.rp9"
+			return Classification.Rp9(rp9Name)
 		}
 
 		val category = FileCategory.fromExtension(extension)

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/IntentImportExecutor.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/IntentImportExecutor.kt
@@ -34,12 +34,15 @@ object IntentImportExecutor {
 			val lhaPath: String,
 			val configPath: String
 		) : Launch
+
+		data class Rp9(val path: String) : Launch
 	}
 
 	suspend fun importAndPrepare(context: Context, uri: Uri): PreparedImport {
 		val rawName = FileManager.getDisplayName(context, uri) ?: uri.lastPathSegment
 		return when (val import = IntentImport.classify(rawName)) {
 			is IntentImport.Classification.Config -> importConfig(context, uri, import.safeName)
+			is IntentImport.Classification.Rp9 -> importRp9(context, uri, import.safeName)
 			is IntentImport.Classification.Media -> importMedia(context, uri, import)
 			is IntentImport.Classification.Unsupported -> {
 				Log.w(TAG, "Ignoring unsupported file from intent: ${import.safeName}")
@@ -104,6 +107,24 @@ object IntentImportExecutor {
 			)
 		} catch (e: Exception) {
 			Log.e(TAG, "Failed to import config from intent", e)
+			PreparedImport(ImportFeedback.importFailed(safeName))
+		}
+	}
+
+	private fun importRp9(context: Context, uri: Uri, safeName: String): PreparedImport {
+		val baseDir = context.getExternalFilesDir(null)
+			?: return PreparedImport(ImportFeedback.importFailed(safeName))
+		val rp9Dir = File(baseDir, StoragePaths.RP9)
+		if (!rp9Dir.exists() && !rp9Dir.mkdirs())
+			return PreparedImport(ImportFeedback.importFailed(safeName))
+		val targetFile = FileManager.uniqueImportTarget(rp9Dir, safeName)
+		return try {
+			val inputStream = context.contentResolver.openInputStream(uri)
+				?: return PreparedImport(ImportFeedback.importFailed(safeName))
+			inputStream.use { input -> targetFile.outputStream().use { output -> input.copyTo(output) } }
+			PreparedImport(ImportFeedback.fileImported(targetFile.name), Launch.Rp9(targetFile.absolutePath))
+		} catch (e: Exception) {
+			Log.e(TAG, "Failed to import RP9 package", e)
 			PreparedImport(ImportFeedback.importFailed(safeName))
 		}
 	}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/IntentImportExecutor.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/IntentImportExecutor.kt
@@ -41,9 +41,10 @@ object IntentImportExecutor {
 		) : Launch
 	}
 
-	suspend fun importAndPrepare(context: Context, uri: Uri): PreparedImport {
+	suspend fun importAndPrepare(context: Context, uri: Uri, intentMimeType: String? = null): PreparedImport {
 		val rawName = FileManager.getDisplayName(context, uri) ?: uri.lastPathSegment
-		return when (val import = IntentImport.classify(rawName)) {
+		val mimeType = intentMimeType ?: context.contentResolver.getType(uri)
+		return when (val import = IntentImport.classify(rawName, mimeType)) {
 			is IntentImport.Classification.Config -> importConfig(context, uri, import.safeName)
 			is IntentImport.Classification.Rp9 -> importRp9(context, uri, import.safeName)
 			is IntentImport.Classification.Media -> importMedia(context, uri, import)

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/IntentImportExecutor.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/IntentImportExecutor.kt
@@ -35,7 +35,10 @@ object IntentImportExecutor {
 			val configPath: String
 		) : Launch
 
-		data class Rp9(val path: String) : Launch
+		data class Rp9(
+			val path: String,
+			val controlSettings: EmulatorSettings
+		) : Launch
 	}
 
 	suspend fun importAndPrepare(context: Context, uri: Uri): PreparedImport {
@@ -122,7 +125,13 @@ object IntentImportExecutor {
 			val inputStream = context.contentResolver.openInputStream(uri)
 				?: return PreparedImport(ImportFeedback.importFailed(safeName))
 			inputStream.use { input -> targetFile.outputStream().use { output -> input.copyTo(output) } }
-			PreparedImport(ImportFeedback.fileImported(targetFile.name), Launch.Rp9(targetFile.absolutePath))
+			PreparedImport(
+				ImportFeedback.fileImported(targetFile.name),
+				Launch.Rp9(
+					path = targetFile.absolutePath,
+					controlSettings = AndroidLaunchConfig.loadLastSessionSettings(context)
+				)
+			)
 		} catch (e: Exception) {
 			Log.e(TAG, "Failed to import RP9 package", e)
 			PreparedImport(ImportFeedback.importFailed(safeName))

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchDiagnostics.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchDiagnostics.kt
@@ -65,6 +65,7 @@ object LaunchDiagnostics {
 		is LaunchRequest.SavedConfig -> "SavedConfig"
 		is LaunchRequest.SettingsConfig -> "SettingsConfig"
 		is LaunchRequest.WhdLoad -> "WhdLoad"
+		is LaunchRequest.Rp9 -> "Rp9"
 	}
 
 	private fun LaunchRequest.configPathOrNull(): String? = when (this) {
@@ -73,6 +74,7 @@ object LaunchDiagnostics {
 		is LaunchRequest.SavedConfig -> configPath
 		is LaunchRequest.SettingsConfig -> configPath
 		is LaunchRequest.WhdLoad -> configPath
+		is LaunchRequest.Rp9 -> null
 	}
 
 	private fun String.toJsonString(): String = buildString {

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchRequest.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchRequest.kt
@@ -79,6 +79,11 @@ sealed interface LaunchRequest {
 		}
 	}
 
+	data class Rp9(val path: String) : LaunchRequest {
+		override fun toArgs(): Array<String> =
+			arrayOf("--rescan-roms", "--autoload", path, "-G")
+	}
+
 	data class AndroidControlOverrides(
 		val joyport0: String,
 		val joyport1: String,

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchRequest.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchRequest.kt
@@ -79,9 +79,17 @@ sealed interface LaunchRequest {
 		}
 	}
 
-	data class Rp9(val path: String) : LaunchRequest {
-		override fun toArgs(): Array<String> =
-			arrayOf("--rescan-roms", "--autoload", path, "-G")
+	data class Rp9(
+		val path: String,
+		val controlOverrides: AndroidControlOverrides? = null
+	) : LaunchRequest {
+		override fun toArgs(): Array<String> {
+			val args = mutableListOf("--rescan-roms", "--autoload", path)
+			// RP9 rebuilds machine preferences, so Android-only controls must follow autoload.
+			controlOverrides?.let { args.addAll(it.toArgs()) }
+			args.add("-G")
+			return args.toTypedArray()
+		}
 	}
 
 	data class AndroidControlOverrides(

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/RecentLaunches.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/RecentLaunches.kt
@@ -51,7 +51,7 @@ object RecentLaunches {
 		fileExists: (String) -> Boolean = { File(it).exists() }
 	): Boolean {
 		return when (entry.optString("type")) {
-			"config", "whdload" -> {
+			"config", "whdload", "rp9" -> {
 				val path = entry.optString("path")
 				path.isNotBlank() && fileExists(path)
 			}
@@ -71,7 +71,7 @@ object RecentLaunches {
 		fileExists: (String) -> Boolean
 	): Boolean {
 		return when (entry.optString("type")) {
-			"config", "whdload" -> {
+			"config", "whdload", "rp9" -> {
 				val path = entry.optString("path")
 				path.isNotBlank() && fileExists(path)
 			}
@@ -102,6 +102,8 @@ object RecentLaunches {
 				.removeSuffix(".lzx")
 				.removeSuffix(".lzh")
 				.ifEmpty { "WHDLoad" }
+			"rp9" -> stripSuffixCaseInsensitive(fileName(entry.optString("path")), ".rp9")
+				.ifEmpty { "RP9" }
 			else -> "?"
 		}
 	}
@@ -117,6 +119,11 @@ object RecentLaunches {
 			"whdload" -> Details(
 				title = label(entry),
 				typeLabel = "WHDLoad",
+				detail = entry.optString("path")
+			)
+			"rp9" -> Details(
+				title = label(entry),
+				typeLabel = "RP9",
 				detail = entry.optString("path")
 			)
 			else -> Details(
@@ -152,6 +159,9 @@ object RecentLaunches {
 
 	private fun fileName(path: String): String =
 		path.substringAfterLast('/').substringAfterLast('\\')
+
+	private fun stripSuffixCaseInsensitive(value: String, suffix: String): String =
+		if (value.endsWith(suffix, ignoreCase = true)) value.dropLast(suffix.length) else value
 
 	private val MEDIA_KEYS = listOf("df0", "df1", "cd")
 }

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/StoragePaths.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/StoragePaths.kt
@@ -5,6 +5,7 @@ object StoragePaths {
 	const val CONTROLLERS = "Controllers"
 	const val WHDBOOT = "WHDBoot"
 	const val WHDLOAD_ARCHIVES = "LHA"
+	const val RP9 = "RP9"
 	const val FLOPPIES = "Floppies"
 	const val HARD_DRIVES = "HardDrives"
 	const val CDROMS = "CDROMs"
@@ -27,6 +28,7 @@ object StoragePaths {
 		HARD_DRIVES,
 		CDROMS,
 		WHDLOAD_ARCHIVES,
+		RP9,
 		CONFIGURATIONS
 	)
 

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/AmiberryApp.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/AmiberryApp.kt
@@ -130,9 +130,10 @@ fun AmiberryApp() {
 
 	// Handle pending file from ACTION_VIEW intent
 	val pendingUri = activity?.pendingFileUri
+	val pendingMimeType = activity?.pendingFileMimeType
 	val assetsReady = activity?.isReady == true
 	val importLaunchInProgress = activity?.importLaunchInProgress == true
-	LaunchedEffect(pendingUri, assetsReady, crashDetected, assetExtractionFailed, importLaunchInProgress) {
+	LaunchedEffect(pendingUri, pendingMimeType, assetsReady, crashDetected, assetExtractionFailed, importLaunchInProgress) {
 		val mainActivity = activity ?: return@LaunchedEffect
 		val uri = pendingUri ?: return@LaunchedEffect
 		if (PendingImportState.shouldProcess(
@@ -144,7 +145,7 @@ fun AmiberryApp() {
 			)
 		) {
 			mainActivity.clearPendingFileUri()
-			mainActivity.importAndLaunch(uri)
+			mainActivity.importAndLaunch(uri, pendingMimeType)
 		}
 	}
 

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/MainActivity.kt
@@ -93,21 +93,25 @@ class MainActivity : ComponentActivity() {
 		// Clear the action so it isn't re-processed on config change
 		intent.action = null
 
+		pendingFileMimeType = intent.type
 		pendingFileUri = uri
 	}
 
-	/** URI from an incoming ACTION_VIEW intent, processed after asset extraction. */
+	/** URI and MIME type from an incoming ACTION_VIEW intent, processed after asset extraction. */
 	var pendingFileUri by mutableStateOf<Uri?>(null)
+		private set
+	var pendingFileMimeType by mutableStateOf<String?>(null)
 		private set
 
 	fun clearPendingFileUri() {
 		pendingFileUri = null
+		pendingFileMimeType = null
 	}
 
 	/**
 	 * Import a file from a content/file URI and launch emulation with it.
 	 */
-	fun importAndLaunch(uri: Uri) {
+	fun importAndLaunch(uri: Uri, mimeType: String? = null) {
 		if (!importLaunchGuard.begin()) {
 			Log.d(TAG, "Ignoring incoming file intent while another import launch is in progress")
 			return
@@ -115,7 +119,7 @@ class MainActivity : ComponentActivity() {
 		lifecycleScope.launch(Dispatchers.IO) {
 			try {
 				val preparedImport = try {
-					IntentImportExecutor.importAndPrepare(this@MainActivity, uri)
+					IntentImportExecutor.importAndPrepare(this@MainActivity, uri, mimeType)
 				} catch (e: Exception) {
 					Log.e(TAG, "Failed to handle incoming file intent", e)
 					ImportFeedback.importFailed(uri.lastPathSegment ?: "file").let { feedback ->

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/MainActivity.kt
@@ -154,7 +154,11 @@ class MainActivity : ComponentActivity() {
 				launch.lhaPath,
 				launch.configPath
 			)
-			is IntentImportExecutor.Launch.Rp9 -> EmulatorLauncher.launchRp9(this, launch.path)
+			is IntentImportExecutor.Launch.Rp9 -> EmulatorLauncher.launchRp9(
+				this,
+				launch.path,
+				launch.controlSettings
+			)
 			null -> Unit
 		}
 	}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/MainActivity.kt
@@ -154,6 +154,7 @@ class MainActivity : ComponentActivity() {
 				launch.lhaPath,
 				launch.configPath
 			)
+			is IntentImportExecutor.Launch.Rp9 -> EmulatorLauncher.launchRp9(this, launch.path)
 			null -> Unit
 		}
 	}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/QuickStartScreen.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/QuickStartScreen.kt
@@ -700,6 +700,12 @@ fun QuickStartScreen(
 														EmulatorLauncher.launchWhdload(context, whdloadPath, configFile.absolutePath)
 													}
 												}
+												"rp9" -> {
+													val rp9Path = entry.optString("path")
+													scope.launchGuarded(launchGuard) {
+														EmulatorLauncher.launchRp9(context, rp9Path)
+													}
+												}
 												"quickstart" -> {
 													val model = AmigaModel.entries.firstOrNull { it.cmdArg == entry.optString("model") } ?: AmigaModel.A500
 													if (model in availableModels) {

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/QuickStartScreen.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/QuickStartScreen.kt
@@ -702,8 +702,9 @@ fun QuickStartScreen(
 												}
 												"rp9" -> {
 													val rp9Path = entry.optString("path")
+													val controlSettings = settingsViewModel.settings
 													scope.launchGuarded(launchGuard) {
-														EmulatorLauncher.launchRp9(context, rp9Path)
+														EmulatorLauncher.launchRp9(context, rp9Path, controlSettings)
 													}
 												}
 												"quickstart" -> {

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/IntentImportTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/IntentImportTest.kt
@@ -20,6 +20,14 @@ class IntentImportTest {
 	}
 
 	@Test
+	fun `classify detects RP9 MIME imports with opaque names`() {
+		assertEquals(
+			IntentImport.Classification.Rp9("opaque-document.rp9"),
+			IntentImport.classify("opaque-document", "Application/Vnd.Cloanto.Rp9; charset=binary")
+		)
+	}
+
+	@Test
 	fun `classify detects media categories case insensitively`() {
 		assertEquals(
 			IntentImport.Classification.Media("Lotus.ADF", FileCategory.FLOPPIES),

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/IntentImportTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/IntentImportTest.kt
@@ -15,6 +15,11 @@ class IntentImportTest {
 	}
 
 	@Test
+	fun `classify detects RP9 packages case insensitively`() {
+		assertEquals(IntentImport.Classification.Rp9("Game.RP9"), IntentImport.classify("Game.RP9"))
+	}
+
+	@Test
 	fun `classify detects media categories case insensitively`() {
 		assertEquals(
 			IntentImport.Classification.Media("Lotus.ADF", FileCategory.FLOPPIES),

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/LaunchRequestTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/LaunchRequestTest.kt
@@ -102,6 +102,35 @@ class LaunchRequestTest {
 	}
 
 	@Test
+	fun `rp9 request applies Android controls after manifest autoload`() {
+		val path = "/tmp/game.rp9"
+		val args = LaunchRequest.Rp9(
+			path = path,
+			controlOverrides = LaunchRequest.AndroidControlOverrides(
+				joyport0 = "mouse",
+				joyport1 = "onscreen_joy",
+				onScreenJoystick = true,
+				onScreenKeyboard = true,
+				onScreenKeyboardNumpad = true
+			)
+		).toArgs()
+
+		assertArrayEquals(
+			arrayOf(
+				"--rescan-roms",
+				"--autoload", path,
+				"-s", "joyport0=mouse",
+				"-s", "amiberry.onscreen_joystick=true",
+				"-s", "amiberry.vkbd_enabled=true",
+				"-s", "amiberry.vkbd_numpad=true",
+				"-s", "input.default_osk=true",
+				"-G"
+			),
+			args
+		)
+	}
+
+	@Test
 	fun `whdload request can include control config before autoload`() {
 		val lhaPath = "/tmp/game.lha"
 		val configPath = "/tmp/android-controls.uae"
@@ -206,6 +235,7 @@ class LaunchRequestTest {
 		assertTrue(LaunchRequest.SavedConfig("/tmp/saved.uae").trackSession)
 		assertTrue(LaunchRequest.SettingsConfig(AmigaModel.A1200, "/tmp/current.uae").trackSession)
 		assertTrue(LaunchRequest.WhdLoad("/tmp/game.lha", configPath = "/tmp/controls.uae").trackSession)
+		assertTrue(LaunchRequest.Rp9("/tmp/game.rp9").trackSession)
 
 		assertFalse(LaunchRequest.AdvancedGui(configPath = "/tmp/edit.uae").trackSession)
 	}
@@ -217,6 +247,7 @@ class LaunchRequestTest {
 			LaunchRequest.SavedConfig("/tmp/saved.uae"),
 			LaunchRequest.SettingsConfig(AmigaModel.A1200, "/tmp/current.uae"),
 			LaunchRequest.WhdLoad("/tmp/game.lha", configPath = "/tmp/controls.uae"),
+			LaunchRequest.Rp9("/tmp/game.rp9"),
 			LaunchRequest.AdvancedGui(configPath = "/tmp/edit.uae")
 		)
 

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/LaunchRequestTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/LaunchRequestTest.kt
@@ -93,6 +93,15 @@ class LaunchRequestTest {
 	}
 
 	@Test
+	fun `rp9 request uses manifest autoload and skip gui`() {
+		val path = "/tmp/game.rp9"
+		assertArrayEquals(
+			arrayOf("--rescan-roms", "--autoload", path, "-G"),
+			LaunchRequest.Rp9(path).toArgs()
+		)
+	}
+
+	@Test
 	fun `whdload request can include control config before autoload`() {
 		val lhaPath = "/tmp/game.lha"
 		val configPath = "/tmp/android-controls.uae"

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/RecentLaunchesTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/RecentLaunchesTest.kt
@@ -13,16 +13,17 @@ class RecentLaunchesTest {
 		val quickstart = quickstart(model = "A500", df0 = "/media/disk.adf")
 		val staleConfig = entry("config", path = "/configs/missing.uae")
 		val whdload = entry("whdload", path = "/whdload/Lotus.lha")
+		val rp9 = entry("rp9", path = "/rp9/Asteroids.rp9")
 		val unsupportedModel = quickstart(model = "CD32", cd = "/cds/game.cue")
 		val unknownType = JSONObject().put("type", "mystery")
 
 		val available = RecentLaunches.available(
-			entries = listOf(quickstart, staleConfig, whdload, unsupportedModel, unknownType),
+			entries = listOf(quickstart, staleConfig, whdload, rp9, unsupportedModel, unknownType),
 			availableModels = setOf(AmigaModel.A500),
-			fileExists = { it in setOf("/media/disk.adf", "/whdload/Lotus.lha", "/cds/game.cue") }
+			fileExists = { it in setOf("/media/disk.adf", "/whdload/Lotus.lha", "/rp9/Asteroids.rp9", "/cds/game.cue") }
 		)
 
-		assertEquals(listOf(quickstart, whdload), available)
+		assertEquals(listOf(quickstart, whdload, rp9), available)
 	}
 
 	@Test
@@ -61,6 +62,7 @@ class RecentLaunchesTest {
 		)
 		assertEquals("Workbench", RecentLaunches.label(entry("config", path = "/configs/Workbench.uae")))
 		assertEquals("Lotus", RecentLaunches.label(entry("whdload", path = "/whdload/Lotus.lha")))
+		assertEquals("Asteroids", RecentLaunches.label(entry("rp9", path = "/rp9/Asteroids.Rp9")))
 		assertEquals("?", RecentLaunches.label(JSONObject().put("type", "mystery")))
 	}
 
@@ -71,6 +73,7 @@ class RecentLaunchesTest {
 		)
 		val config = RecentLaunches.details(entry("config", path = "/configs/Workbench.uae"))
 		val whdload = RecentLaunches.details(entry("whdload", path = "/whdload/Lotus.lha"))
+		val rp9 = RecentLaunches.details(entry("rp9", path = "/rp9/Asteroids.rp9"))
 
 		assertEquals("Workbench.adf", quickstart.title)
 		assertEquals("Quick Start", quickstart.typeLabel)
@@ -79,6 +82,8 @@ class RecentLaunchesTest {
 		assertEquals("/configs/Workbench.uae", config.detail)
 		assertEquals("WHDLoad", whdload.typeLabel)
 		assertEquals("/whdload/Lotus.lha", whdload.detail)
+		assertEquals("RP9", rp9.typeLabel)
+		assertEquals("/rp9/Asteroids.rp9", rp9.detail)
 	}
 
 	@Test

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/MainActivityImportLaunchGuardArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/MainActivityImportLaunchGuardArchitectureTest.kt
@@ -17,7 +17,7 @@ class MainActivityImportLaunchGuardArchitectureTest {
 		)
 		assertTrue(
 			"importAndLaunch should reject a second incoming file launch while one is already being prepared.",
-			Regex("""fun importAndLaunch\(uri: Uri\) \{[\s\S]*if \(!importLaunchGuard\.begin\(\)\) \{[\s\S]*return""")
+			Regex("""fun importAndLaunch\(uri: Uri, mimeType: String\? = null\) \{[\s\S]*if \(!importLaunchGuard\.begin\(\)\) \{[\s\S]*return""")
 				.containsMatchIn(mainActivity)
 		)
 		assertTrue(
@@ -48,8 +48,17 @@ class MainActivityImportLaunchGuardArchitectureTest {
 		)
 		assertTrue(
 			"AmiberryApp should include importLaunchInProgress in pending import effect keys.",
-			Regex("""LaunchedEffect\(pendingUri, assetsReady, crashDetected, assetExtractionFailed, importLaunchInProgress\)""")
+			Regex("""LaunchedEffect\(pendingUri, pendingMimeType, assetsReady, crashDetected, assetExtractionFailed, importLaunchInProgress\)""")
 				.containsMatchIn(app)
+		)
+		assertTrue(
+			"MainActivity should preserve the MIME type that routed the ACTION_VIEW intent.",
+			mainActivity.contains("pendingFileMimeType = intent.type")
+		)
+		assertTrue(
+			"Pending imports should pass the original MIME type to classification.",
+			app.contains("mainActivity.importAndLaunch(uri, pendingMimeType)") &&
+				mainActivity.contains("IntentImportExecutor.importAndPrepare(this@MainActivity, uri, mimeType)")
 		)
 		assertTrue(
 			"PendingImportState should block processing while a direct import launch is already active.",

--- a/cmake/SourceFiles.cmake
+++ b/cmake/SourceFiles.cmake
@@ -252,6 +252,8 @@ set(SOURCE_FILES
         src/osdep/amiberry_update.cpp
         src/osdep/amiberry_uaenet.cpp
         src/osdep/amiberry_whdbooter.cpp
+        src/osdep/amiberry_rp9.cpp
+        src/osdep/rp9_manifest.cpp
         src/osdep/blkdev_ioctl.cpp
         src/osdep/ioport.cpp
         src/osdep/sigsegv_handler.cpp

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -352,6 +352,8 @@ SOURCES_OSDEP := $(LIBRETRO_DIR)/libretro.cpp \
                 $(AMIBERRY_DIR)/src/osdep/amiberry_uaenet.cpp \
                 $(AMIBERRY_DIR)/src/osdep/amiberry_hardfile.cpp \
                 $(AMIBERRY_DIR)/src/osdep/amiberry_whdbooter.cpp \
+                $(AMIBERRY_DIR)/src/osdep/amiberry_rp9.cpp \
+                $(AMIBERRY_DIR)/src/osdep/rp9_manifest.cpp \
                 $(AMIBERRY_DIR)/src/osdep/amiberry_filesys.cpp \
                 $(AMIBERRY_DIR)/src/osdep/cda_play.cpp \
                 $(AMIBERRY_DIR)/src/osdep/charset.cpp \

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -160,7 +160,7 @@ static void input_log_file_write(const char* fmt, ...);
 static std::string system_dir;
 static std::string save_dir;
 static std::string content_dir;
-static std::string whdload_temp_path;
+static std::string content_temp_path;
 static std::string cached_model;
 static std::string cached_kickstart_override;
 static std::string cached_cpu_model;
@@ -3778,16 +3778,23 @@ static void core_entry(void)
 	if (game_path[0])
 		game_ext = path_extension_lower(game_path);
 	const bool is_whdload = (game_ext == "lha" || game_ext == "lzh");
+	const bool is_rp9 = game_ext == "rp9";
 	const bool is_cd = content_is_cd || is_cd_extension(game_ext);
 	const bool user_kick_override = !cached_kickstart_override.empty() && cached_kickstart_override != "auto";
+	std::string deferred_rp9_kickstart;
 
-	auto push_s_option = [&safe_strdup](const std::string& value) {
+	std::vector<std::string> deferred_rp9_options;
+	auto push_s_option = [&safe_strdup, &deferred_rp9_options, is_rp9](const std::string& value) {
+		if (is_rp9) {
+			deferred_rp9_options.emplace_back(value);
+			return;
+		}
 		safe_strdup("-s");
 		safe_strdup(value.c_str());
 	};
 
 	const char* model = cached_model.empty() ? nullptr : cached_model.c_str();
-	if (model)
+	if (model && !is_rp9)
 	{
 		// Map libretro preset names to --model args that main.cpp recognizes.
 		// main.cpp only handles: A500, A500P, A600, A1000, A2000, A3000, A1200, A4000, CD32, CDTV
@@ -3834,12 +3841,12 @@ static void core_entry(void)
 	}
 
 	const char* cpu_model = cached_cpu_model.empty() ? nullptr : cached_cpu_model.c_str();
-	if (cpu_model && strcmp(cpu_model, "auto") != 0) {
+	if (!is_rp9 && cpu_model && strcmp(cpu_model, "auto") != 0) {
 		push_s_option(std::string("cpu_model=") + cpu_model);
 	}
 
 	const char* chipset = cached_chipset_value();
-	if (chipset && strcmp(chipset, "auto") != 0) {
+	if (!is_rp9 && chipset && strcmp(chipset, "auto") != 0) {
 		push_s_option(std::string("chipset=") + chipset);
 	}
 
@@ -3860,11 +3867,11 @@ static void core_entry(void)
 		push_s_option("sound_stereo_separation=" + cached_stereo_sep);
 	}
 
-	if (!cached_floppy_speed.empty() && cached_floppy_speed != "100") {
+	if (!is_rp9 && !cached_floppy_speed.empty() && cached_floppy_speed != "100") {
 		push_s_option("floppy_speed=" + cached_floppy_speed);
 	}
 
-	if (!cached_video_standard.empty() && cached_video_standard != "auto") {
+	if (!is_rp9 && !cached_video_standard.empty() && cached_video_standard != "auto") {
 		if (cached_video_standard == "ntsc")
 			push_s_option("ntsc=true");
 		else if (cached_video_standard == "pal")
@@ -3901,7 +3908,8 @@ static void core_entry(void)
 	}
 #endif
 
-	safe_strdup("-G"); // No GUI
+	if (!is_rp9)
+		safe_strdup("-G"); // RP9 must receive this after its complete manifest config.
 
 	std::string rom_path_value;
 	if (!system_dir.empty() || !save_dir.empty()) {
@@ -3932,13 +3940,17 @@ static void core_entry(void)
 		if (user_kick_override) {
 			have_kick = resolve_kickstart_override_value(cached_kickstart_override.c_str(), kick_path, sizeof(kick_path)) ||
 				find_kickstart_in_system_dir(model, kick_path, sizeof(kick_path));
-		} else if (!is_whdload) {
+		} else if (!is_whdload && !is_rp9) {
 			have_kick = find_kickstart_in_system_dir(model, kick_path, sizeof(kick_path));
 		}
 
 		if (have_kick) {
-			safe_strdup("-r");
-			safe_strdup(kick_path);
+			if (is_rp9)
+				deferred_rp9_kickstart = kick_path;
+			else {
+				safe_strdup("-r");
+				safe_strdup(kick_path);
+			}
 			if (log_cb)
 				log_cb(RETRO_LOG_INFO, "Using Kickstart ROM: %s\n", kick_path);
 			libretro_debug_log("kickstart override: %s\n", kick_path);
@@ -3961,21 +3973,17 @@ static void core_entry(void)
 		const std::string saveimage_path = "saveimage_dir=" + save_dir;
 		const std::string savestate_path = "savestate_dir=" + save_dir;
 		const std::string statefile_path = "statefile_path=" + save_dir;
-		safe_strdup("-s");
-		safe_strdup(cfg_path.c_str());
-		safe_strdup("-s");
-		safe_strdup(saveimage_path.c_str());
-		safe_strdup("-s");
-		safe_strdup(savestate_path.c_str());
-		safe_strdup("-s");
-		safe_strdup(statefile_path.c_str());
+		push_s_option(cfg_path);
+		push_s_option(saveimage_path);
+		push_s_option(savestate_path);
+		push_s_option(statefile_path);
 	}
 
 	if (game_path[0])
 	{
-		if (is_whdload) {
+		if (is_whdload || is_rp9) {
 			if (log_cb)
-				log_cb(RETRO_LOG_INFO, "WHDLoad autoload: %s\n", game_path);
+				log_cb(RETRO_LOG_INFO, "%s autoload: %s\n", is_rp9 ? "RP9" : "WHDLoad", game_path);
 			safe_strdup("--autoload");
 			safe_strdup(game_path);
 		} else if (is_cd) {
@@ -4003,6 +4011,17 @@ static void core_entry(void)
 		} else {
 			safe_strdup(game_path);
 		}
+	}
+	if (is_rp9) {
+		if (!deferred_rp9_kickstart.empty()) {
+			safe_strdup("-r");
+			safe_strdup(deferred_rp9_kickstart.c_str());
+		}
+		for (const auto& option : deferred_rp9_options) {
+			safe_strdup("-s");
+			safe_strdup(option.c_str());
+		}
+		safe_strdup("-G");
 	}
 	argv.push_back(nullptr);
 
@@ -4537,39 +4556,45 @@ bool retro_load_game(const struct retro_game_info *info)
 
 	const std::string ext = info_ext && info_ext->ext ? info_ext->ext : path_extension_lower(path);
 	const bool is_whdload = (ext == "lha" || ext == "lzh");
-	libretro_debug_log("retro_load_game: path='%s' ext='%s' is_whdload=%d\n",
-		path.c_str(), ext.c_str(), is_whdload ? 1 : 0);
+	const bool is_rp9 = ext == "rp9";
+	libretro_debug_log("retro_load_game: path='%s' ext='%s' is_whdload=%d is_rp9=%d\n",
+		path.c_str(), ext.c_str(), is_whdload ? 1 : 0, is_rp9 ? 1 : 0);
 
-	if (is_whdload) {
+	if (is_whdload || is_rp9) {
+		const char* content_label = is_rp9 ? "RP9" : "WHDLoad";
+		const char* temp_prefix = is_rp9 ? "rp9_" : "whdload_";
 		if (log_cb) {
-			log_cb(RETRO_LOG_INFO, "WHDLoad content detected: path='%s' ext='%s'\n",
-				path.c_str(), ext.c_str());
+			log_cb(RETRO_LOG_INFO, "%s content detected: path='%s' ext='%s'\n",
+				content_label, path.c_str(), ext.c_str());
 			if (info_ext)
-				log_cb(RETRO_LOG_INFO, "WHDLoad info_ext: full_path='%s' archive_path='%s' archive_file='%s' file_in_archive=%d size=%zu\n",
+				log_cb(RETRO_LOG_INFO, "%s info_ext: full_path='%s' archive_path='%s' archive_file='%s' file_in_archive=%d size=%zu\n",
+					content_label,
 					info_ext->full_path ? info_ext->full_path : "",
 					info_ext->archive_path ? info_ext->archive_path : "",
 					info_ext->archive_file ? info_ext->archive_file : "",
 					info_ext->file_in_archive ? 1 : 0,
 					info_ext->size);
 		}
-		setup_whdload_paths();
+		if (is_whdload)
+			setup_whdload_paths();
 
-		std::string whd_path = path;
+		std::string package_path = path;
 		bool extracted = false;
 
 		if (info_ext && info_ext->data && info_ext->size > 0 &&
 			(info_ext->file_in_archive || !info_ext->full_path || !*info_ext->full_path)) {
-			const std::string base = info_ext->name ? info_ext->name : "whdload";
+			const std::string base = info_ext->name ? info_ext->name : (is_rp9 ? "rp9" : "whdload");
 			const std::string out_dir = !save_dir.empty() ? save_dir : (!system_dir.empty() ? system_dir : (!content_dir.empty() ? content_dir : "."));
 			std::string safe_name = sanitize_filename(base);
 			if (safe_name.length() > 200) safe_name.resize(200);
-			const std::string out_file = "whdload_" + safe_name + "." + (info_ext->ext ? info_ext->ext : "lha");
+			const std::string out_file = std::string(temp_prefix) + safe_name + "." +
+				(info_ext->ext ? info_ext->ext : (is_rp9 ? "rp9" : "lha"));
 			const std::string out_path = path_join(out_dir, out_file);
 			if (vfs_write_file(out_path.c_str(), info_ext->data, info_ext->size)) {
-				whd_path = out_path;
+				package_path = out_path;
 				extracted = true;
 			} else if (log_cb) {
-				log_cb(RETRO_LOG_WARN, "Failed to write WHDLoad data to %s\n", out_path.c_str());
+				log_cb(RETRO_LOG_WARN, "Failed to write %s data to %s\n", content_label, out_path.c_str());
 			}
 		} else if (info_ext && info_ext->file_in_archive && info_ext->archive_path && info_ext->archive_file) {
 			std::string vfs_path = std::string(info_ext->archive_path) + "#" + info_ext->archive_file;
@@ -4579,55 +4604,55 @@ bool retro_load_game(const struct retro_game_info *info)
 				const std::string out_dir = !save_dir.empty() ? save_dir : (!system_dir.empty() ? system_dir : (!content_dir.empty() ? content_dir : "."));
 				std::string safe_name = sanitize_filename(base);
 				if (safe_name.length() > 200) safe_name.resize(200);
-				const std::string out_file = "whdload_" + safe_name + "." + ext;
+				const std::string out_file = std::string(temp_prefix) + safe_name + "." + ext;
 				const std::string out_path = path_join(out_dir, out_file);
 				if (vfs_write_file(out_path.c_str(), data.data(), data.size())) {
-					whd_path = out_path;
+					package_path = out_path;
 					extracted = true;
 				} else if (log_cb) {
-					log_cb(RETRO_LOG_WARN, "Failed to write WHDLoad file to %s\n", out_path.c_str());
+					log_cb(RETRO_LOG_WARN, "Failed to write %s file to %s\n", content_label, out_path.c_str());
 				}
 			}
 		}
 
 		if (!extracted)
-			whd_path = canonicalize_existing_host_path(whd_path);
+			package_path = canonicalize_existing_host_path(package_path);
 
-		if (!extracted && (has_non_ascii(whd_path) || !file_readable(whd_path.c_str()))) {
+		if (!extracted && (has_non_ascii(package_path) || !file_readable(package_path.c_str()))) {
 			std::vector<uint8_t> data;
-			if (vfs_read_all(whd_path.c_str(), data)) {
-				const std::string base = path_basename(whd_path);
+			if (vfs_read_all(package_path.c_str(), data)) {
+				const std::string base = path_basename(package_path);
 				const std::string out_dir = !save_dir.empty() ? save_dir : (!system_dir.empty() ? system_dir : (!content_dir.empty() ? content_dir : "."));
 				std::string safe_name = sanitize_filename(base);
 				if (safe_name.length() > 200) safe_name.resize(200);
-				const std::string out_file = "whdload_" + safe_name;
+				const std::string out_file = std::string(temp_prefix) + safe_name;
 				const std::string out_path = path_join(out_dir, out_file);
 				if (vfs_write_file(out_path.c_str(), data.data(), data.size())) {
-					whd_path = out_path;
+					package_path = out_path;
 					extracted = true;
 				} else if (log_cb) {
-					log_cb(RETRO_LOG_WARN, "Failed to write WHDLoad temp file to %s\n", out_path.c_str());
+					log_cb(RETRO_LOG_WARN, "Failed to write %s temp file to %s\n", content_label, out_path.c_str());
 				}
 			} else if (log_cb) {
-				log_cb(RETRO_LOG_WARN, "Failed to read WHDLoad path via VFS: %s\n", whd_path.c_str());
+				log_cb(RETRO_LOG_WARN, "Failed to read %s path via VFS: %s\n", content_label, package_path.c_str());
 			}
 		}
 
-		if (!whd_path.empty()) {
-			whdload_temp_path = extracted ? whd_path : std::string();
-			libretro_debug_log("WHDLoad using path: %s (extracted=%d)\n", whd_path.c_str(), extracted ? 1 : 0);
+		if (!package_path.empty()) {
+			content_temp_path = extracted ? package_path : std::string();
+			libretro_debug_log("%s using path: %s (extracted=%d)\n", content_label, package_path.c_str(), extracted ? 1 : 0);
 			disk_images.clear();
 			disk_index = 0;
 			disk_ejected = false;
 			last_disk_index = 0;
 			last_disk_ejected = false;
 			DiskImage image;
-			image.path = whd_path;
+			image.path = package_path;
 			disk_images.push_back(image);
-			strncpy(game_path, whd_path.c_str(), sizeof(game_path) - 1);
+			strncpy(game_path, package_path.c_str(), sizeof(game_path) - 1);
 			game_path[sizeof(game_path) - 1] = '\0';
 			if (log_cb)
-				log_cb(RETRO_LOG_INFO, "WHDLoad using path: %s\n", game_path);
+				log_cb(RETRO_LOG_INFO, "%s using path: %s\n", content_label, game_path);
 			return true;
 		}
 	}
@@ -4724,12 +4749,12 @@ void retro_unload_game(void)
 	delete_core_fiber();
 	reset_core_runtime_state();
 	cheat_entries.clear();
-	if (!whdload_temp_path.empty()) {
+	if (!content_temp_path.empty()) {
 		if (vfs_available && vfs_iface.remove)
-			vfs_iface.remove(whdload_temp_path.c_str());
+			vfs_iface.remove(content_temp_path.c_str());
 		else
-			remove(whdload_temp_path.c_str());
-		whdload_temp_path.clear();
+			remove(content_temp_path.c_str());
+		content_temp_path.clear();
 	}
 }
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -53,6 +53,7 @@ extern "C" {
 #include "blkdev.h"
 #include "gui.h"
 #include "amiberry_gfx.h"
+#include "amiberry_rp9.h"
 #include "irenderer.h"
 #include "statusline.h"
 #include "zfile.h"
@@ -2279,6 +2280,13 @@ static libretro_crop_mode get_libretro_crop_mode()
 	return libretro_crop_mode::auto_crop;
 }
 
+static bool libretro_preserves_rp9_manifest_crop()
+{
+	return libretro_should_preserve_rp9_clip(
+		get_libretro_crop_mode() == libretro_crop_mode::auto_crop,
+		rp9_loaded_has_clip());
+}
+
 static bool libretro_crop_equals(const libretro_crop& a, const libretro_crop& b)
 {
 	return a.active == b.active
@@ -2438,6 +2446,30 @@ static void libretro_update_crop_aspect(libretro_crop& crop)
 	auto_crop_display_dimensions(crop.w, crop.h, currprefs.gfx_resolution,
 		currprefs.gfx_vresolution, vblank_hz > 55.0f, width, height);
 	crop.aspect = height > 0 ? static_cast<float>(width) / static_cast<float>(height) : 0.0f;
+}
+
+static bool libretro_crop_from_manual_prefs(const SDL_Surface* surface, libretro_crop& crop)
+{
+	if (!surface || !currprefs.gfx_manual_crop)
+		return false;
+
+	LibretroCropRect rect = {
+		currprefs.gfx_horizontal_offset,
+		currprefs.gfx_vertical_offset,
+		currprefs.gfx_manual_crop_width > 0 ? currprefs.gfx_manual_crop_width : surface->w,
+		currprefs.gfx_manual_crop_height > 0 ? currprefs.gfx_manual_crop_height : surface->h
+	};
+	libretro_crop_clamp_rect(surface->w, surface->h, rect);
+	if (!libretro_crop_rect_valid(rect))
+		return false;
+
+	crop.x = rect.x;
+	crop.y = rect.y;
+	crop.w = rect.w;
+	crop.h = rect.h;
+	crop.active = true;
+	libretro_update_crop_aspect(crop);
+	return true;
 }
 
 static bool libretro_visible_content_bounds(const SDL_Surface* surface, LibretroCropRect& bounds)
@@ -2723,6 +2755,8 @@ static void libretro_enable_core_auto_crop()
 {
 	if (get_libretro_crop_mode() != libretro_crop_mode::auto_crop)
 		return;
+	if (libretro_preserves_rp9_manifest_crop())
+		return;
 
 	const bool changed = !currprefs.gfx_auto_crop
 		|| !changed_prefs.gfx_auto_crop
@@ -2762,15 +2796,20 @@ static void libretro_enable_core_auto_crop()
 
 static void libretro_disable_core_auto_crop()
 {
+	const bool preserve_rp9_clip = rp9_loaded_has_clip();
 	const bool changed = currprefs.gfx_auto_crop
 		|| changed_prefs.gfx_auto_crop
-		|| currprefs.gfx_manual_crop
-		|| changed_prefs.gfx_manual_crop;
+		|| (!preserve_rp9_clip && (currprefs.gfx_manual_crop
+			|| changed_prefs.gfx_manual_crop));
 
 	currprefs.gfx_auto_crop = false;
 	changed_prefs.gfx_auto_crop = false;
-	currprefs.gfx_manual_crop = false;
-	changed_prefs.gfx_manual_crop = false;
+	// Disabled and fixed libretro modes ignore the native crop rectangle, but
+	// retain an RP9 manifest clip so switching back to Automatic can restore it.
+	if (!preserve_rp9_clip) {
+		currprefs.gfx_manual_crop = false;
+		changed_prefs.gfx_manual_crop = false;
+	}
 	force_auto_crop = false;
 
 	if (changed) {
@@ -2842,6 +2881,11 @@ libretro_crop libretro_compute_crop(void)
 		libretro_disable_core_auto_crop();
 		if (libretro_fixed_crop_from_surface(surface, crop_mode, crop))
 			return libretro_cache_crop(crop);
+		return libretro_cache_crop(crop);
+	}
+	if (libretro_preserves_rp9_manifest_crop()) {
+		libretro_reset_submitted_crop();
+		libretro_crop_from_manual_prefs(surface, crop);
 		return libretro_cache_crop(crop);
 	}
 
@@ -3934,7 +3978,8 @@ static void core_entry(void)
 			push_s_option("ntsc=false");
 	}
 
-	if (get_libretro_crop_mode() == libretro_crop_mode::auto_crop) {
+	const bool automatic_crop = get_libretro_crop_mode() == libretro_crop_mode::auto_crop;
+	if (libretro_should_queue_auto_crop_options(automatic_crop, is_rp9)) {
 		push_s_option("gfx_auto_crop=true");
 		push_s_option("gfx_manual_crop=false");
 		push_s_option("gfx_horizontal_offset=0");

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -26,6 +26,7 @@
 #include <atomic>
 #include <chrono>
 #include <climits>
+#include <iterator>
 #include <mutex>
 #include <string>
 #include <utility>
@@ -1978,6 +1979,43 @@ static bool parse_m3u(const char* path, std::vector<DiskImage>& out_images)
 }
 
 static bool libretro_get_image_label(unsigned index, char* s, size_t len);
+
+static void sync_rp9_disk_control_media()
+{
+	const auto& floppy_paths = rp9_get_loaded_floppy_paths();
+	const auto& cd_paths = rp9_get_loaded_cd_paths();
+	const bool use_cd_paths = !cd_paths.empty()
+		&& (floppy_paths.empty() || currprefs.cs_cd32cd || currprefs.cs_cdtvcd);
+	const auto& media_paths = use_cd_paths ? cd_paths : floppy_paths;
+	const TCHAR* inserted_path = use_cd_paths
+		? currprefs.cdslots[0].name
+		: currprefs.floppyslots[0].df;
+
+	std::lock_guard<std::mutex> lock(disk_mutex);
+	disk_images.clear();
+	for (const auto& path : media_paths)
+		disk_images.push_back({ path, {} });
+
+	content_is_cd = use_cd_paths;
+	disk_index = 0;
+	disk_ejected = disk_images.empty() || !inserted_path[0];
+	if (!disk_ejected) {
+		const auto inserted = std::find_if(disk_images.begin(), disk_images.end(), [inserted_path](const auto& image) {
+			return image.path == inserted_path;
+		});
+		if (inserted != disk_images.end())
+			disk_index = static_cast<unsigned>(std::distance(disk_images.begin(), inserted));
+		else
+			disk_ejected = true;
+	}
+	last_disk_index = disk_index;
+	last_disk_ejected = disk_ejected;
+
+	if (log_cb) {
+		log_cb(RETRO_LOG_INFO, "RP9 disk control: exposed %zu %s image(s)\n",
+			disk_images.size(), use_cd_paths ? "CD" : "floppy");
+	}
+}
 
 static void show_message(const char* text, unsigned duration_ms = 2000,
 	enum retro_log_level level = RETRO_LOG_INFO)
@@ -4587,6 +4625,8 @@ void retro_run(void)
 		}
 		if (core_shutdown_complete)
 			return;
+		if (path_extension_lower(game_path) == "rp9")
+			sync_rp9_disk_control_media();
 		core_started = true;
 		update_memory_map();
 		return;
@@ -4773,9 +4813,11 @@ bool retro_load_game(const struct retro_game_info *info)
 			disk_ejected = false;
 			last_disk_index = 0;
 			last_disk_ejected = false;
-			DiskImage image;
-			image.path = package_path;
-			disk_images.push_back(image);
+			if (!is_rp9) {
+				DiskImage image;
+				image.path = package_path;
+				disk_images.push_back(image);
+			}
 			strncpy(game_path, package_path.c_str(), sizeof(game_path) - 1);
 			game_path[sizeof(game_path) - 1] = '\0';
 			if (log_cb)

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -4031,6 +4031,8 @@ static void core_entry(void)
 		if (rom_path_value.empty())
 			rom_path_value = !system_dir.empty() ? system_dir : save_dir;
 		const std::string rom_path = "rom_path=" + rom_path_value;
+		// RP9 defers this preference until after autoload, but main's RP9 source
+		// pre-scan registers ROMs from the directory before manifest validation.
 		push_s_option(rom_path);
 	}
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1323,10 +1323,13 @@ static bool vfs_write_file(const char* path, const void* data, size_t size)
 	return written == size;
 }
 
-// sysdeps remaps mkdir for Amiga host calls, but it also rewrites the VFS member name.
-// No direct mkdir calls occur below this point, so expose the interface token again.
+// sysdeps remaps mkdir/rmdir for Amiga host calls, but it also rewrites VFS member names.
+// Host content staging below needs the real directory operations.
 #ifdef mkdir
 #undef mkdir
+#endif
+#ifdef rmdir
+#undef rmdir
 #endif
 static int vfs_mkdir_exclusive(const char* path)
 {
@@ -1335,12 +1338,24 @@ static int vfs_mkdir_exclusive(const char* path)
 	return retro_vfs_mkdir_impl(path);
 }
 
+static int remove_empty_content_directory(const std::string& directory)
+{
+#ifdef _WIN32
+	const int result = _rmdir(directory.c_str());
+#else
+	const int result = ::rmdir(directory.c_str());
+#endif
+	// The fallback handles UTF-8 Windows paths and virtual paths such as SAF
+	// without delegating directory removal to the frontend's file-only callback.
+	return result == 0 ? 0 : retro_vfs_file_remove_impl(directory.c_str());
+}
+
 static void remove_content_temp_artifacts(const std::string& file_path, const std::string& directory)
 {
 	if (!file_path.empty())
 		filestream_delete(file_path.c_str());
 	if (!directory.empty())
-		filestream_delete(directory.c_str());
+		remove_empty_content_directory(directory);
 }
 
 static bool stage_content_file(const std::string& parent_directory, const std::string& filename,

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -4046,9 +4046,13 @@ static void core_entry(void)
 		}
 
 		if (have_kick) {
-			if (is_rp9)
+			if (is_rp9) {
+				// The first occurrence registers the ROM before RP9 manifest
+				// validation. Reapply it after autoload because RP9 rebuilds prefs.
+				safe_strdup("-r");
+				safe_strdup(kick_path);
 				deferred_rp9_kickstart = kick_path;
-			else {
+			} else {
 				safe_strdup("-r");
 				safe_strdup(kick_path);
 			}

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -24,9 +24,11 @@
 #include <sys/stat.h>
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <climits>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #ifdef __cplusplus
@@ -35,6 +37,7 @@ extern "C" {
 #include "retro_dirent.h"
 #include "streams/file_stream.h"
 #include "file/file_path.h"
+#include "vfs/vfs_implementation.h"
 #ifdef __cplusplus
 }
 #endif
@@ -161,6 +164,7 @@ static std::string system_dir;
 static std::string save_dir;
 static std::string content_dir;
 static std::string content_temp_path;
+static std::string content_temp_directory;
 static std::string cached_model;
 static std::string cached_kickstart_override;
 static std::string cached_cpu_model;
@@ -1316,6 +1320,58 @@ static bool vfs_write_file(const char* path, const void* data, size_t size)
 	const size_t written = fwrite(data, 1, size, f);
 	fclose(f);
 	return written == size;
+}
+
+// sysdeps remaps mkdir for Amiga host calls, but it also rewrites the VFS member name.
+// No direct mkdir calls occur below this point, so expose the interface token again.
+#ifdef mkdir
+#undef mkdir
+#endif
+static int vfs_mkdir_exclusive(const char* path)
+{
+	if (vfs_available && vfs_iface.mkdir)
+		return vfs_iface.mkdir(path);
+	return retro_vfs_mkdir_impl(path);
+}
+
+static void remove_content_temp_artifacts(const std::string& file_path, const std::string& directory)
+{
+	if (!file_path.empty())
+		filestream_delete(file_path.c_str());
+	if (!directory.empty())
+		filestream_delete(directory.c_str());
+}
+
+static bool stage_content_file(const std::string& parent_directory, const std::string& filename,
+	const void* data, size_t size, std::string& staged_path, std::string& staged_directory)
+{
+	static std::atomic<uint64_t> sequence{0};
+	const auto timestamp = static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+	const auto serial = sequence.fetch_add(1, std::memory_order_relaxed);
+
+	for (unsigned attempt = 0; attempt < 128; ++attempt) {
+		char directory_name[80];
+		snprintf(directory_name, sizeof(directory_name), ".amiberry-content-%llx-%llx-%x",
+			static_cast<unsigned long long>(timestamp), static_cast<unsigned long long>(serial), attempt);
+		const std::string candidate_directory = path_join(parent_directory, directory_name);
+		const int mkdir_result = vfs_mkdir_exclusive(candidate_directory.c_str());
+		if (mkdir_result == -2)
+			continue;
+		if (mkdir_result != 0)
+			return false;
+
+		const std::string candidate_path = path_join(candidate_directory, sanitize_filename(filename));
+		if (vfs_write_file(candidate_path.c_str(), data, size)) {
+			staged_path = candidate_path;
+			staged_directory = candidate_directory;
+			return true;
+		}
+
+		remove_content_temp_artifacts(candidate_path, candidate_directory);
+		return false;
+	}
+
+	return false;
 }
 
 static bool vfs_read_all(const char* path, std::vector<uint8_t>& out)
@@ -4579,6 +4635,7 @@ bool retro_load_game(const struct retro_game_info *info)
 			setup_whdload_paths();
 
 		std::string package_path = path;
+		std::string package_temp_directory;
 		bool extracted = false;
 
 		if (info_ext && info_ext->data && info_ext->size > 0 &&
@@ -4589,12 +4646,13 @@ bool retro_load_game(const struct retro_game_info *info)
 			if (safe_name.length() > 200) safe_name.resize(200);
 			const std::string out_file = std::string(temp_prefix) + safe_name + "." +
 				(info_ext->ext ? info_ext->ext : (is_rp9 ? "rp9" : "lha"));
-			const std::string out_path = path_join(out_dir, out_file);
-			if (vfs_write_file(out_path.c_str(), info_ext->data, info_ext->size)) {
-				package_path = out_path;
+			std::string out_path;
+			if (stage_content_file(out_dir, out_file, info_ext->data, info_ext->size,
+				out_path, package_temp_directory)) {
+				package_path = std::move(out_path);
 				extracted = true;
 			} else if (log_cb) {
-				log_cb(RETRO_LOG_WARN, "Failed to write %s data to %s\n", content_label, out_path.c_str());
+				log_cb(RETRO_LOG_WARN, "Failed to stage %s data in %s\n", content_label, out_dir.c_str());
 			}
 		} else if (info_ext && info_ext->file_in_archive && info_ext->archive_path && info_ext->archive_file) {
 			std::string vfs_path = std::string(info_ext->archive_path) + "#" + info_ext->archive_file;
@@ -4605,12 +4663,13 @@ bool retro_load_game(const struct retro_game_info *info)
 				std::string safe_name = sanitize_filename(base);
 				if (safe_name.length() > 200) safe_name.resize(200);
 				const std::string out_file = std::string(temp_prefix) + safe_name + "." + ext;
-				const std::string out_path = path_join(out_dir, out_file);
-				if (vfs_write_file(out_path.c_str(), data.data(), data.size())) {
-					package_path = out_path;
+				std::string out_path;
+				if (stage_content_file(out_dir, out_file, data.data(), data.size(),
+					out_path, package_temp_directory)) {
+					package_path = std::move(out_path);
 					extracted = true;
 				} else if (log_cb) {
-					log_cb(RETRO_LOG_WARN, "Failed to write %s file to %s\n", content_label, out_path.c_str());
+					log_cb(RETRO_LOG_WARN, "Failed to stage %s file in %s\n", content_label, out_dir.c_str());
 				}
 			}
 		}
@@ -4626,12 +4685,13 @@ bool retro_load_game(const struct retro_game_info *info)
 				std::string safe_name = sanitize_filename(base);
 				if (safe_name.length() > 200) safe_name.resize(200);
 				const std::string out_file = std::string(temp_prefix) + safe_name;
-				const std::string out_path = path_join(out_dir, out_file);
-				if (vfs_write_file(out_path.c_str(), data.data(), data.size())) {
-					package_path = out_path;
+				std::string out_path;
+				if (stage_content_file(out_dir, out_file, data.data(), data.size(),
+					out_path, package_temp_directory)) {
+					package_path = std::move(out_path);
 					extracted = true;
 				} else if (log_cb) {
-					log_cb(RETRO_LOG_WARN, "Failed to write %s temp file to %s\n", content_label, out_path.c_str());
+					log_cb(RETRO_LOG_WARN, "Failed to stage %s temp file in %s\n", content_label, out_dir.c_str());
 				}
 			} else if (log_cb) {
 				log_cb(RETRO_LOG_WARN, "Failed to read %s path via VFS: %s\n", content_label, package_path.c_str());
@@ -4640,6 +4700,7 @@ bool retro_load_game(const struct retro_game_info *info)
 
 		if (!package_path.empty()) {
 			content_temp_path = extracted ? package_path : std::string();
+			content_temp_directory = extracted ? package_temp_directory : std::string();
 			libretro_debug_log("%s using path: %s (extracted=%d)\n", content_label, package_path.c_str(), extracted ? 1 : 0);
 			disk_images.clear();
 			disk_index = 0;
@@ -4749,13 +4810,9 @@ void retro_unload_game(void)
 	delete_core_fiber();
 	reset_core_runtime_state();
 	cheat_entries.clear();
-	if (!content_temp_path.empty()) {
-		if (vfs_available && vfs_iface.remove)
-			vfs_iface.remove(content_temp_path.c_str());
-		else
-			remove(content_temp_path.c_str());
-		content_temp_path.clear();
-	}
+	remove_content_temp_artifacts(content_temp_path, content_temp_directory);
+	content_temp_path.clear();
+	content_temp_directory.clear();
 }
 
 unsigned retro_get_region(void)

--- a/libretro/libretro_crop_helpers.h
+++ b/libretro/libretro_crop_helpers.h
@@ -24,6 +24,20 @@ struct LibretroCropPixelBuffer {
 constexpr int libretro_crop_expand_stable_frames = 6;
 constexpr int libretro_crop_settle_stable_frames = 18;
 
+inline bool libretro_should_queue_auto_crop_options(const bool automatic_crop,
+	const bool is_rp9)
+{
+	// RP9 must be parsed before deciding whether its manifest clip or the
+	// libretro automatic crop policy owns the output rectangle.
+	return automatic_crop && !is_rp9;
+}
+
+inline bool libretro_should_preserve_rp9_clip(const bool automatic_crop,
+	const bool rp9_has_clip)
+{
+	return automatic_crop && rp9_has_clip;
+}
+
 inline int libretro_crop_rect_right(const LibretroCropRect& rect)
 {
 	return rect.x + rect.w;

--- a/packaging/MacOSXBundleInfo.plist.in
+++ b/packaging/MacOSXBundleInfo.plist.in
@@ -55,6 +55,22 @@
 				<key>LSHandlerRank</key>
 				<string>Owner</string>
 			</dict>
+			<dict>
+				<key>CFBundleTypeName</key>
+				<string>RetroPlatform Package</string>
+				<key>CFBundleTypeExtensions</key>
+				<array>
+					<string>rp9</string>
+				</array>
+				<key>CFBundleTypeMIMETypes</key>
+				<array>
+					<string>application/vnd.cloanto.rp9</string>
+				</array>
+				<key>CFBundleTypeRole</key>
+				<string>Viewer</string>
+				<key>LSHandlerRank</key>
+				<string>Owner</string>
+			</dict>
 		</array>
 	</dict>
 </plist>

--- a/packaging/ios/iOSBundleInfo.plist.in
+++ b/packaging/ios/iOSBundleInfo.plist.in
@@ -75,6 +75,22 @@
 				<key>LSHandlerRank</key>
 				<string>Owner</string>
 			</dict>
+			<dict>
+				<key>CFBundleTypeName</key>
+				<string>RetroPlatform Package</string>
+				<key>CFBundleTypeExtensions</key>
+				<array>
+					<string>rp9</string>
+				</array>
+				<key>CFBundleTypeMIMETypes</key>
+				<array>
+					<string>application/vnd.cloanto.rp9</string>
+				</array>
+				<key>CFBundleTypeRole</key>
+				<string>Viewer</string>
+				<key>LSHandlerRank</key>
+				<string>Owner</string>
+			</dict>
 		</array>
 		<key>UIFileSharingEnabled</key>
 		<true/>

--- a/packaging/linux/Amiberry.desktop
+++ b/packaging/linux/Amiberry.desktop
@@ -13,4 +13,4 @@ Terminal=false
 Categories=Game;Emulator;
 Keywords=Amiga;Emulator;Retro;Commodore;A500;A1200;A4000;WHDLoad;
 PrefersNonDefaultGPU=true
-MimeType=application/x-SPS-virtual-media-image;application/x-DMS-compressed-disk-image;application/x-amiga-disk-image;application/x-cue;application/x-WHDLoad-game-archive;application/x-UAE-savestate-file;
+MimeType=application/x-SPS-virtual-media-image;application/x-DMS-compressed-disk-image;application/x-amiga-disk-image;application/x-cue;application/x-WHDLoad-game-archive;application/x-UAE-savestate-file;application/vnd.cloanto.rp9;

--- a/packaging/linux/Amiberry.metainfo.xml
+++ b/packaging/linux/Amiberry.metainfo.xml
@@ -19,6 +19,11 @@
     <url type="donation">https://ko-fi.com/midwan</url>
     <url type="vcs-browser">https://github.com/BlitterStudio/amiberry</url>
 
+    <provides>
+        <binary>amiberry</binary>
+        <mediatype>application/vnd.cloanto.rp9</mediatype>
+    </provides>
+
     <branding>
         <color type="primary" scheme_preference="light">#3584e4</color>
         <color type="primary" scheme_preference="dark">#1a5fb4</color>

--- a/packaging/linux/mime/amiberry.xml
+++ b/packaging/linux/mime/amiberry.xml
@@ -43,4 +43,10 @@
         </magic>
         <glob pattern="*.uss"/>
     </mime-type>
+    <mime-type type="application/vnd.cloanto.rp9">
+        <comment>RetroPlatform package</comment>
+        <generic-icon name="input-gaming"/>
+        <sub-class-of type="application/zip"/>
+        <glob pattern="*.rp9" weight="80"/>
+    </mime-type>
 </mime-info>

--- a/packaging/windows/fileassoc.iss
+++ b/packaging/windows/fileassoc.iss
@@ -3,6 +3,7 @@ ChangesAssociations=yes
 
 [Tasks]
 Name: "fileassoc"; Description: "File associations:"; GroupDescription: "Associate Amiga file types with Amiberry:"; Flags: unchecked
+Name: "fileassoc\rp9"; Description: ".rp9 - RetroPlatform Package"; Flags: unchecked
 Name: "fileassoc\uae"; Description: ".uae - Amiberry Configuration"; Flags: unchecked
 Name: "fileassoc\adf"; Description: ".adf - Amiga Disk Image"; Flags: unchecked
 Name: "fileassoc\ipf"; Description: ".ipf - IPF Disk Image"; Flags: unchecked
@@ -15,6 +16,13 @@ Name: "fileassoc\chd"; Description: ".chd - MAME Compressed Disk Image"; Flags: 
 Name: "fileassoc\iso"; Description: ".iso - CD Image"; Flags: unchecked
 
 [Registry]
+; .rp9 - RetroPlatform Package
+Root: HKA; Subkey: "Software\Classes\.rp9"; ValueType: string; ValueName: "Content Type"; ValueData: "application/vnd.cloanto.rp9"; Flags: uninsdeletevalue; Tasks: fileassoc\rp9
+Root: HKA; Subkey: "Software\Classes\.rp9\OpenWithProgids"; ValueType: string; ValueName: "Amiberry.rp9"; ValueData: ""; Flags: uninsdeletevalue; Tasks: fileassoc\rp9
+Root: HKA; Subkey: "Software\Classes\Amiberry.rp9"; ValueType: string; ValueName: ""; ValueData: "RetroPlatform Package"; Flags: uninsdeletekey; Tasks: fileassoc\rp9
+Root: HKA; Subkey: "Software\Classes\Amiberry.rp9\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\Amiberry.exe,0"; Tasks: fileassoc\rp9
+Root: HKA; Subkey: "Software\Classes\Amiberry.rp9\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\Amiberry.exe"" ""%1"""; Tasks: fileassoc\rp9
+
 ; .uae - Amiberry Configuration
 Root: HKA; Subkey: "Software\Classes\.uae\OpenWithProgids"; ValueType: string; ValueName: "Amiberry.uae"; ValueData: ""; Flags: uninsdeletevalue; Tasks: fileassoc\uae
 Root: HKA; Subkey: "Software\Classes\Amiberry.uae"; ValueType: string; ValueName: ""; ValueData: "Amiberry Configuration"; Flags: uninsdeletekey; Tasks: fileassoc\uae

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -10644,111 +10644,149 @@ void error_log (const TCHAR *format, ...)
 #ifdef AMIBERRY
 int bip_a4000(struct uae_prefs* p, int rom)
 {
-	return bip_a4000(p, 0, 0, 0);
+	const int v = bip_a4000(p, 0, 0, 0);
+	if (rom < 0)
+		return v;
+
+	int roms[4];
+	if (rom == 300) {
+		roms[0] = 12;
+		roms[1] = -1;
+	} else if (rom == 310) {
+		roms[0] = 16;
+		roms[1] = 31;
+		roms[2] = 13;
+		roms[3] = -1;
+	} else {
+		return 0;
+	}
+	return configure_rom(p, roms, 0);
 }
 
 int bip_cd32(struct uae_prefs* p, int rom)
 {
+	if (rom >= 0 && rom != 310 && rom != RP9_SYSTEM_ROM_310_CD32)
+		return 0;
 	return bip_cd32(p, 0, 0, 0);
 }
 
-int bip_cdtv(struct uae_prefs* p, int rom)
-{
-	return bip_cdtv(p, 0, 0, 0);
-}
-
-int bip_a1200(struct uae_prefs* p, int rom)
+static int configure_rp9_early_system_rom(struct uae_prefs* p, const int rom)
 {
 	int roms[4];
 
-	int v = bip_a1200(p, 0, 0, 0);
-	if (rom == 310)
-	{
-		roms[0] = 15;
-		roms[1] = 11;
-		roms[2] = 31;
-		roms[3] = -1;
-		v = configure_rom(p, roms, 0);
-	}
-
-	return v;
-}
-
-int bip_a500plus(struct uae_prefs* p, int rom)
-{
-	int roms[4];
-
-	int v = bip_a500p(p, 0, 0, 0);
-	if (rom == 130)
-	{
-		roms[0] = 6;
-		roms[1] = 5;
-		roms[2] = 4;
-		roms[3] = -1;
-	}
-	else
-	{
-		roms[0] = 7;
-		roms[1] = 6;
-		roms[2] = 5;
-		roms[3] = -1;
-	}
-	return configure_rom(p, roms, 0);
-}
-
-static int configure_a500_a2000_rom(struct uae_prefs* p, int rom)
-{
-	int roms[4];
-
-	// RetroPlatform system ROM codes identify the requested Kickstart version.
-	// Prefer the matching ROM, then progressively compatible fallbacks.
+	// An RP9 configuration ROM is a requirement. Alternatives below are only
+	// regional or hardware variants of that exact Kickstart release.
 	switch (rom)
 	{
 	case 100:
 		roms[0] = 1;
-		roms[1] = 3;
-		roms[2] = 2;
+		roms[1] = -1;
 		break;
 	case 110:
 		roms[0] = p->ntscmode ? 2 : 3;
 		roms[1] = p->ntscmode ? 3 : 2;
-		roms[2] = 1;
+		roms[2] = -1;
+		break;
+	case 120:
+		roms[0] = 5;
+		roms[1] = 4;
+		roms[2] = -1;
 		break;
 	case 130:
 		roms[0] = 6;
-		roms[1] = 5;
-		roms[2] = 4;
+		roms[1] = -1;
+		break;
+	case 204:
+		roms[0] = 7;
+		roms[1] = -1;
+		break;
+	case 205:
+		roms[0] = 10;
+		roms[1] = 9;
+		roms[2] = 8;
+		roms[3] = -1;
 		break;
 	case 310:
 		roms[0] = 14;
-		roms[1] = 6;
-		roms[2] = 5;
+		roms[1] = -1;
 		break;
-	case 120:
 	default:
-		roms[0] = 5;
-		roms[1] = 4;
-		roms[2] = 3;
-		break;
+		return 0;
 	}
-	roms[3] = -1;
 	return configure_rom(p, roms, 0);
+}
+
+int bip_cdtv(struct uae_prefs* p, int rom)
+{
+	const int v = bip_cdtv(p, 0, 0, 0);
+	if (rom < 0)
+		return v;
+	if (rom != 120 && rom != 130 && rom != 310)
+		return 0;
+	if (!configure_rp9_early_system_rom(p, rom))
+		return 0;
+
+	const int extension_roms[] = { 20, 21, 22, -1 };
+	return configure_rom(p, extension_roms, 0);
+}
+
+int bip_a1200(struct uae_prefs* p, int rom)
+{
+	const int v = bip_a1200(p, 0, 0, 0);
+	if (rom < 0)
+		return v;
+
+	int roms[2];
+	if (rom == 300) {
+		roms[0] = 11;
+		roms[1] = -1;
+	} else if (rom == 310) {
+		roms[0] = 15;
+		roms[1] = -1;
+	} else {
+		return 0;
+	}
+	return configure_rom(p, roms, 0);
+}
+
+int bip_a500plus(struct uae_prefs* p, int rom)
+{
+	const int v = bip_a500p(p, 0, 0, 0);
+	if (rom < 0)
+		return v;
+	if (rom != 120 && rom != 130 && rom != 204 && rom != 310)
+		return 0;
+	return configure_rp9_early_system_rom(p, rom);
 }
 
 int bip_a500(struct uae_prefs* p, int rom)
 {
-	bip_a500(p, 0, 0, 0);
-	return configure_a500_a2000_rom(p, rom);
+	const int v = bip_a500(p, 0, 0, 0);
+	if (rom < 0)
+		return v;
+	if (rom != 100 && rom != 110 && rom != 120 && rom != 130 && rom != 310)
+		return 0;
+	return configure_rp9_early_system_rom(p, rom);
 }
 
 int bip_a600(struct uae_prefs* p, int rom)
 {
-	return bip_a600(p, 0, 0, 0);
+	const int v = bip_a600(p, 0, 0, 0);
+	if (rom < 0)
+		return v;
+	if (rom != 120 && rom != 130 && rom != 204 && rom != 205 && rom != 310)
+		return 0;
+	return configure_rp9_early_system_rom(p, rom);
 }
 
 int bip_a1000(struct uae_prefs* p, int rom)
 {
-	return bip_a1000(p, 0, 0, 0);
+	const int v = bip_a1000(p, 0, 0, 0);
+	if (rom < 0)
+		return v;
+	if (rom != 100 && rom != 110 && rom != 120 && rom != 130)
+		return 0;
+	return configure_rp9_early_system_rom(p, rom);
 }
 
 int bip_a2000(struct uae_prefs* p, int rom)
@@ -10761,11 +10799,29 @@ int bip_a2000(struct uae_prefs* p, int rom)
 	p->cpu_compatible = false;
 	p->nr_floppies = 1;
 	p->floppyslots[1].dfxtype = DRV_NONE;
-	return configure_a500_a2000_rom(p, rom);
+	if (rom < 0)
+		rom = 130;
+	if (rom != 100 && rom != 110 && rom != 120 && rom != 130 && rom != 310)
+		return 0;
+	return configure_rp9_early_system_rom(p, rom);
 }
 
 int bip_a3000(struct uae_prefs* p, int rom)
 {
-	return bip_a3000(p, 0, 0, 0);
+	const int v = bip_a3000(p, 0, 0, 0);
+	if (rom < 0)
+		return v;
+
+	int roms[2];
+	if (rom == 130)
+		roms[0] = 32;
+	else if (rom == 204)
+		roms[0] = 71;
+	else if (rom == 310)
+		roms[0] = 61;
+	else
+		return 0;
+	roms[1] = -1;
+	return configure_rom(p, roms, 0);
 }
 #endif

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -10642,34 +10642,6 @@ void error_log (const TCHAR *format, ...)
 }
 
 #ifdef AMIBERRY
-int bip_a4000(struct uae_prefs* p, int rom)
-{
-	const int v = bip_a4000(p, 0, 0, 0);
-	if (rom < 0)
-		return v;
-
-	int roms[4];
-	if (rom == 300) {
-		roms[0] = 12;
-		roms[1] = -1;
-	} else if (rom == 310) {
-		roms[0] = 16;
-		roms[1] = 31;
-		roms[2] = 13;
-		roms[3] = -1;
-	} else {
-		return 0;
-	}
-	return configure_rom(p, roms, 0);
-}
-
-int bip_cd32(struct uae_prefs* p, int rom)
-{
-	if (rom >= 0 && rom != 310 && rom != RP9_SYSTEM_ROM_310_CD32)
-		return 0;
-	return bip_cd32(p, 0, 0, 0);
-}
-
 static int configure_rp9_early_system_rom(struct uae_prefs* p, const int rom)
 {
 	int roms[4];
@@ -10716,77 +10688,186 @@ static int configure_rp9_early_system_rom(struct uae_prefs* p, const int rom)
 	return configure_rom(p, roms, 0);
 }
 
+int configure_rp9_system_rom(struct uae_prefs* p, const rp9_system_model model, const int rom)
+{
+	int roms[4];
+	switch (model)
+	{
+	case rp9_system_model::a1000:
+		if (rom != 100 && rom != 110 && rom != 120 && rom != 130)
+			return 0;
+		return configure_rp9_early_system_rom(p, rom);
+	case rp9_system_model::a500:
+	case rp9_system_model::a2000:
+		if (rom != 100 && rom != 110 && rom != 120 && rom != 130 && rom != 310)
+			return 0;
+		return configure_rp9_early_system_rom(p, rom);
+	case rp9_system_model::a500plus:
+		if (rom != 120 && rom != 130 && rom != 204 && rom != 310)
+			return 0;
+		return configure_rp9_early_system_rom(p, rom);
+	case rp9_system_model::a600:
+		if (rom != 120 && rom != 130 && rom != 204 && rom != 205 && rom != 310)
+			return 0;
+		return configure_rp9_early_system_rom(p, rom);
+	case rp9_system_model::a1200:
+		if (rom == 300)
+			roms[0] = 11;
+		else if (rom == 310)
+			roms[0] = 15;
+		else
+			return 0;
+		roms[1] = -1;
+		return configure_rom(p, roms, 0);
+	case rp9_system_model::a3000:
+		if (rom == 130)
+			roms[0] = 32;
+		else if (rom == 204)
+			roms[0] = 71;
+		else if (rom == 310)
+			roms[0] = 61;
+		else
+			return 0;
+		roms[1] = -1;
+		return configure_rom(p, roms, 0);
+	case rp9_system_model::a4000:
+		if (rom == 300) {
+			roms[0] = 12;
+			roms[1] = -1;
+		} else if (rom == 310) {
+			roms[0] = 16;
+			roms[1] = 31;
+			roms[2] = 13;
+			roms[3] = -1;
+		} else {
+			return 0;
+		}
+		return configure_rom(p, roms, 0);
+	case rp9_system_model::cdtv:
+		if (rom != 120 && rom != 130 && rom != 310)
+			return 0;
+		if (!configure_rp9_early_system_rom(p, rom))
+			return 0;
+		roms[0] = 20;
+		roms[1] = 21;
+		roms[2] = 22;
+		roms[3] = -1;
+		return configure_rom(p, roms, 0);
+	case rp9_system_model::cd32:
+		if (rom != 310 && rom != RP9_SYSTEM_ROM_310_CD32)
+			return 0;
+		return bip_cd32(p, 0, 0, 0);
+	}
+	return 0;
+}
+
+int bip_a4000(struct uae_prefs* p, int rom)
+{
+	return bip_a4000(p, 0, 0, 0);
+}
+
+int bip_cd32(struct uae_prefs* p, int rom)
+{
+	return bip_cd32(p, 0, 0, 0);
+}
+
 int bip_cdtv(struct uae_prefs* p, int rom)
 {
-	const int v = bip_cdtv(p, 0, 0, 0);
-	if (rom < 0)
-		return v;
-	if (rom != 120 && rom != 130 && rom != 310)
-		return 0;
-	if (!configure_rp9_early_system_rom(p, rom))
-		return 0;
-
-	const int extension_roms[] = { 20, 21, 22, -1 };
-	return configure_rom(p, extension_roms, 0);
+	return bip_cdtv(p, 0, 0, 0);
 }
 
 int bip_a1200(struct uae_prefs* p, int rom)
 {
-	const int v = bip_a1200(p, 0, 0, 0);
-	if (rom < 0)
-		return v;
+	int roms[4];
 
-	int roms[2];
-	if (rom == 300) {
-		roms[0] = 11;
-		roms[1] = -1;
-	} else if (rom == 310) {
+	int v = bip_a1200(p, 0, 0, 0);
+	if (rom == 310)
+	{
 		roms[0] = 15;
-		roms[1] = -1;
-	} else {
-		return 0;
+		roms[1] = 11;
+		roms[2] = 31;
+		roms[3] = -1;
+		v = configure_rom(p, roms, 0);
 	}
-	return configure_rom(p, roms, 0);
+
+	return v;
 }
 
 int bip_a500plus(struct uae_prefs* p, int rom)
 {
-	const int v = bip_a500p(p, 0, 0, 0);
-	if (rom < 0)
-		return v;
-	if (rom != 120 && rom != 130 && rom != 204 && rom != 310)
-		return 0;
-	return configure_rp9_early_system_rom(p, rom);
+	int roms[4];
+
+	bip_a500p(p, 0, 0, 0);
+	if (rom == 130)
+	{
+		roms[0] = 6;
+		roms[1] = 5;
+		roms[2] = 4;
+		roms[3] = -1;
+	}
+	else
+	{
+		roms[0] = 7;
+		roms[1] = 6;
+		roms[2] = 5;
+		roms[3] = -1;
+	}
+	return configure_rom(p, roms, 0);
+}
+
+static int configure_a500_a2000_rom(struct uae_prefs* p, int rom)
+{
+	int roms[4];
+
+	// General model selection keeps compatible fallbacks for users who do not
+	// have the preferred ROM. RP9 requirements use the strict helper above.
+	switch (rom)
+	{
+	case 100:
+		roms[0] = 1;
+		roms[1] = 3;
+		roms[2] = 2;
+		break;
+	case 110:
+		roms[0] = p->ntscmode ? 2 : 3;
+		roms[1] = p->ntscmode ? 3 : 2;
+		roms[2] = 1;
+		break;
+	case 130:
+		roms[0] = 6;
+		roms[1] = 5;
+		roms[2] = 4;
+		break;
+	case 310:
+		roms[0] = 14;
+		roms[1] = 6;
+		roms[2] = 5;
+		break;
+	case 120:
+	default:
+		roms[0] = 5;
+		roms[1] = 4;
+		roms[2] = 3;
+		break;
+	}
+	roms[3] = -1;
+	return configure_rom(p, roms, 0);
 }
 
 int bip_a500(struct uae_prefs* p, int rom)
 {
-	const int v = bip_a500(p, 0, 0, 0);
-	if (rom < 0)
-		return v;
-	if (rom != 100 && rom != 110 && rom != 120 && rom != 130 && rom != 310)
-		return 0;
-	return configure_rp9_early_system_rom(p, rom);
+	bip_a500(p, 0, 0, 0);
+	return configure_a500_a2000_rom(p, rom);
 }
 
 int bip_a600(struct uae_prefs* p, int rom)
 {
-	const int v = bip_a600(p, 0, 0, 0);
-	if (rom < 0)
-		return v;
-	if (rom != 120 && rom != 130 && rom != 204 && rom != 205 && rom != 310)
-		return 0;
-	return configure_rp9_early_system_rom(p, rom);
+	return bip_a600(p, 0, 0, 0);
 }
 
 int bip_a1000(struct uae_prefs* p, int rom)
 {
-	const int v = bip_a1000(p, 0, 0, 0);
-	if (rom < 0)
-		return v;
-	if (rom != 100 && rom != 110 && rom != 120 && rom != 130)
-		return 0;
-	return configure_rp9_early_system_rom(p, rom);
+	return bip_a1000(p, 0, 0, 0);
 }
 
 int bip_a2000(struct uae_prefs* p, int rom)
@@ -10799,29 +10880,11 @@ int bip_a2000(struct uae_prefs* p, int rom)
 	p->cpu_compatible = false;
 	p->nr_floppies = 1;
 	p->floppyslots[1].dfxtype = DRV_NONE;
-	if (rom < 0)
-		rom = 130;
-	if (rom != 100 && rom != 110 && rom != 120 && rom != 130 && rom != 310)
-		return 0;
-	return configure_rp9_early_system_rom(p, rom);
+	return configure_a500_a2000_rom(p, rom);
 }
 
 int bip_a3000(struct uae_prefs* p, int rom)
 {
-	const int v = bip_a3000(p, 0, 0, 0);
-	if (rom < 0)
-		return v;
-
-	int roms[2];
-	if (rom == 130)
-		roms[0] = 32;
-	else if (rom == 204)
-		roms[0] = 71;
-	else if (rom == 310)
-		roms[0] = 61;
-	else
-		return 0;
-	roms[1] = -1;
-	return configure_rom(p, roms, 0);
+	return bip_a3000(p, 0, 0, 0);
 }
 #endif

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -10696,26 +10696,49 @@ int bip_a500plus(struct uae_prefs* p, int rom)
 	return configure_rom(p, roms, 0);
 }
 
-int bip_a500(struct uae_prefs* p, int rom)
+static int configure_a500_a2000_rom(struct uae_prefs* p, int rom)
 {
 	int roms[4];
 
-	int v = bip_a500(p, 0, 0, 0);
-	if (rom == 130)
+	// RetroPlatform system ROM codes identify the requested Kickstart version.
+	// Prefer the matching ROM, then progressively compatible fallbacks.
+	switch (rom)
 	{
+	case 100:
+		roms[0] = 1;
+		roms[1] = 3;
+		roms[2] = 2;
+		break;
+	case 110:
+		roms[0] = p->ntscmode ? 2 : 3;
+		roms[1] = p->ntscmode ? 3 : 2;
+		roms[2] = 1;
+		break;
+	case 130:
 		roms[0] = 6;
 		roms[1] = 5;
 		roms[2] = 4;
-		roms[3] = -1;
-	}
-	else
-	{
+		break;
+	case 310:
+		roms[0] = 14;
+		roms[1] = 6;
+		roms[2] = 5;
+		break;
+	case 120:
+	default:
 		roms[0] = 5;
 		roms[1] = 4;
 		roms[2] = 3;
-		roms[3] = -1;
+		break;
 	}
+	roms[3] = -1;
 	return configure_rom(p, roms, 0);
+}
+
+int bip_a500(struct uae_prefs* p, int rom)
+{
+	bip_a500(p, 0, 0, 0);
+	return configure_a500_a2000_rom(p, rom);
 }
 
 int bip_a600(struct uae_prefs* p, int rom)
@@ -10730,22 +10753,6 @@ int bip_a1000(struct uae_prefs* p, int rom)
 
 int bip_a2000(struct uae_prefs* p, int rom)
 {
-	int roms[4];
-
-	if (rom == 130)
-	{
-		roms[0] = 6;
-		roms[1] = 5;
-		roms[2] = 4;
-		roms[3] = -1;
-	}
-	else
-	{
-		roms[0] = 5;
-		roms[1] = 4;
-		roms[2] = 3;
-		roms[3] = -1;
-	}
 	p->cs_compatible = CP_A2000;
 	built_in_chipset_prefs(p);
 	p->chipmem.size = 0x00080000;
@@ -10754,7 +10761,7 @@ int bip_a2000(struct uae_prefs* p, int rom)
 	p->cpu_compatible = false;
 	p->nr_floppies = 1;
 	p->floppyslots[1].dfxtype = DRV_NONE;
-	return configure_rom(p, roms, 0);
+	return configure_a500_a2000_rom(p, rom);
 }
 
 int bip_a3000(struct uae_prefs* p, int rom)

--- a/src/include/options.h
+++ b/src/include/options.h
@@ -1177,6 +1177,21 @@ extern void copy_inputdevice_prefs(const struct uae_prefs *src, struct uae_prefs
 // Distinguish the CD32-specific 3.1 image from the generic 310 RP9 code.
 constexpr int RP9_SYSTEM_ROM_310_CD32 = 31032;
 
+enum class rp9_system_model
+{
+	a1000,
+	a500,
+	a500plus,
+	a600,
+	a1200,
+	a2000,
+	a3000,
+	a4000,
+	cdtv,
+	cd32
+};
+
+extern int configure_rp9_system_rom(struct uae_prefs* p, rp9_system_model model, int rom);
 extern int bip_a500(struct uae_prefs* p, int rom);
 extern int bip_a500plus(struct uae_prefs* p, int rom);
 extern int bip_a600(struct uae_prefs* p, int rom);

--- a/src/include/options.h
+++ b/src/include/options.h
@@ -1174,6 +1174,9 @@ extern void copy_prefs(const struct uae_prefs* src, struct uae_prefs* dst);
 extern void copy_inputdevice_prefs(const struct uae_prefs *src, struct uae_prefs *dst);
 
 #ifdef AMIBERRY
+// Distinguish the CD32-specific 3.1 image from the generic 310 RP9 code.
+constexpr int RP9_SYSTEM_ROM_310_CD32 = 31032;
+
 extern int bip_a500(struct uae_prefs* p, int rom);
 extern int bip_a500plus(struct uae_prefs* p, int rom);
 extern int bip_a600(struct uae_prefs* p, int rom);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1662,6 +1662,7 @@ static int real_main2 (int argc, TCHAR **argv)
 			return 1;
 		}
 	}
+	rp9_cleanup_unused();
 
 #ifndef LIBRETRO
 	if (amiberry_options.update_check && get_update_method() != UpdateMethod::DISABLED) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1200,6 +1200,8 @@ static void register_cmdline_rp9_rom_sources(const int argc, TCHAR** argv)
 			}
 			constexpr auto rom_path_prefix = _T("rom_path=");
 			constexpr auto rom_path_prefix_length = 9;
+			constexpr auto qualified_rom_path_prefix = TARGET_NAME _T(".rom_path=");
+			constexpr auto qualified_rom_path_prefix_length = sizeof(TARGET_NAME _T(".rom_path=")) / sizeof(TCHAR) - 1;
 			constexpr auto rom_file_prefix = _T("kickstart_rom_file=");
 			constexpr auto rom_file_prefix_length = 19;
 			constexpr auto rom_ext_file_prefix = _T("kickstart_ext_rom_file=");
@@ -1209,6 +1211,9 @@ static void register_cmdline_rp9_rom_sources(const int argc, TCHAR** argv)
 			bool directory = false;
 			if (_tcsnicmp(argument, rom_path_prefix, rom_path_prefix_length) == 0) {
 				path_argument = argument + rom_path_prefix_length;
+				directory = true;
+			} else if (_tcsnicmp(argument, qualified_rom_path_prefix, qualified_rom_path_prefix_length) == 0) {
+				path_argument = argument + qualified_rom_path_prefix_length;
 				directory = true;
 			} else if (_tcsnicmp(argument, rom_file_prefix, rom_file_prefix_length) == 0) {
 				path_argument = argument + rom_file_prefix_length;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1395,6 +1395,16 @@ static void parse_cmdline (int argc, TCHAR **argv)
 			const auto ret = parse_cmdline_option(&currprefs, argv[i][1], arg);
 			if (ret == -1)
 				usage();
+#ifdef AMIBERRY
+			// RP9 validates explicit ROM requirements while --autoload is parsed.
+			// Register a preceding -r path so an override outside scanned ROM roots
+			// can satisfy that validation.
+			if (ret && argv[i][1] == 'r' && currprefs.romfile[0]
+				&& !rp9_register_rom_override(currprefs.romfile)) {
+				write_log(_T("Kickstart override could not be registered for RP9 validation: %s\n"),
+					currprefs.romfile);
+			}
+#endif
 			if (ret && extra_arg)
 				i++;
 		} else if (!loaded) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1167,24 +1167,47 @@ static TCHAR *parsetextpath (const TCHAR *s)
 }
 
 #ifdef AMIBERRY
-static void register_cmdline_rom_overrides(const int argc, TCHAR** argv)
+static void register_cmdline_rp9_rom_sources(const int argc, TCHAR** argv)
 {
 	for (auto index = 1; index < argc; ++index) {
-		if (argv[index][0] != '-' || argv[index][1] != 'r')
+		if (argv[index][0] != '-')
 			continue;
 
-		const TCHAR* argument = argv[index] + 2;
-		if (!argument[0]) {
-			if (index + 1 >= argc)
-				continue;
-			argument = argv[++index];
+		if (argv[index][1] == 'r') {
+			const TCHAR* argument = argv[index] + 2;
+			if (!argument[0]) {
+				if (index + 1 >= argc)
+					continue;
+				argument = argv[++index];
+			}
+
+			auto* const path = parsetextpath(argument);
+			if (path[0] && !rp9_register_rom_override(path)) {
+				write_log(_T("Kickstart override could not be registered for RP9 validation: %s\n"), path);
+			}
+			xfree(path);
+			continue;
 		}
 
-		auto* const path = parsetextpath(argument);
-		if (path[0] && !rp9_register_rom_override(path)) {
-			write_log(_T("Kickstart override could not be registered for RP9 validation: %s\n"), path);
+		if (argv[index][1] == 's') {
+			const TCHAR* argument = argv[index] + 2;
+			if (!argument[0]) {
+				if (index + 1 >= argc)
+					continue;
+				argument = argv[++index];
+			}
+			constexpr auto rom_path_prefix = _T("rom_path=");
+			constexpr auto rom_path_prefix_length = 9;
+			if (_tcsnicmp(argument, rom_path_prefix, rom_path_prefix_length) != 0)
+				continue;
+
+			auto* const path = parsetextpath(argument + rom_path_prefix_length);
+			const auto registered = rp9_register_rom_directory(path);
+			if (registered > 0) {
+				write_log(_T("RP9: registered %d ROM(s) from command-line ROM path '%s'\n"), registered, path);
+			}
+			xfree(path);
 		}
-		xfree(path);
 	}
 }
 #endif
@@ -1224,8 +1247,8 @@ static void parse_cmdline (int argc, TCHAR **argv)
 
 #ifdef AMIBERRY
 	// RP9 validates required ROMs as soon as --autoload is parsed, so publish
-	// every explicit override before processing options in their requested order.
-	register_cmdline_rom_overrides(argc, argv);
+	// every explicit override and ROM path before processing options in order.
+	register_cmdline_rp9_rom_sources(argc, argv);
 #endif
 
 	for (auto i = 1; i < argc; i++) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1166,6 +1166,29 @@ static TCHAR *parsetextpath (const TCHAR *s)
 	return s3;
 }
 
+#ifdef AMIBERRY
+static void register_cmdline_rom_overrides(const int argc, TCHAR** argv)
+{
+	for (auto index = 1; index < argc; ++index) {
+		if (argv[index][0] != '-' || argv[index][1] != 'r')
+			continue;
+
+		const TCHAR* argument = argv[index] + 2;
+		if (!argument[0]) {
+			if (index + 1 >= argc)
+				continue;
+			argument = argv[++index];
+		}
+
+		auto* const path = parsetextpath(argument);
+		if (path[0] && !rp9_register_rom_override(path)) {
+			write_log(_T("Kickstart override could not be registered for RP9 validation: %s\n"), path);
+		}
+		xfree(path);
+	}
+}
+#endif
+
 std::string get_filename_extension(const TCHAR* filename)
 {
 	const std::string fName(filename);
@@ -1198,6 +1221,12 @@ static void parse_cmdline (int argc, TCHAR **argv)
 	if (cmdline_started)
 		return;
 	cmdline_started = true;
+
+#ifdef AMIBERRY
+	// RP9 validates required ROMs as soon as --autoload is parsed, so publish
+	// every explicit override before processing options in their requested order.
+	register_cmdline_rom_overrides(argc, argv);
+#endif
 
 	for (auto i = 1; i < argc; i++) {
 		if (_tcsncmp(argv[i], _T("-cli="), 5) == 0 || _tcsncmp(argv[i], _T("--cli="), 6) == 0) {
@@ -1395,16 +1424,6 @@ static void parse_cmdline (int argc, TCHAR **argv)
 			const auto ret = parse_cmdline_option(&currprefs, argv[i][1], arg);
 			if (ret == -1)
 				usage();
-#ifdef AMIBERRY
-			// RP9 validates explicit ROM requirements while --autoload is parsed.
-			// Register a preceding -r path so an override outside scanned ROM roots
-			// can satisfy that validation.
-			if (ret && argv[i][1] == 'r' && currprefs.romfile[0]
-				&& !rp9_register_rom_override(currprefs.romfile)) {
-				write_log(_T("Kickstart override could not be registered for RP9 validation: %s\n"),
-					currprefs.romfile);
-			}
-#endif
 			if (ret && extra_arg)
 				i++;
 		} else if (!loaded) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1173,7 +1173,8 @@ static void register_cmdline_rp9_rom_sources(const int argc, TCHAR** argv)
 		if (argv[index][0] != '-')
 			continue;
 
-		if (argv[index][1] == 'r') {
+		if (argv[index][1] == 'r' || argv[index][1] == 'K') {
+			const auto extended = argv[index][1] == 'K';
 			const TCHAR* argument = argv[index] + 2;
 			if (!argument[0]) {
 				if (index + 1 >= argc)
@@ -1183,7 +1184,8 @@ static void register_cmdline_rp9_rom_sources(const int argc, TCHAR** argv)
 
 			auto* const path = parsetextpath(argument);
 			if (path[0] && !rp9_register_rom_override(path)) {
-				write_log(_T("Kickstart override could not be registered for RP9 validation: %s\n"), path);
+				write_log(_T("%sKickstart override could not be registered for RP9 validation: %s\n"),
+					extended ? _T("Extended ") : _T(""), path);
 			}
 			xfree(path);
 			continue;
@@ -1198,13 +1200,32 @@ static void register_cmdline_rp9_rom_sources(const int argc, TCHAR** argv)
 			}
 			constexpr auto rom_path_prefix = _T("rom_path=");
 			constexpr auto rom_path_prefix_length = 9;
-			if (_tcsnicmp(argument, rom_path_prefix, rom_path_prefix_length) != 0)
-				continue;
+			constexpr auto rom_file_prefix = _T("kickstart_rom_file=");
+			constexpr auto rom_file_prefix_length = 19;
+			constexpr auto rom_ext_file_prefix = _T("kickstart_ext_rom_file=");
+			constexpr auto rom_ext_file_prefix_length = 23;
 
-			auto* const path = parsetextpath(argument + rom_path_prefix_length);
-			const auto registered = rp9_register_rom_directory(path);
-			if (registered > 0) {
-				write_log(_T("RP9: registered %d ROM(s) from command-line ROM path '%s'\n"), registered, path);
+			const TCHAR* path_argument = nullptr;
+			bool directory = false;
+			if (_tcsnicmp(argument, rom_path_prefix, rom_path_prefix_length) == 0) {
+				path_argument = argument + rom_path_prefix_length;
+				directory = true;
+			} else if (_tcsnicmp(argument, rom_file_prefix, rom_file_prefix_length) == 0) {
+				path_argument = argument + rom_file_prefix_length;
+			} else if (_tcsnicmp(argument, rom_ext_file_prefix, rom_ext_file_prefix_length) == 0) {
+				path_argument = argument + rom_ext_file_prefix_length;
+			} else {
+				continue;
+			}
+
+			auto* const path = parsetextpath(path_argument);
+			if (directory) {
+				const auto registered = rp9_register_rom_directory(path);
+				if (registered > 0) {
+					write_log(_T("RP9: registered %d ROM(s) from command-line ROM path '%s'\n"), registered, path);
+				}
+			} else if (path[0] && !rp9_register_rom_override(path)) {
+				write_log(_T("Kickstart configuration override could not be registered for RP9 validation: %s\n"), path);
 			}
 			xfree(path);
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,6 +77,7 @@
 #ifndef LIBRETRO
 #include "amiberry_update.h"
 #endif
+#include "amiberry_rp9.h"
 
 
 // Special version string so that AmigaOS can detect it
@@ -1009,7 +1010,7 @@ void usage()
 	std::cout << " --model <Amiga Model>      Amiga model to emulate, from the QuickStart options." << '\n';
 	std::cout << "                            Available options are: A1000, A500, A500P, A600, A2000, A3000, A1200, A4000, CD32 and CDTV.\n" <<
 		'\n';
-	std::cout << " --autoload <file>          Load an .lha WHDLoad game or a CD32 CD image, using the WHDBooter." << '\n';
+	std::cout << " --autoload <file>          Load an RP9 package, an .lha WHDLoad game, or a CD image." << '\n';
 	std::cout << " --cdimage <file>           Load the CD image provided when starting emulation." << '\n';
 	std::cout << " --statefile <file>         Load a save state file." << '\n';
 	std::cout << " -s <option>=<value>        Set one or more configuration options directly, without loading a file." <<
@@ -1018,7 +1019,7 @@ void usage()
 		'\n';
 	std::cout << "\nAdditional options:" << '\n';
 	std::cout << "amiberry <file>             Auto-detect the type of file and use the default action for it." << '\n';
-	std::cout << "                            Supported file types are: .uae config, .lha WHDLoad, CD images and disk images." << '\n';
+	std::cout << "                            Supported file types are: .uae configs, .rp9 packages, .lha WHDLoad, CD and disk images." << '\n';
 	std::cout << " -0 <disk.adf>              Insert specified ADF image into emulated floppy drive 0-3." << '\n';
 	std::cout << " -1 <disk.adf>              " << '\n';
 	std::cout << " -2 <disk.adf>              " << '\n';
@@ -1320,7 +1321,7 @@ static void parse_cmdline (int argc, TCHAR **argv)
 			}
 			loaded = true;
 		}
-		// Auto-load .cue / .lha  
+		// Auto-load RP9, WHDLoad or CD content.
 		else if (_tcscmp(argv[i], _T("--autoload")) == 0)
 		{
 			if (i + 1 == argc)
@@ -1329,25 +1330,31 @@ static void parse_cmdline (int argc, TCHAR **argv)
 			{
 				auto* const txt = parsetextpath(argv[++i]);
 				const auto txt2 = get_filename_extension(txt); // Extract the extension from the string  (incl '.')
-				if (_tcscmp(txt2.c_str(), ".lha") == 0)
+				if (_tcsicmp(txt2.c_str(), ".rp9") == 0)
+				{
+					write_log("RP9... %s\n", txt);
+					if (target_cfgfile_load(&currprefs, txt, CONFIG_TYPE_ALL, 0))
+						config_loaded = true;
+				}
+				else if (_tcsicmp(txt2.c_str(), ".lha") == 0)
 				{
 					write_log("WHDLoad... %s\n", txt);
 					add_file_to_mru_list(lstMRUWhdloadList, std::string(txt));
 					whdload_prefs.whdload_filename = std::string(txt);
 					whdload_auto_prefs(&currprefs, txt);
-					xfree(txt);
 				}
-				else if (_tcscmp(txt2.c_str(), ".cue") == 0
-					|| _tcscmp(txt2.c_str(), ".iso") == 0
-					|| _tcscmp(txt2.c_str(), ".chd") == 0)
+				else if (_tcsicmp(txt2.c_str(), ".cue") == 0
+					|| _tcsicmp(txt2.c_str(), ".iso") == 0
+					|| _tcsicmp(txt2.c_str(), ".chd") == 0)
 				{
 					write_log("CDTV/CD32... %s\n", txt);
 					add_file_to_mru_list(lstMRUCDList, std::string(txt));
 					cd_auto_prefs(&currprefs, txt);
-					xfree(txt);
 				}
 				else
 					write_log("Unknown extension for autoload... %s\n", txt);
+				xfree(txt);
+				loaded = true;
 			}
 		}
 		else if (_tcscmp(argv[i], _T("--log")) == 0)
@@ -1394,7 +1401,15 @@ static void parse_cmdline (int argc, TCHAR **argv)
 			auto* const txt = parsetextpath(argv[i]);
 			const auto txt2 = get_filename_extension(txt); // Extract the extension from the string  (incl '.')
 #ifdef AMIBERRY
-			if (_tcscmp(txt2.c_str(), ".lha") == 0)
+			if (_tcsicmp(txt2.c_str(), ".rp9") == 0)
+			{
+				write_log("RP9... %s\n", txt);
+				if (target_cfgfile_load(&currprefs, txt, CONFIG_TYPE_ALL, 0)) {
+					config_loaded = true;
+					currprefs.start_gui = false;
+				}
+			}
+			else if (_tcsicmp(txt2.c_str(), ".lha") == 0)
 			{
 				write_log("WHDLoad... %s\n", txt);
 				add_file_to_mru_list(lstMRUWhdloadList, std::string(txt));

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -6032,8 +6032,6 @@ int target_cfgfile_load(uae_prefs* p, const char* filename, int type, const int 
 		rp9_clear_loaded_path();
 	if (type > 0)
 		return result;
-	if (result)
-		extract_filename(filename, last_loaded_config);
 
 	for (auto i = 0; i < p->nr_floppies; ++i)
 	{
@@ -6045,7 +6043,12 @@ int target_cfgfile_load(uae_prefs* p, const char* filename, int type, const int 
 	}
 	if (p->cdslots[0].inuse && p->cdslots[0].name[0])
 		add_file_to_mru_list(lstMRUCDList, p->cdslots[0].name);
-	set_last_loaded_config(filename, isdefault != 0);
+	if (is_rp9) {
+		last_loaded_config[0] = 0;
+		last_loaded_config_is_automatic_default = false;
+	} else {
+		set_last_loaded_config(filename, isdefault != 0);
+	}
 	set_last_active_config(filename);
 	return result;
 }

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -61,6 +61,7 @@
 
 #include "amiberry_input.h"
 #include "amiberry_adpf.h"
+#include "amiberry_rp9.h"
 #include "amiberry_update.h"
 #include "clipboard.h"
 #include "dpi_handler.hpp"
@@ -3193,9 +3194,9 @@ static void handle_drop_file_event(const SDL_Event& event)
 	const char* dropped_file = event.drop.data;
 	const auto ext = get_filename_extension(dropped_file);
 
-	if (strcasecmp(ext.c_str(), ".uae") == 0)
+	if (strcasecmp(ext.c_str(), ".uae") == 0 || strcasecmp(ext.c_str(), ".rp9") == 0)
 	{
-		// Load configuration file
+		// Load configuration or self-contained RP9 package
 		uae_restart(&currprefs, 1, dropped_file);
 		gui_running = false;
 	}
@@ -5985,6 +5986,14 @@ int target_cfgfile_load(uae_prefs* p, const char* filename, int type, const int 
 {
 	int type2;
 	auto result = 0;
+	auto extension = std::filesystem::path(filename).extension().string();
+	std::transform(extension.begin(), extension.end(), extension.begin(), [](const unsigned char ch) {
+		return static_cast<char>(std::tolower(ch));
+	});
+	// An RP9 manifest describes the complete machine. Partial host/hardware loading
+	// would produce a configuration that does not match the package requirements.
+	if (extension == ".rp9")
+		type = CONFIG_TYPE_DEFAULT;
 
 	if (isdefault) {
 		path_statefile[0] = 0;
@@ -6001,17 +6010,23 @@ int target_cfgfile_load(uae_prefs* p, const char* filename, int type, const int 
 		write_log(_T("config reset\n"));
 	}
 
-	const char* ptr = strstr(const_cast<char*>(filename), ".uae");
-	if (ptr)
+	if (extension == ".uae")
 	{
 		write_log(_T("target_cfgfile_load: loading file %s\n"), filename);
 		result = cfgfile_load(p, filename, &type2, 0, isdefault ? 0 : 1);
+	}
+	else if (extension == ".rp9")
+	{
+		write_log(_T("target_cfgfile_load: loading RP9 package %s\n"), filename);
+		result = rp9_parse_file(p, filename) ? 1 : 0;
 	}
 	if (!result)
 	{
 		write_log(_T("target_cfgfile_load: loading file %s failed\n"), filename);
 		return result;
 	}
+	if (extension != ".rp9")
+		rp9_clear_loaded_path();
 	if (type > 0)
 		return result;
 	if (result)
@@ -6025,6 +6040,8 @@ int target_cfgfile_load(uae_prefs* p, const char* filename, int type, const int 
 		if (strlen(p->floppyslots[i].df) > 0)
 			add_file_to_mru_list(lstMRUDiskList, std::string(p->floppyslots[i].df));
 	}
+	if (p->cdslots[0].inuse && p->cdslots[0].name[0])
+		add_file_to_mru_list(lstMRUCDList, p->cdslots[0].name);
 	set_last_loaded_config(filename, isdefault != 0);
 	set_last_active_config(filename);
 	return result;
@@ -11101,6 +11118,7 @@ int amiberry_main(int argc, char* argv[])
 	}
 
 	logging_init();
+	rp9_init();
 #if defined (CPU_arm) && !defined (_WIN32)
 	memset(&action, 0, sizeof action);
 	action.sa_sigaction = signal_segv;
@@ -11260,6 +11278,7 @@ int amiberry_main(int argc, char* argv[])
 
 	romlist_clear();
 	free_keyring();
+	rp9_cleanup();
 
 	logging_cleanup();
 

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -10006,6 +10006,7 @@ static void ensure_amiberry_user_directories()
 	ensure_directory_exists_if_missing(harddrive_path);
 	ensure_directory_exists_if_missing(cdrom_path);
 	ensure_directory_exists_if_missing(rom_path);
+	ensure_directory_exists_if_missing(rp9_path);
 	ensure_directory_exists_if_missing(saveimage_dir);
 	ensure_directory_exists_if_missing(savestate_dir);
 	ensure_directory_exists_if_missing(ripper_path);

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -5982,6 +5982,29 @@ void set_floppy_sounds_path(const std::string& newpath)
 	macos_bookmark_store(newpath);
 }
 
+static void register_rp9_rom_sources_from_prefs(const uae_prefs* prefs)
+{
+	if (!prefs)
+		return;
+
+	for (const auto& path : prefs->path_rom.path) {
+		if (!path[0])
+			continue;
+		const auto registered = rp9_register_rom_directory(path);
+		if (registered > 0) {
+			write_log(_T("RP9: registered %d ROM(s) from configured ROM path '%s'\n"), registered, path);
+		}
+	}
+
+	for (const auto* path : { prefs->romfile, prefs->romextfile, prefs->romextfile2 }) {
+		if (!path[0] || path[0] == ':')
+			continue;
+		if (!rp9_register_rom_override(path)) {
+			write_log(_T("RP9: configured ROM override could not be registered: %s\n"), path);
+		}
+	}
+}
+
 int target_cfgfile_load(uae_prefs* p, const char* filename, int type, const int isdefault)
 {
 	int type2;
@@ -6019,6 +6042,9 @@ int target_cfgfile_load(uae_prefs* p, const char* filename, int type, const int 
 	else if (extension == ".rp9")
 	{
 		write_log(_T("target_cfgfile_load: loading RP9 package %s\n"), filename);
+		// A preceding config or -s option may have supplied ROM sources that the
+		// RP9 machine builder needs before it replaces the current preferences.
+		register_rp9_rom_sources_from_prefs(p);
 		result = rp9_parse_file(p, filename) ? 1 : 0;
 	}
 	if (!result)

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -5990,22 +5990,23 @@ int target_cfgfile_load(uae_prefs* p, const char* filename, int type, const int 
 	std::transform(extension.begin(), extension.end(), extension.begin(), [](const unsigned char ch) {
 		return static_cast<char>(std::tolower(ch));
 	});
+	const bool is_rp9 = extension == ".rp9";
 	// An RP9 manifest describes the complete machine. Partial host/hardware loading
 	// would produce a configuration that does not match the package requirements.
-	if (extension == ".rp9")
+	if (is_rp9)
 		type = CONFIG_TYPE_DEFAULT;
 
-	if (isdefault) {
+	if (isdefault && !is_rp9) {
 		path_statefile[0] = 0;
 	}
 
 	type = std::max(type, 0);
 
-	if (type == 0 || type == 1) {
+	if (!is_rp9 && (type == 0 || type == 1)) {
 		discard_prefs(p, 0);
 	}
 	type2 = type;
-	if (type == 0 || type == 3) {
+	if (!is_rp9 && (type == 0 || type == 3)) {
 		default_prefs(p, true, type);
 		write_log(_T("config reset\n"));
 	}
@@ -6025,6 +6026,8 @@ int target_cfgfile_load(uae_prefs* p, const char* filename, int type, const int 
 		write_log(_T("target_cfgfile_load: loading file %s failed\n"), filename);
 		return result;
 	}
+	if (is_rp9 && isdefault)
+		path_statefile[0] = 0;
 	if (extension != ".rp9")
 		rp9_clear_loaded_path();
 	if (type > 0)

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -48,6 +48,7 @@ std::string loaded_path;
 std::string last_error;
 bool loaded_has_clip;
 std::vector<std::filesystem::path> temporary_directories;
+std::vector<std::string> loaded_cd_paths;
 std::atomic<unsigned long long> directory_sequence { 0 };
 
 bool directory_contains_path(const std::filesystem::path& directory, const TCHAR* value)
@@ -96,6 +97,13 @@ bool pending_snapshot_references_directory(const std::filesystem::path& director
 	return savestate_state != 0 && directory_contains_path(directory, savestate_fname);
 }
 
+bool loaded_cd_paths_reference_directory(const std::filesystem::path& directory)
+{
+	return std::any_of(loaded_cd_paths.begin(), loaded_cd_paths.end(), [&directory](const auto& path) {
+		return directory_contains_path(directory, path.c_str());
+	});
+}
+
 void cleanup_unused_temporary_directories(const uae_prefs* additional_prefs = nullptr)
 {
 	for (auto directory = temporary_directories.begin(); directory != temporary_directories.end();) {
@@ -103,7 +111,8 @@ void cleanup_unused_temporary_directories(const uae_prefs* additional_prefs = nu
 			|| prefs_reference_directory(&changed_prefs, *directory)
 			|| (additional_prefs != &currprefs && additional_prefs != &changed_prefs
 				&& prefs_reference_directory(additional_prefs, *directory))
-			|| pending_snapshot_references_directory(*directory)) {
+			|| pending_snapshot_references_directory(*directory)
+			|| loaded_cd_paths_reference_directory(*directory)) {
 			++directory;
 			continue;
 		}
@@ -1217,6 +1226,7 @@ void rp9_init()
 	loaded_path.clear();
 	last_error.clear();
 	loaded_has_clip = false;
+	loaded_cd_paths.clear();
 }
 
 void rp9_cleanup()
@@ -1407,6 +1417,7 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 
 	for (const auto& warning : manifest.warnings)
 		write_log(_T("RP9: %s\n"), warning.c_str());
+	loaded_cd_paths = cd_paths;
 	temporary_directories.emplace_back(std::move(extraction_directory));
 	cleanup_unused_temporary_directories(prefs);
 	publish_cd_swap_list(cd_paths);
@@ -1444,4 +1455,5 @@ void rp9_clear_loaded_path()
 	}
 	loaded_path.clear();
 	loaded_has_clip = false;
+	loaded_cd_paths.clear();
 }

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -741,8 +741,29 @@ std::filesystem::path resolve_media_path(const rp9::Media& media,
 
 	std::error_code error;
 	if (root == "absolute" || root == "external") {
-		set_error("RP9 media uses a disallowed external host path: " + media.path);
-		return {};
+		const std::filesystem::path path(media.path);
+		if (!path.is_absolute()) {
+			set_error("RP9 external media path is not absolute on this host: " + media.path);
+			return {};
+		}
+
+		const auto status = std::filesystem::status(path, error);
+		if (error) {
+			set_error("Could not inspect RP9 external media path '" + media.path + "': " + error.message());
+			return {};
+		}
+		if (!std::filesystem::exists(status)) {
+			set_error("RP9 external media was not found: " + media.path);
+			return {};
+		}
+		if (!std::filesystem::is_regular_file(status) && !std::filesystem::is_directory(status)) {
+			set_error("RP9 external media is not a regular file or directory: " + media.path);
+			return {};
+		}
+
+		const auto resolved = path.lexically_normal();
+		write_log(_T("RP9: resolved external media: %s\n"), resolved.string().c_str());
+		return resolved;
 	}
 	if (root == "data" || root == "shared") {
 		const auto base = std::filesystem::path(get_rp9_path());

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -91,11 +91,81 @@ int system_rom_code(const std::string& value)
 	return parse_integer(normalized, result) ? result : -1;
 }
 
+std::string deployment_id(const char* manifest, const std::size_t size)
+{
+	// Keep deployments stable if an RP9 is moved while separating packages that
+	// happen to use the same embedded media names. The manifest is small and is
+	// the package's stable identity for this purpose.
+	std::uint64_t hash = 14695981039346656037ULL;
+	for (std::size_t index = 0; index < size; ++index) {
+		hash ^= static_cast<unsigned char>(manifest[index]);
+		hash *= 1099511628211ULL;
+	}
+	std::array<char, 16> buffer {};
+	const auto [end, error] = std::to_chars(buffer.data(), buffer.data() + buffer.size(), hash, 16);
+	if (error != std::errc {})
+		return "package";
+	return std::string(16 - static_cast<std::size_t>(end - buffer.data()), '0')
+		+ std::string(buffer.data(), end);
+}
+
+bool deployed_media_path(const rp9::Media& media, const std::string& package_id,
+	std::filesystem::path& destination, std::string& normalized)
+{
+	if (!rp9::normalize_package_path(media.path, normalized))
+		return false;
+	const char* media_directory = nullptr;
+	switch (media.type) {
+	case rp9::MediaType::Floppy:
+		media_directory = "adf";
+		break;
+	case rp9::MediaType::HardDrive:
+		media_directory = "hdf";
+		break;
+	case rp9::MediaType::Cd:
+		media_directory = "cd";
+		break;
+	case rp9::MediaType::Tape:
+		media_directory = "tape";
+		break;
+	case rp9::MediaType::Snapshot:
+		media_directory = "snapshot";
+		break;
+	default:
+		return false;
+	}
+	destination = std::filesystem::path(get_rp9_path()) / "Shared" / media_directory
+		/ package_id / std::filesystem::path(normalized);
+	return true;
+}
+
+std::unordered_map<std::string, std::filesystem::path> find_existing_deployments(const rp9::Manifest& manifest,
+	const std::string& package_id)
+{
+	std::unordered_map<std::string, std::filesystem::path> result;
+	for (const auto& media : manifest.media) {
+		if (!media.deploy && lowercase(media.root) != "deploy")
+			continue;
+		std::filesystem::path destination;
+		std::string normalized;
+		if (!deployed_media_path(media, package_id, destination, normalized))
+			continue;
+		std::error_code error;
+		if (std::filesystem::is_regular_file(destination, error) && !error)
+			result.emplace(lowercase(normalized), destination);
+	}
+	return result;
+}
+
 bool set_default_system(uae_prefs* prefs, const rp9::Manifest& manifest)
 {
 	default_prefs(prefs, true, 0);
 	const auto& system = manifest.system;
 	auto rom = system_rom_code(manifest.system_rom);
+	if (manifest.video == "ntsc" || manifest.video == "a-ntsc")
+		prefs->ntscmode = true;
+	else if (manifest.video == "pal" || manifest.video == "a-pal")
+		prefs->ntscmode = false;
 	// A system-only configuration means the model's canonical configuration.
 	// The AMIBERRY wrappers historically use -1 to select KS 1.2 for these two
 	// models, whereas the canonical A500/A2000 profile uses KS 1.3.
@@ -198,7 +268,8 @@ std::filesystem::path create_extraction_directory()
 }
 
 bool extract_archive(unzFile archive, const std::filesystem::path& directory,
-	std::unordered_map<std::string, std::filesystem::path>& files)
+	std::unordered_map<std::string, std::filesystem::path>& files,
+	const std::unordered_map<std::string, std::filesystem::path>& skipped_files)
 {
 	unz_global_info global {};
 	if (unzGetGlobalInfo(archive, &global) != UNZ_OK || global.number_entry > maximum_archive_entries) {
@@ -250,68 +321,72 @@ bool extract_archive(unzFile archive, const std::filesystem::path& directory,
 		if (is_directory) {
 			std::filesystem::create_directories(destination, error);
 		} else if (lowercase(normalized) != manifest_name) {
-			if (total_size > maximum_extracted_size - info.uncompressed_size) {
-				set_error("RP9 package exceeds the 16 GiB extraction safety limit");
-				return false;
-			}
-			total_size += info.uncompressed_size;
-			if (std::filesystem::exists(destination, error)) {
-				set_error("RP9 archive contains paths that collide on this filesystem: " + entry_name);
-				return false;
-			}
-			if (error) {
-				set_error("Could not validate an RP9 extraction path: " + error.message());
-				return false;
-			}
-			std::filesystem::create_directories(destination.parent_path(), error);
-			if (error) {
-				set_error("Could not create an RP9 extraction directory: " + error.message());
-				return false;
-			}
-			auto output = uae_fopen(destination.string().c_str(), _T("wbe"));
-			if (!output) {
-				set_error("Could not extract RP9 entry: " + normalized);
-				return false;
-			}
-			if (unzOpenCurrentFile(archive) != UNZ_OK) {
-				fclose(output);
-				set_error("Could not open compressed RP9 entry: " + normalized);
-				return false;
-			}
-			std::uint64_t written = 0;
-			for (;;) {
-				const auto bytes = unzReadCurrentFile(archive, buffer.data(), static_cast<unsigned int>(buffer.size()));
-				if (bytes < 0) {
-					unzCloseCurrentFile(archive);
-					fclose(output);
-					set_error("Error while extracting RP9 entry: " + normalized);
+			if (skipped_files.find(path_key) != skipped_files.end()) {
+				write_log(_T("RP9: skipping embedded copy of deployed media: %s\n"), normalized.c_str());
+			} else {
+				if (total_size > maximum_extracted_size - info.uncompressed_size) {
+					set_error("RP9 package exceeds the 16 GiB extraction safety limit");
 					return false;
 				}
-				if (bytes == 0)
-					break;
-				if (written > info.uncompressed_size
-					|| static_cast<std::uint64_t>(bytes) > info.uncompressed_size - written) {
-					unzCloseCurrentFile(archive);
-					fclose(output);
-					set_error("RP9 entry expands beyond its declared size: " + normalized);
+				total_size += info.uncompressed_size;
+				if (std::filesystem::exists(destination, error)) {
+					set_error("RP9 archive contains paths that collide on this filesystem: " + entry_name);
 					return false;
 				}
-				if (fwrite(buffer.data(), 1, static_cast<std::size_t>(bytes), output)
-					!= static_cast<std::size_t>(bytes)) {
-					unzCloseCurrentFile(archive);
-					fclose(output);
-					set_error("Could not write RP9 entry: " + normalized);
+				if (error) {
+					set_error("Could not validate an RP9 extraction path: " + error.message());
 					return false;
 				}
-				written += static_cast<std::uint64_t>(bytes);
+				std::filesystem::create_directories(destination.parent_path(), error);
+				if (error) {
+					set_error("Could not create an RP9 extraction directory: " + error.message());
+					return false;
+				}
+				auto output = uae_fopen(destination.string().c_str(), _T("wbe"));
+				if (!output) {
+					set_error("Could not extract RP9 entry: " + normalized);
+					return false;
+				}
+				if (unzOpenCurrentFile(archive) != UNZ_OK) {
+					fclose(output);
+					set_error("Could not open compressed RP9 entry: " + normalized);
+					return false;
+				}
+				std::uint64_t written = 0;
+				for (;;) {
+					const auto bytes = unzReadCurrentFile(archive, buffer.data(), static_cast<unsigned int>(buffer.size()));
+					if (bytes < 0) {
+						unzCloseCurrentFile(archive);
+						fclose(output);
+						set_error("Error while extracting RP9 entry: " + normalized);
+						return false;
+					}
+					if (bytes == 0)
+						break;
+					if (written > info.uncompressed_size
+						|| static_cast<std::uint64_t>(bytes) > info.uncompressed_size - written) {
+						unzCloseCurrentFile(archive);
+						fclose(output);
+						set_error("RP9 entry expands beyond its declared size: " + normalized);
+						return false;
+					}
+					if (fwrite(buffer.data(), 1, static_cast<std::size_t>(bytes), output)
+						!= static_cast<std::size_t>(bytes)) {
+						unzCloseCurrentFile(archive);
+						fclose(output);
+						set_error("Could not write RP9 entry: " + normalized);
+						return false;
+					}
+					written += static_cast<std::uint64_t>(bytes);
+				}
+				const auto output_close_result = fclose(output);
+				if (unzCloseCurrentFile(archive) != UNZ_OK || output_close_result != 0
+					|| written != info.uncompressed_size) {
+					set_error("RP9 entry failed its integrity check: " + normalized);
+					return false;
+				}
+				files.emplace(lowercase(normalized), destination);
 			}
-			const auto output_close_result = fclose(output);
-			if (unzCloseCurrentFile(archive) != UNZ_OK || output_close_result != 0
-				|| written != info.uncompressed_size) {
-				set_error("RP9 entry failed its integrity check: " + normalized);
-				return false;
-			}
-			files.emplace(lowercase(normalized), destination);
 		}
 		if (error) {
 			set_error("Could not create an RP9 extraction path: " + error.message());
@@ -326,11 +401,66 @@ bool extract_archive(unzFile archive, const std::filesystem::path& directory,
 }
 
 std::filesystem::path resolve_media_path(const rp9::Media& media,
-	const std::unordered_map<std::string, std::filesystem::path>& files)
+	const std::unordered_map<std::string, std::filesystem::path>& files,
+	const std::string& deployment_id)
 {
 	std::string normalized;
 	const auto root = lowercase(media.root);
-	if (root.empty() || root == "embedded" || root == "deploy") {
+	if (media.deploy || root == "deploy") {
+		std::filesystem::path destination;
+		if (!deployed_media_path(media, deployment_id, destination, normalized))
+			return {};
+		std::error_code error;
+		if (std::filesystem::exists(destination, error)) {
+			if (!error && std::filesystem::is_regular_file(destination, error) && !error) {
+				write_log(_T("RP9: reusing deployed media: %s\n"), destination.string().c_str());
+				return destination;
+			}
+			set_error("RP9 deployed-media destination is not a regular file: " + destination.string());
+			return {};
+		}
+		if (error) {
+			set_error("Could not inspect RP9 deployed-media destination: " + error.message());
+			return {};
+		}
+		const auto found = files.find(lowercase(normalized));
+		if (found == files.end())
+			return {};
+
+		std::filesystem::create_directories(destination.parent_path(), error);
+		if (error) {
+			set_error("Could not create the RP9 deployed-media directory: " + error.message());
+			return {};
+		}
+
+		auto temporary = destination;
+		temporary += ".tmp-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count())
+			+ "-" + std::to_string(directory_sequence.fetch_add(1));
+		std::filesystem::copy_file(found->second, temporary, std::filesystem::copy_options::none, error);
+		if (error) {
+			std::error_code cleanup_error;
+			std::filesystem::remove(temporary, cleanup_error);
+			set_error("Could not deploy RP9 media: " + error.message());
+			return {};
+		}
+		std::filesystem::rename(temporary, destination, error);
+		if (error) {
+			// A second process may have completed the same deployment first.
+			std::error_code destination_error;
+			if (std::filesystem::is_regular_file(destination, destination_error) && !destination_error) {
+				std::filesystem::remove(temporary, destination_error);
+				write_log(_T("RP9: reusing concurrently deployed media: %s\n"), destination.string().c_str());
+				return destination;
+			}
+			std::error_code cleanup_error;
+			std::filesystem::remove(temporary, cleanup_error);
+			set_error("Could not finish deploying RP9 media: " + error.message());
+			return {};
+		}
+		write_log(_T("RP9: deployed media to: %s\n"), destination.string().c_str());
+		return destination;
+	}
+	if (root.empty() || root == "embedded") {
 		if (!rp9::normalize_package_path(media.path, normalized))
 			return {};
 		const auto found = files.find(lowercase(normalized));
@@ -678,20 +808,24 @@ bool is_rdb_hardfile(const std::filesystem::path& path)
 }
 
 bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
-	const std::unordered_map<std::string, std::filesystem::path>& files)
+	const std::unordered_map<std::string, std::filesystem::path>& files,
+	const std::string& deployment_id)
 {
-	int floppy_count = 0;
 	int device_number = 0;
-	std::array<bool, 4> floppy_drive_assigned {};
 	bool cd_attached = false;
 	bool snapshot_attached = false;
 	if (!apply_boot(prefs, manifest, device_number))
 		return false;
+	const bool boot_floppy_attached = manifest.has_boot && manifest.boot.type == "adf";
+	int floppy_count = boot_floppy_attached ? 1 : 0;
+	std::array<bool, 4> floppy_drive_assigned {};
+	floppy_drive_assigned[0] = boot_floppy_attached;
 
 	for (const auto& media : manifest.media) {
-		const auto path = resolve_media_path(media, files);
+		const auto path = resolve_media_path(media, files, deployment_id);
 		if (path.empty()) {
-			set_error("RP9 media was not found or uses an unsupported root: " + media.path);
+			if (last_error.empty())
+				set_error("RP9 media was not found or uses an unsupported root: " + media.path);
 			return false;
 		}
 		const auto path_string = path.string();
@@ -801,18 +935,24 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 	std::string manifest_error;
 	bool result = read_manifest(archive, manifest_data)
 		&& rp9::parse_manifest(manifest_data.data(), manifest_data.size() - 1, manifest, manifest_error);
+	const auto package_deployment_id = result
+		? deployment_id(manifest_data.data(), manifest_data.size() - 1)
+		: std::string {};
+	const auto existing_deployments = result
+		? find_existing_deployments(manifest, package_deployment_id)
+		: std::unordered_map<std::string, std::filesystem::path> {};
 	if (!result && last_error.empty())
 		set_error(manifest_error);
 
 	std::filesystem::path extraction_directory;
-	std::unordered_map<std::string, std::filesystem::path> extracted_files;
+	auto extracted_files = existing_deployments;
 	if (result) {
 		extraction_directory = create_extraction_directory();
 		if (extraction_directory.empty()) {
 			set_error("Could not create the RP9 temporary directory");
 			result = false;
 		} else {
-			result = extract_archive(archive, extraction_directory, extracted_files);
+			result = extract_archive(archive, extraction_directory, extracted_files, existing_deployments);
 		}
 	}
 	unzClose(archive);
@@ -826,7 +966,7 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 		result = apply_peripherals(prefs, manifest);
 		if (result) {
 			apply_video_and_clip(prefs, manifest);
-			result = apply_media(prefs, manifest, extracted_files);
+			result = apply_media(prefs, manifest, extracted_files, package_deployment_id);
 		}
 		if (prefs->m68k_speed >= 0)
 			prefs->cachesize = 0;

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -40,6 +40,7 @@ constexpr std::uint64_t maximum_extracted_size = 16ULL * 1024 * 1024 * 1024;
 constexpr unsigned long maximum_archive_entries = 10000;
 constexpr std::size_t maximum_entry_name = 4096;
 constexpr std::size_t extraction_buffer_size = 128 * 1024;
+constexpr int invalid_system_rom = -2;
 
 std::string loaded_path;
 std::string last_error;
@@ -164,12 +165,28 @@ bool parse_integer(const std::string& value, int& result)
 int system_rom_code(const std::string& value)
 {
 	const auto normalized = lowercase(value);
+	if (normalized.empty())
+		return -1;
+	if (normalized == "1.0" || normalized == "1.0.0" || normalized == "kickstart 1.0")
+		return 100;
+	if (normalized == "1.1" || normalized == "1.1.0" || normalized == "kickstart 1.1")
+		return 110;
+	if (normalized == "1.2" || normalized == "1.2.0" || normalized == "kickstart 1.2")
+		return 120;
 	if (normalized == "1.3" || normalized == "1.3.0" || normalized == "kickstart 1.3")
 		return 130;
+	if (normalized == "2.04" || normalized == "kickstart 2.04")
+		return 204;
+	if (normalized == "2.05" || normalized == "kickstart 2.05")
+		return 205;
+	if (normalized == "3.0" || normalized == "3.0.0" || normalized == "kickstart 3.0")
+		return 300;
 	if (normalized == "3.1" || normalized == "3.1.0" || normalized == "kickstart 3.1")
 		return 310;
+	if (normalized == "310-cd32" || normalized == "3.1-cd32" || normalized == "kickstart 3.1 cd32")
+		return RP9_SYSTEM_ROM_310_CD32;
 	int result = -1;
-	return parse_integer(normalized, result) ? result : -1;
+	return parse_integer(normalized, result) ? result : invalid_system_rom;
 }
 
 std::string deployment_id(const char* manifest, const std::size_t size)
@@ -248,48 +265,59 @@ bool set_default_system(uae_prefs* prefs, const rp9::Manifest& manifest)
 	inputdevice_joyport_config_store(prefs, _T("mouse"), 0, -1, -1, 0);
 	inputdevice_joyport_config_store(prefs, _T("joy0"), 1, -1, -1, 0);
 	const auto& system = manifest.system;
-	auto rom = system_rom_code(manifest.system_rom);
+	const auto normalized_rom = lowercase(manifest.system_rom);
+	const bool has_explicit_rom = !normalized_rom.empty();
 	if (manifest.video == "ntsc" || manifest.video == "a-ntsc")
 		prefs->ntscmode = true;
 	else if (manifest.video == "pal" || manifest.video == "a-pal")
 		prefs->ntscmode = false;
-	// A system-only configuration means the model's canonical configuration.
-	// The AMIBERRY wrappers historically use -1 to select KS 1.2 for these two
-	// models, whereas the canonical A500/A2000 profile uses KS 1.3.
-	if (rom < 0 && (system == "a-500" || system == "a500"
-		|| system == "a-2000" || system == "a2000"))
-		rom = 130;
+	if (system == "a-aros") {
+		if (has_explicit_rom && normalized_rom != "aros-latest") {
+			set_error("Unsupported RP9 system ROM '" + manifest.system_rom + "' for " + system);
+			return false;
+		}
+		bip_a4000(prefs, -1);
+		copy_path(prefs->romfile, MAX_DPATH, ":AROS");
+		return true;
+	}
+	const auto rom = system_rom_code(manifest.system_rom);
+	if (rom == invalid_system_rom) {
+		set_error("Unsupported RP9 system ROM: " + manifest.system_rom);
+		return false;
+	}
+	int configured = 0;
 
 	if (system == "a-1000" || system == "a1000")
-		bip_a1000(prefs, rom);
+		configured = bip_a1000(prefs, rom);
 	else if (system == "a-500" || system == "a500")
-		bip_a500(prefs, rom);
+		configured = bip_a500(prefs, rom);
 	else if (system == "a-500plus" || system == "a-500+" || system == "a500plus")
-		bip_a500plus(prefs, rom);
+		configured = bip_a500plus(prefs, rom);
 	else if (system == "a-600" || system == "a600")
-		bip_a600(prefs, rom);
+		configured = bip_a600(prefs, rom);
 	else if (system == "a-1200" || system == "a1200")
-		bip_a1200(prefs, rom);
+		configured = bip_a1200(prefs, rom);
 	else if (system == "a-2000" || system == "a2000")
-		bip_a2000(prefs, rom);
+		configured = bip_a2000(prefs, rom);
 	else if (system == "a-3000" || system == "a3000")
-		bip_a3000(prefs, rom);
+		configured = bip_a3000(prefs, rom);
 	else if (system == "a-4000" || system == "a4000" || system == "a-4xxx")
-		bip_a4000(prefs, rom);
+		configured = bip_a4000(prefs, rom);
 	else if (system == "a-walker")
 		// Walker used AGA, IDE and a 68030; A1200 is Amiberry's closest
 		// canonical base before the manifest's CPU and RAM overrides are applied.
-		bip_a1200(prefs, rom);
-	else if (system == "a-aros") {
-		bip_a4000(prefs, rom);
-		copy_path(prefs->romfile, MAX_DPATH, ":AROS");
-	}
+		configured = bip_a1200(prefs, rom);
 	else if (system == "cdtv" || system == "a-cdtv")
-		bip_cdtv(prefs, rom);
+		configured = bip_cdtv(prefs, rom);
 	else if (system == "cd32" || system == "a-cd32")
-		bip_cd32(prefs, rom);
+		configured = bip_cd32(prefs, rom);
 	else {
 		set_error("Unsupported RP9 system: " + system);
+		return false;
+	}
+	if (has_explicit_rom && !configured) {
+		set_error("Required RP9 system ROM '" + manifest.system_rom
+			+ "' is unavailable or incompatible with " + system);
 		return false;
 	}
 	return true;

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -38,6 +38,7 @@ namespace
 constexpr const char* manifest_name = "rp9-manifest.xml";
 constexpr std::uint64_t maximum_manifest_size = 4 * 1024 * 1024;
 constexpr std::uint64_t maximum_extracted_size = 16ULL * 1024 * 1024 * 1024;
+constexpr std::uintmax_t maximum_scanned_rom_size = 10000000;
 constexpr unsigned long maximum_archive_entries = 10000;
 constexpr std::size_t maximum_entry_name = 4096;
 constexpr std::size_t extraction_buffer_size = 128 * 1024;
@@ -902,6 +903,7 @@ bool apply_peripherals(uae_prefs* prefs, const rp9::Manifest& manifest)
 			return false;
 #endif
 		} else if (peripheral.name == "rtg" && peripheral.type == "picasso-iv") {
+			prefs->address_space_24 = false;
 			prefs->rtgboards[0].rtgmem_type = GFXBOARD_ID_PICASSO4_Z3;
 			prefs->rtgboards[0].rtgmem_size = static_cast<uae_u32>(std::min<std::uint64_t>(
 				peripheral.has_memory ? peripheral.memory : 4 * 1024 * 1024, UINT32_MAX));
@@ -1257,6 +1259,44 @@ bool rp9_register_rom_override(const char* filename)
 
 	romlist_add(filename, rom);
 	return true;
+}
+
+int rp9_register_rom_directory(const char* directory)
+{
+	if (!directory || !directory[0])
+		return 0;
+
+	std::error_code error;
+	const std::filesystem::path root(directory);
+	if (!std::filesystem::is_directory(root, error) || error)
+		return 0;
+
+	std::vector<std::filesystem::path> candidates;
+	for (std::filesystem::directory_iterator entry(root,
+		std::filesystem::directory_options::skip_permission_denied, error), end;
+		entry != end; entry.increment(error)) {
+		if (error)
+			break;
+		if (!entry->is_regular_file(error) || error) {
+			error.clear();
+			continue;
+		}
+		const auto size = entry->file_size(error);
+		if (error || size >= maximum_scanned_rom_size) {
+			error.clear();
+			continue;
+		}
+		if (_tcsicmp(entry->path().filename().string().c_str(), _T("rom.key")) != 0)
+			candidates.push_back(entry->path());
+	}
+
+	std::sort(candidates.begin(), candidates.end());
+	int registered = 0;
+	for (const auto& candidate : candidates) {
+		if (rp9_register_rom_override(candidate.string().c_str()))
+			++registered;
+	}
+	return registered;
 }
 
 bool rp9_parse_file(uae_prefs* prefs, const char* filename)

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -286,35 +286,49 @@ bool set_default_system(uae_prefs* prefs, const rp9::Manifest& manifest)
 		return false;
 	}
 	int configured = 0;
+	auto rp9_model = rp9_system_model::a500;
 
-	if (system == "a-1000" || system == "a1000")
+	if (system == "a-1000" || system == "a1000") {
 		configured = bip_a1000(prefs, rom);
-	else if (system == "a-500" || system == "a500")
-		configured = bip_a500(prefs, rom);
-	else if (system == "a-500plus" || system == "a-500+" || system == "a500plus")
+		rp9_model = rp9_system_model::a1000;
+	} else if (system == "a-500" || system == "a500") {
+		configured = bip_a500(prefs, rom < 0 ? 130 : rom);
+		rp9_model = rp9_system_model::a500;
+	} else if (system == "a-500plus" || system == "a-500+" || system == "a500plus") {
 		configured = bip_a500plus(prefs, rom);
-	else if (system == "a-600" || system == "a600")
+		rp9_model = rp9_system_model::a500plus;
+	} else if (system == "a-600" || system == "a600") {
 		configured = bip_a600(prefs, rom);
-	else if (system == "a-1200" || system == "a1200")
+		rp9_model = rp9_system_model::a600;
+	} else if (system == "a-1200" || system == "a1200") {
 		configured = bip_a1200(prefs, rom);
-	else if (system == "a-2000" || system == "a2000")
-		configured = bip_a2000(prefs, rom);
-	else if (system == "a-3000" || system == "a3000")
+		rp9_model = rp9_system_model::a1200;
+	} else if (system == "a-2000" || system == "a2000") {
+		configured = bip_a2000(prefs, rom < 0 ? 130 : rom);
+		rp9_model = rp9_system_model::a2000;
+	} else if (system == "a-3000" || system == "a3000") {
 		configured = bip_a3000(prefs, rom);
-	else if (system == "a-4000" || system == "a4000" || system == "a-4xxx")
+		rp9_model = rp9_system_model::a3000;
+	} else if (system == "a-4000" || system == "a4000" || system == "a-4xxx") {
 		configured = bip_a4000(prefs, rom);
-	else if (system == "a-walker")
+		rp9_model = rp9_system_model::a4000;
+	} else if (system == "a-walker") {
 		// Walker used AGA, IDE and a 68030; A1200 is Amiberry's closest
 		// canonical base before the manifest's CPU and RAM overrides are applied.
 		configured = bip_a1200(prefs, rom);
-	else if (system == "cdtv" || system == "a-cdtv")
+		rp9_model = rp9_system_model::a1200;
+	} else if (system == "cdtv" || system == "a-cdtv") {
 		configured = bip_cdtv(prefs, rom);
-	else if (system == "cd32" || system == "a-cd32")
+		rp9_model = rp9_system_model::cdtv;
+	} else if (system == "cd32" || system == "a-cd32") {
 		configured = bip_cd32(prefs, rom);
-	else {
+		rp9_model = rp9_system_model::cd32;
+	} else {
 		set_error("Unsupported RP9 system: " + system);
 		return false;
 	}
+	if (has_explicit_rom)
+		configured = configure_rp9_system_rom(prefs, rp9_model, rom);
 	if (has_explicit_rom && !configured) {
 		set_error("Required RP9 system ROM '" + manifest.system_rom
 			+ "' is unavailable or incompatible with " + system);
@@ -1122,6 +1136,8 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 	reset_inputdevice_config(prefs, true);
 	copy_prefs(candidate.get(), prefs);
 	reset_inputdevice_config(candidate.get(), false);
+	savestate_state = 0;
+	savestate_fname[0] = 0;
 	rp9_clear_loaded_path();
 	if (!snapshot_path.empty()) {
 		copy_path(savestate_fname, MAX_DPATH, snapshot_path);

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -1175,6 +1175,8 @@ bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
 	if (!apply_boot(prefs, manifest, device_number))
 		return false;
 	const bool boot_floppy_attached = manifest.has_boot && manifest.boot.type == "adf";
+	if (boot_floppy_attached)
+		floppy_paths.emplace_back(prefs->floppyslots[0].df);
 	int floppy_count = boot_floppy_attached ? 1 : 0;
 	std::array<bool, 4> floppy_drive_assigned {};
 	floppy_drive_assigned[0] = boot_floppy_attached;

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -10,6 +10,7 @@
 #include <cctype>
 #include <cstdint>
 #include <filesystem>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -239,7 +240,13 @@ std::unordered_map<std::string, std::filesystem::path> find_existing_deployments
 
 bool set_default_system(uae_prefs* prefs, const rp9::Manifest& manifest)
 {
-	default_prefs(prefs, true, 0);
+	// Build RP9 preferences without clearing the live input-device store. The
+	// caller commits that global reset only after the complete package succeeds.
+	const auto whdload_write_cache = whdload_prefs.write_cache;
+	default_prefs(prefs, false, 0);
+	whdload_prefs.write_cache = whdload_write_cache;
+	inputdevice_joyport_config_store(prefs, _T("mouse"), 0, -1, -1, 0);
+	inputdevice_joyport_config_store(prefs, _T("joy0"), 1, -1, -1, 0);
 	const auto& system = manifest.system;
 	auto rom = system_rom_code(manifest.system_rom);
 	if (manifest.video == "ntsc" || manifest.video == "a-ntsc")
@@ -889,7 +896,7 @@ bool is_rdb_hardfile(const std::filesystem::path& path)
 
 bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
 	const std::unordered_map<std::string, std::filesystem::path>& files,
-	const std::string& deployment_id)
+	const std::string& deployment_id, std::string& snapshot_path)
 {
 	int device_number = 0;
 	bool cd_attached = false;
@@ -972,8 +979,7 @@ bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
 		}
 		case rp9::MediaType::Snapshot:
 			if (!snapshot_attached) {
-				copy_path(savestate_fname, MAX_DPATH, path_string);
-				savestate_state = STATE_DORESTORE;
+				snapshot_path = path_string;
 				snapshot_attached = true;
 			}
 			break;
@@ -1009,7 +1015,6 @@ void rp9_cleanup_unused()
 bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 {
 	last_error.clear();
-	rp9_clear_loaded_path();
 	if (!prefs || !filename || !filename[0]) {
 		set_error("No RP9 package was specified");
 		return false;
@@ -1055,18 +1060,22 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 	unzClose(archive);
 	zfile_fclose(file);
 
-	if (result)
-		result = set_default_system(prefs, manifest);
+	std::unique_ptr<uae_prefs> candidate;
+	std::string snapshot_path;
 	if (result) {
-		apply_compatibility(prefs, manifest);
-		apply_ram(prefs, manifest);
-		result = apply_peripherals(prefs, manifest);
+		candidate = std::make_unique<uae_prefs>();
+		result = set_default_system(candidate.get(), manifest);
+	}
+	if (result) {
+		apply_compatibility(candidate.get(), manifest);
+		apply_ram(candidate.get(), manifest);
+		result = apply_peripherals(candidate.get(), manifest);
 		if (result) {
-			apply_video_and_clip(prefs, manifest);
-			result = apply_media(prefs, manifest, extracted_files, package_deployment_id);
+			apply_video_and_clip(candidate.get(), manifest);
+			result = apply_media(candidate.get(), manifest, extracted_files, package_deployment_id, snapshot_path);
 		}
-		if (prefs->m68k_speed >= 0)
-			prefs->cachesize = 0;
+		if (candidate->m68k_speed >= 0)
+			candidate->cachesize = 0;
 	}
 
 	if (!result) {
@@ -1074,13 +1083,28 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 			std::error_code error;
 			std::filesystem::remove_all(extraction_directory, error);
 		}
+		if (candidate)
+			reset_inputdevice_config(candidate.get(), false);
 		return false;
+	}
+
+	// Publish the complete configuration and package-owned global state only
+	// after every manifest requirement and media attachment has succeeded.
+	discard_prefs(prefs, 0);
+	reset_inputdevice_config(prefs, true);
+	copy_prefs(candidate.get(), prefs);
+	reset_inputdevice_config(candidate.get(), false);
+	rp9_clear_loaded_path();
+	if (!snapshot_path.empty()) {
+		copy_path(savestate_fname, MAX_DPATH, snapshot_path);
+		savestate_state = STATE_DORESTORE;
 	}
 
 	for (const auto& warning : manifest.warnings)
 		write_log(_T("RP9: %s\n"), warning.c_str());
 	temporary_directories.emplace_back(std::move(extraction_directory));
 	cleanup_unused_temporary_directories(prefs);
+	whdload_prefs.write_cache = false;
 	whdload_prefs.whdload_filename.clear();
 	loaded_path = filename;
 	loaded_has_clip = manifest.has_clip;

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -831,8 +831,10 @@ void apply_ram(uae_prefs* prefs, const rp9::Manifest& manifest)
 			prefs->chipmem.size = static_cast<uae_u32>(std::min<std::uint64_t>(ram.size, UINT32_MAX));
 		else if (ram.type == "fast")
 			prefs->fastmem[0].size = static_cast<uae_u32>(std::min<std::uint64_t>(ram.size, UINT32_MAX));
-		else if (ram.type == "z3")
+		else if (ram.type == "z3") {
+			prefs->address_space_24 = false;
 			prefs->z3fastmem[0].size = static_cast<uae_u32>(std::min<std::uint64_t>(ram.size, UINT32_MAX));
+		}
 		else if (ram.type == "slow" || ram.type == "bogo")
 			prefs->bogomem.size = static_cast<uae_u32>(std::min<std::uint64_t>(ram.size, UINT32_MAX));
 		else

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -1,0 +1,875 @@
+#include "sysdeps.h"
+
+#include "amiberry_rp9.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <charconv>
+#include <chrono>
+#include <cctype>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "archivers/zip/unzip.h"
+#include "amiga_constants.h"
+#include "blkdev.h"
+#include "custom.h"
+#include "cpuboard.h"
+#include "disk.h"
+#include "gfxboard.h"
+#include "inputdevice.h"
+#include "memory.h"
+#include "newcpu.h"
+#include "options.h"
+#include "rp9_manifest.h"
+#include "savestate.h"
+#include "target.h"
+#include "zfile.h"
+
+namespace
+{
+constexpr const char* manifest_name = "rp9-manifest.xml";
+constexpr std::uint64_t maximum_manifest_size = 4 * 1024 * 1024;
+constexpr std::uint64_t maximum_extracted_size = 16ULL * 1024 * 1024 * 1024;
+constexpr unsigned long maximum_archive_entries = 10000;
+constexpr std::size_t maximum_entry_name = 4096;
+constexpr std::size_t extraction_buffer_size = 128 * 1024;
+
+std::string loaded_path;
+std::string last_error;
+bool loaded_has_clip;
+std::vector<std::filesystem::path> temporary_directories;
+std::atomic<unsigned long long> directory_sequence { 0 };
+
+std::string lowercase(std::string value)
+{
+	std::transform(value.begin(), value.end(), value.begin(), [](const unsigned char ch) {
+		return static_cast<char>(std::tolower(ch));
+	});
+	return value;
+}
+
+void set_error(const std::string& value)
+{
+	last_error = value;
+	write_log(_T("RP9: %s\n"), value.c_str());
+}
+
+void copy_path(TCHAR* destination, const std::size_t size, const std::string& source)
+{
+	if (size == 0)
+		return;
+	_tcsncpy(destination, source.c_str(), size - 1);
+	destination[size - 1] = 0;
+}
+
+bool parse_integer(const std::string& value, int& result)
+{
+	if (value.empty())
+		return false;
+	int parsed = 0;
+	const auto [end, error] = std::from_chars(value.data(), value.data() + value.size(), parsed);
+	if (error != std::errc {} || end != value.data() + value.size())
+		return false;
+	result = parsed;
+	return true;
+}
+
+int system_rom_code(const std::string& value)
+{
+	const auto normalized = lowercase(value);
+	if (normalized == "1.3" || normalized == "1.3.0" || normalized == "kickstart 1.3")
+		return 130;
+	if (normalized == "3.1" || normalized == "3.1.0" || normalized == "kickstart 3.1")
+		return 310;
+	int result = -1;
+	return parse_integer(normalized, result) ? result : -1;
+}
+
+bool set_default_system(uae_prefs* prefs, const rp9::Manifest& manifest)
+{
+	default_prefs(prefs, true, 0);
+	const auto& system = manifest.system;
+	auto rom = system_rom_code(manifest.system_rom);
+	// A system-only configuration means the model's canonical configuration.
+	// The AMIBERRY wrappers historically use -1 to select KS 1.2 for these two
+	// models, whereas the canonical A500/A2000 profile uses KS 1.3.
+	if (rom < 0 && (system == "a-500" || system == "a500"
+		|| system == "a-2000" || system == "a2000"))
+		rom = 130;
+
+	if (system == "a-1000" || system == "a1000")
+		bip_a1000(prefs, rom);
+	else if (system == "a-500" || system == "a500")
+		bip_a500(prefs, rom);
+	else if (system == "a-500plus" || system == "a-500+" || system == "a500plus")
+		bip_a500plus(prefs, rom);
+	else if (system == "a-600" || system == "a600")
+		bip_a600(prefs, rom);
+	else if (system == "a-1200" || system == "a1200")
+		bip_a1200(prefs, rom);
+	else if (system == "a-2000" || system == "a2000")
+		bip_a2000(prefs, rom);
+	else if (system == "a-3000" || system == "a3000")
+		bip_a3000(prefs, rom);
+	else if (system == "a-4000" || system == "a4000" || system == "a-4xxx")
+		bip_a4000(prefs, rom);
+	else if (system == "a-walker")
+		// Walker used AGA, IDE and a 68030; A1200 is Amiberry's closest
+		// canonical base before the manifest's CPU and RAM overrides are applied.
+		bip_a1200(prefs, rom);
+	else if (system == "a-aros") {
+		bip_a4000(prefs, rom);
+		copy_path(prefs->romfile, MAX_DPATH, ":AROS");
+	}
+	else if (system == "cdtv" || system == "a-cdtv")
+		bip_cdtv(prefs, rom);
+	else if (system == "cd32" || system == "a-cd32")
+		bip_cd32(prefs, rom);
+	else {
+		set_error("Unsupported RP9 system: " + system);
+		return false;
+	}
+	return true;
+}
+
+bool read_manifest(unzFile archive, std::vector<char>& data)
+{
+	if (unzLocateFile(archive, manifest_name, 2) != UNZ_OK) {
+		set_error("Package does not contain rp9-manifest.xml");
+		return false;
+	}
+
+	unz_file_info info {};
+	if (unzGetCurrentFileInfo(archive, &info, nullptr, 0, nullptr, 0, nullptr, 0) != UNZ_OK
+		|| info.uncompressed_size == 0 || info.uncompressed_size > maximum_manifest_size) {
+		set_error("RP9 manifest is empty or exceeds the 4 MiB safety limit");
+		return false;
+	}
+	if (unzOpenCurrentFile(archive) != UNZ_OK) {
+		set_error("Could not open RP9 manifest");
+		return false;
+	}
+
+	data.resize(static_cast<std::size_t>(info.uncompressed_size) + 1);
+	std::size_t offset = 0;
+	while (offset < info.uncompressed_size) {
+		const auto remaining = static_cast<unsigned int>(std::min<std::size_t>(
+			info.uncompressed_size - offset, extraction_buffer_size));
+		const auto bytes = unzReadCurrentFile(archive, data.data() + offset, remaining);
+		if (bytes <= 0) {
+			unzCloseCurrentFile(archive);
+			set_error("Could not read complete RP9 manifest");
+			return false;
+		}
+		offset += static_cast<std::size_t>(bytes);
+	}
+	const auto close_result = unzCloseCurrentFile(archive);
+	if (close_result != UNZ_OK) {
+		set_error("RP9 manifest failed its integrity check");
+		return false;
+	}
+	data[offset] = 0;
+	return true;
+}
+
+std::filesystem::path create_extraction_directory()
+{
+	std::error_code error;
+	auto root = std::filesystem::path(get_rp9_path()) / "tmp";
+	std::filesystem::create_directories(root, error);
+	if (error)
+		return {};
+
+	const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+	for (int attempt = 0; attempt < 16; ++attempt) {
+		auto directory = root / ("rp9-" + std::to_string(now) + "-"
+			+ std::to_string(directory_sequence.fetch_add(1)));
+		if (std::filesystem::create_directory(directory, error))
+			return directory;
+		error.clear();
+	}
+	return {};
+}
+
+bool extract_archive(unzFile archive, const std::filesystem::path& directory,
+	std::unordered_map<std::string, std::filesystem::path>& files)
+{
+	unz_global_info global {};
+	if (unzGetGlobalInfo(archive, &global) != UNZ_OK || global.number_entry > maximum_archive_entries) {
+		set_error("RP9 archive has an invalid or excessive number of entries");
+		return false;
+	}
+	if (unzGoToFirstFile(archive) != UNZ_OK) {
+		set_error("RP9 archive contains no readable entries");
+		return false;
+	}
+
+	std::vector<char> buffer(extraction_buffer_size);
+	std::uint64_t total_size = 0;
+	std::unordered_set<std::string> seen_paths;
+	for (unsigned long index = 0; index < global.number_entry; ++index) {
+		unz_file_info info {};
+		if (unzGetCurrentFileInfo(archive, &info, nullptr, 0, nullptr, 0, nullptr, 0) != UNZ_OK
+			|| info.size_filename == 0 || info.size_filename > maximum_entry_name) {
+			set_error("RP9 archive contains an invalid entry");
+			return false;
+		}
+		std::vector<char> name(static_cast<std::size_t>(info.size_filename) + 1);
+		if (unzGetCurrentFileInfo(archive, &info, name.data(), static_cast<unsigned long>(name.size()),
+			nullptr, 0, nullptr, 0) != UNZ_OK) {
+			set_error("Could not read an RP9 archive entry name");
+			return false;
+		}
+		const std::string entry_name(name.data(), static_cast<std::size_t>(info.size_filename));
+		if (entry_name.find('\0') != std::string::npos) {
+			set_error("RP9 archive contains an entry name with an embedded null byte");
+			return false;
+		}
+
+		std::string normalized;
+		if (!rp9::normalize_package_path(entry_name, normalized)) {
+			set_error("Unsafe path in RP9 archive: " + entry_name);
+			return false;
+		}
+		auto path_key = lowercase(normalized);
+		if (!path_key.empty() && path_key.back() == '/')
+			path_key.pop_back();
+		if (!seen_paths.emplace(path_key).second) {
+			set_error("RP9 archive contains a duplicate path: " + entry_name);
+			return false;
+		}
+		const bool is_directory = entry_name.back() == '/' || entry_name.back() == '\\';
+		const auto destination = directory / std::filesystem::path(normalized);
+		std::error_code error;
+		if (is_directory) {
+			std::filesystem::create_directories(destination, error);
+		} else if (lowercase(normalized) != manifest_name) {
+			if (total_size > maximum_extracted_size - info.uncompressed_size) {
+				set_error("RP9 package exceeds the 16 GiB extraction safety limit");
+				return false;
+			}
+			total_size += info.uncompressed_size;
+			if (std::filesystem::exists(destination, error)) {
+				set_error("RP9 archive contains paths that collide on this filesystem: " + entry_name);
+				return false;
+			}
+			if (error) {
+				set_error("Could not validate an RP9 extraction path: " + error.message());
+				return false;
+			}
+			std::filesystem::create_directories(destination.parent_path(), error);
+			if (error) {
+				set_error("Could not create an RP9 extraction directory: " + error.message());
+				return false;
+			}
+			auto output = uae_fopen(destination.string().c_str(), _T("wbe"));
+			if (!output) {
+				set_error("Could not extract RP9 entry: " + normalized);
+				return false;
+			}
+			if (unzOpenCurrentFile(archive) != UNZ_OK) {
+				fclose(output);
+				set_error("Could not open compressed RP9 entry: " + normalized);
+				return false;
+			}
+			std::uint64_t written = 0;
+			for (;;) {
+				const auto bytes = unzReadCurrentFile(archive, buffer.data(), static_cast<unsigned int>(buffer.size()));
+				if (bytes < 0) {
+					unzCloseCurrentFile(archive);
+					fclose(output);
+					set_error("Error while extracting RP9 entry: " + normalized);
+					return false;
+				}
+				if (bytes == 0)
+					break;
+				if (written > info.uncompressed_size
+					|| static_cast<std::uint64_t>(bytes) > info.uncompressed_size - written) {
+					unzCloseCurrentFile(archive);
+					fclose(output);
+					set_error("RP9 entry expands beyond its declared size: " + normalized);
+					return false;
+				}
+				if (fwrite(buffer.data(), 1, static_cast<std::size_t>(bytes), output)
+					!= static_cast<std::size_t>(bytes)) {
+					unzCloseCurrentFile(archive);
+					fclose(output);
+					set_error("Could not write RP9 entry: " + normalized);
+					return false;
+				}
+				written += static_cast<std::uint64_t>(bytes);
+			}
+			const auto output_close_result = fclose(output);
+			if (unzCloseCurrentFile(archive) != UNZ_OK || output_close_result != 0
+				|| written != info.uncompressed_size) {
+				set_error("RP9 entry failed its integrity check: " + normalized);
+				return false;
+			}
+			files.emplace(lowercase(normalized), destination);
+		}
+		if (error) {
+			set_error("Could not create an RP9 extraction path: " + error.message());
+			return false;
+		}
+		if (index + 1 < global.number_entry && unzGoToNextFile(archive) != UNZ_OK) {
+			set_error("RP9 archive ended before all entries were read");
+			return false;
+		}
+	}
+	return true;
+}
+
+std::filesystem::path resolve_media_path(const rp9::Media& media,
+	const std::unordered_map<std::string, std::filesystem::path>& files)
+{
+	std::string normalized;
+	const auto root = lowercase(media.root);
+	if (root.empty() || root == "embedded" || root == "deploy") {
+		if (!rp9::normalize_package_path(media.path, normalized))
+			return {};
+		const auto found = files.find(lowercase(normalized));
+		return found == files.end() ? std::filesystem::path {} : found->second;
+	}
+
+	std::filesystem::path path(media.path);
+	std::error_code error;
+	if (root == "absolute" || root == "external")
+		return path.is_absolute() && std::filesystem::exists(path, error) ? path : std::filesystem::path {};
+	if (root == "data" || root == "shared") {
+		const auto base = std::filesystem::path(get_rp9_path());
+		std::filesystem::path relative_path;
+		if (!media.path.empty()) {
+			if (!rp9::normalize_package_path(media.path, normalized))
+				return {};
+			relative_path = std::filesystem::path(normalized);
+		}
+		std::vector<std::filesystem::path> candidates;
+		if (root == "shared") {
+			// The empty shared root is the user-facing Shared volume, stored
+			// under Shared/dir/Local in the current Amiga Files layout.
+			if (relative_path.empty()) {
+				candidates = { base / "data" / "Shared" / "dir" / "Local",
+					base / "Shared" / "dir" / "Local" };
+			}
+			candidates.emplace_back(base / "data" / "Shared" / relative_path);
+			candidates.emplace_back(base / "Shared" / relative_path);
+		} else {
+			candidates = { base / "data" / relative_path, base / relative_path };
+		}
+		for (const auto& candidate : candidates) {
+			if (std::filesystem::exists(candidate, error))
+				return candidate;
+			error.clear();
+		}
+	}
+	return {};
+}
+
+void apply_compatibility(uae_prefs* prefs, const rp9::Manifest& manifest)
+{
+	for (const auto& value : manifest.compatibility) {
+		if (value == "flexible-blitter-immediate")
+			prefs->immediate_blits = true;
+		else if (value == "turbo-floppy")
+			prefs->floppy_speed = 400;
+		else if (value == "flexible-sprite-collisions-spritesplayfield")
+			prefs->collision_level = 2;
+		else if (value == "flexible-sprite-collisions-spritesonly")
+			prefs->collision_level = 1;
+		else if (value == "flexible-sound")
+			prefs->produce_sound = 2;
+		else if (value == "mouse-integration" || value == "mouseintegration")
+			prefs->input_tablet = TABLET_MOUSEHACK;
+		else if (value == "turbo-cpu")
+			prefs->m68k_speed = -1;
+		else if (value == "jit") {
+#ifdef JIT
+			prefs->cachesize = MAX_JIT_CACHE;
+			prefs->address_space_24 = false;
+			prefs->compfpu = true;
+#endif
+		} else if (value == "flexible-cpu-cycles") {
+			prefs->cpu_compatible = false;
+		} else if (value != "flexible-blitter-cycles"
+			&& value != "flexible-cpu-compatibility"
+			&& value != "hostio"
+			&& value != "nosavestate"
+			&& value != "flexible-maxhorizontal-nohires"
+			&& value != "flexible-maxhorizontal-nosuperhires"
+			&& value != "flexible-maxvertical-nointerlace") {
+			write_log(_T("RP9: unsupported compatibility hint '%s'\n"), value.c_str());
+		}
+	}
+}
+
+void apply_ram(uae_prefs* prefs, const rp9::Manifest& manifest)
+{
+	for (const auto& ram : manifest.ram) {
+		if (ram.type == "chip")
+			prefs->chipmem.size = static_cast<uae_u32>(std::min<std::uint64_t>(ram.size, UINT32_MAX));
+		else if (ram.type == "fast")
+			prefs->fastmem[0].size = static_cast<uae_u32>(std::min<std::uint64_t>(ram.size, UINT32_MAX));
+		else if (ram.type == "z3")
+			prefs->z3fastmem[0].size = static_cast<uae_u32>(std::min<std::uint64_t>(ram.size, UINT32_MAX));
+		else if (ram.type == "slow" || ram.type == "bogo")
+			prefs->bogomem.size = static_cast<uae_u32>(std::min<std::uint64_t>(ram.size, UINT32_MAX));
+		else
+			write_log(_T("RP9: unsupported RAM type '%s'\n"), ram.type.c_str());
+	}
+}
+
+bool apply_peripherals(uae_prefs* prefs, const rp9::Manifest& manifest)
+{
+	for (const auto& peripheral : manifest.peripherals) {
+		if (peripheral.name == "floppy") {
+			if (peripheral.unit < 0 || peripheral.unit >= 4) {
+				write_log(_T("RP9: ignoring invalid floppy unit %d\n"), peripheral.unit);
+				continue;
+			}
+			prefs->floppyslots[peripheral.unit].dfxtype = peripheral.type == "hd" ? DRV_35_HD : DRV_35_DD;
+			prefs->nr_floppies = std::max(prefs->nr_floppies, peripheral.unit + 1);
+		} else if (peripheral.name == "a-501") {
+			prefs->bogomem.size = 0x00080000;
+		} else if (peripheral.name == "cpu") {
+			if (!peripheral.type.empty()) {
+				int cpu = 0;
+				if (parse_integer(peripheral.type, cpu)
+					&& (cpu == 68000 || cpu == 68010 || cpu == 68020 || cpu == 68030 || cpu == 68040 || cpu == 68060)) {
+					prefs->cpu_model = cpu;
+					if (cpu > 68020)
+						prefs->address_space_24 = false;
+					if (cpu == 68040 || cpu == 68060)
+						prefs->fpu_model = cpu;
+				} else {
+					write_log(_T("RP9: unsupported CPU type '%s'\n"), peripheral.type.c_str());
+				}
+			}
+			if (peripheral.speed == "max")
+				prefs->m68k_speed = -1;
+		} else if (peripheral.name == "fpu") {
+			if (peripheral.type == "68881")
+				prefs->fpu_model = 68881;
+			else if (peripheral.type == "68882")
+				prefs->fpu_model = 68882;
+		} else if (peripheral.name == "jit") {
+#ifdef JIT
+			if (peripheral.has_memory)
+				prefs->cachesize = static_cast<int>(std::clamp<std::uint64_t>(peripheral.memory / 1024, 1, MAX_JIT_CACHE));
+			else
+				prefs->cachesize = MAX_JIT_CACHE;
+			if (peripheral.has_fpu)
+				prefs->compfpu = peripheral.fpu;
+			prefs->address_space_24 = false;
+#endif
+		} else if (peripheral.name == "ppc" && peripheral.type == "cyberstorm") {
+#ifdef WITH_PPC
+			// RetroPlatform's "cyberstorm" PPC profile denotes the complete
+			// CyberStorm PPC accelerator, including its 68060 and SCSI controller.
+			prefs->cpu_model = 68060;
+			prefs->fpu_model = 68060;
+			prefs->address_space_24 = false;
+			prefs->ppc_mode = 1;
+			cpuboard_setboard(prefs, BOARD_CYBERSTORM, BOARD_CYBERSTORM_SUB_PPC);
+			if (peripheral.has_memory)
+				prefs->cpuboardmem1.size = static_cast<uae_u32>(std::min<std::uint64_t>(
+					peripheral.memory, UINT32_MAX));
+#else
+			set_error("This RP9 package requires CyberStorm PPC support, which is not enabled in this build");
+			return false;
+#endif
+		} else if (peripheral.name == "rtg" && peripheral.type == "picasso-iv") {
+			prefs->rtgboards[0].rtgmem_type = GFXBOARD_ID_PICASSO4_Z3;
+			prefs->rtgboards[0].rtgmem_size = static_cast<uae_u32>(std::min<std::uint64_t>(
+				peripheral.has_memory ? peripheral.memory : 4 * 1024 * 1024, UINT32_MAX));
+		} else if ((peripheral.name == "scsi" && peripheral.type == "cyberstorm")
+			|| (peripheral.name == "optical" && peripheral.type == "cd")) {
+			// These controllers are part of the CyberStorm/CD machine profiles.
+		} else if (peripheral.name == "input-joystick" && peripheral.unit >= 0 && peripheral.unit < MAX_JPORTS) {
+			prefs->jports[peripheral.unit].mode = JSEM_MODE_JOYSTICK;
+		} else if (peripheral.name == "input-mouse" && peripheral.unit >= 0 && peripheral.unit < MAX_JPORTS) {
+			prefs->jports[peripheral.unit].mode = JSEM_MODE_MOUSE;
+		} else if (peripheral.name == "input-cd32" && peripheral.unit >= 0 && peripheral.unit < MAX_JPORTS) {
+			prefs->jports[peripheral.unit].mode = JSEM_MODE_JOYSTICK_CD32;
+		} else if (peripheral.name == "automount-removable") {
+			prefs->automount_removable = true;
+		} else if (peripheral.name == "keyboard") {
+			const auto& layout = peripheral.layout;
+			if (layout.empty() || layout == "en" || layout == "en-us" || layout == "en-gb")
+				prefs->keyboard_lang = KBD_LANG_US;
+			else if (layout == "da" || layout == "da-dk" || layout == "dk")
+				prefs->keyboard_lang = KBD_LANG_DK;
+			else if (layout == "de" || layout == "de-de")
+				prefs->keyboard_lang = KBD_LANG_DE;
+			else if (layout == "sv" || layout == "sv-se" || layout == "se")
+				prefs->keyboard_lang = KBD_LANG_SE;
+			else if (layout == "fr" || layout == "fr-fr")
+				prefs->keyboard_lang = KBD_LANG_FR;
+			else if (layout == "it" || layout == "it-it")
+				prefs->keyboard_lang = KBD_LANG_IT;
+			else if (layout == "es" || layout == "es-es")
+				prefs->keyboard_lang = KBD_LANG_ES;
+			else
+				write_log(_T("RP9: unsupported keyboard layout '%s'\n"), layout.c_str());
+		} else if (peripheral.name != "silent-drives"
+			&& peripheral.name != "filter-interpolation"
+			&& peripheral.name != "printer") {
+			write_log(_T("RP9: unsupported peripheral '%s'\n"), peripheral.name.c_str());
+		}
+	}
+	return true;
+}
+
+void apply_video_and_clip(uae_prefs* prefs, const rp9::Manifest& manifest)
+{
+	if (manifest.video == "ntsc" || manifest.video == "a-ntsc")
+		prefs->ntscmode = true;
+	else if (manifest.video == "pal" || manifest.video == "a-pal")
+		prefs->ntscmode = false;
+
+	if (!manifest.has_clip)
+		return;
+	const auto hres = std::clamp(prefs->gfx_resolution, RES_LORES, RES_SUPERHIRES);
+	const auto vres = std::clamp(prefs->gfx_vresolution, VRES_NONDOUBLE, VRES_DOUBLE);
+	const auto horizontal_scale = 1U << (RES_SUPERHIRES - hres);
+	const auto vertical_scale = 1U << (VRES_DOUBLE - vres);
+	const int full_width = AMIGA_WIDTH_MAX << hres;
+	const int full_height = (prefs->ntscmode ? AMIGA_HEIGHT_MAX_NTSC : AMIGA_HEIGHT_MAX_PAL) << vres;
+	const int width = static_cast<int>(std::min<std::uint64_t>(
+		std::max(1U, manifest.clip.width / horizontal_scale), full_width));
+	const int height = static_cast<int>(std::min<std::uint64_t>(
+		std::max(1U, manifest.clip.height / vertical_scale), full_height));
+	const auto relative_left = (static_cast<std::int64_t>(manifest.clip.left) - 112)
+		/ static_cast<std::int64_t>(horizontal_scale);
+	// RP9 top coordinates expose the standard interlaced vertical-blanking
+	// interval. Amiberry's native render surface begins after that interval.
+	const auto vertical_blanking = prefs->ntscmode ? 42 : 52;
+	const auto relative_top = (static_cast<std::int64_t>(manifest.clip.top) - vertical_blanking)
+		/ static_cast<std::int64_t>(vertical_scale);
+	// RP9 clip positions are absolute within the maximum visible Amiga area.
+	// Only the documented 112-SuperHires-unit RP9 left-origin correction is
+	// removed; these are not offsets relative to a centered crop rectangle.
+	const auto horizontal_offset = std::clamp<std::int64_t>(
+		relative_left, 0, std::max(0, full_width - width));
+	const auto vertical_offset = std::clamp<std::int64_t>(
+		relative_top, 0, std::max(0, full_height - height));
+
+	prefs->gfx_auto_crop = false;
+	prefs->gfx_manual_crop = true;
+	prefs->gfx_manual_crop_width = width;
+	prefs->gfx_manual_crop_height = height;
+	prefs->gfx_horizontal_offset = static_cast<int>(horizontal_offset);
+	prefs->gfx_vertical_offset = static_cast<int>(vertical_offset);
+}
+
+bool is_rdb_hardfile(const std::filesystem::path& path);
+
+bool add_harddrive(uae_prefs* prefs, const std::filesystem::path& path, const std::string& volume_name,
+	const bool readonly, const int boot_priority, int& device_number)
+{
+	uaedev_config_info config {};
+	std::error_code error;
+	const bool directory = std::filesystem::is_directory(path, error);
+	uci_set_defaults(&config, !directory && is_rdb_hardfile(path));
+	config.type = directory ? UAEDEV_DIR : UAEDEV_HDF;
+	config.readonly = readonly;
+	config.bootpri = boot_priority;
+	snprintf(config.devname, sizeof config.devname, _T("DH%d"), device_number++);
+	copy_path(config.rootdir, sizeof config.rootdir / sizeof(TCHAR), path.string());
+	if (directory) {
+		const auto name = volume_name.empty() ? path.filename().string() : volume_name;
+		copy_path(config.volname, sizeof config.volname / sizeof(TCHAR), name.empty() ? "RP9" : name);
+	}
+	return add_filesys_config(prefs, -1, &config) != nullptr;
+}
+
+std::filesystem::path find_boot_media(const rp9::Boot& boot)
+{
+	const auto base = std::filesystem::path(get_rp9_path());
+	const auto filename = "workbench-" + boot.value;
+	std::vector<std::filesystem::path> candidates;
+	if (boot.type == "hdf") {
+		candidates = { base / (filename + ".hdf"),
+			base / "Shared" / "hdf" / (filename + ".hdf"),
+			base / "data" / "Shared" / "hdf" / (filename + ".hdf"),
+			base / "Shared" / "HDF" / ("AWB" + boot.value + ".HDF"),
+			base / "Shared" / "hdf" / ("awb" + boot.value + ".hdf"),
+			base / "data" / "Shared" / "HDF" / ("AWB" + boot.value + ".HDF"),
+			base / "data" / "Shared" / "hdf" / ("awb" + boot.value + ".hdf") };
+	} else if (boot.type == "adf") {
+		candidates = { base / (filename + ".adf"), base / "Shared" / "ADF" / ("AWB" + boot.value + ".ADF"),
+			base / "Shared" / "adf" / ("awb" + boot.value + ".adf"),
+			base / "Shared" / "adf" / ("amiga-os-" + boot.value + "-workbench.adf"),
+			base / "Shared" / "ADF" / ("amiga-os-" + boot.value + "-workbench.adf"),
+			base / "data" / "Shared" / "ADF" / ("AWB" + boot.value + ".ADF"),
+			base / "data" / "Shared" / "adf" / ("amiga-os-" + boot.value + "-workbench.adf"),
+			base / "data" / "Shared" / "ADF" / ("amiga-os-" + boot.value + "-workbench.adf") };
+	} else if (boot.type == "dir") {
+		candidates = { base / filename, base / "Shared" / "dir" / "System",
+			base / "data" / "Shared" / "dir" / "System" };
+	}
+	std::error_code error;
+	for (const auto& candidate : candidates) {
+		if (std::filesystem::exists(candidate, error))
+			return candidate;
+		error.clear();
+	}
+	return {};
+}
+
+bool apply_boot(uae_prefs* prefs, const rp9::Manifest& manifest, int& device_number)
+{
+	if (!manifest.has_boot || manifest.boot.type.empty())
+		return true;
+	if (manifest.boot.type != "hdf" && manifest.boot.type != "adf" && manifest.boot.type != "dir") {
+		set_error("Unsupported RP9 boot media type: " + manifest.boot.type);
+		return false;
+	}
+	if (manifest.boot.value.empty()
+		|| !std::all_of(manifest.boot.value.begin(), manifest.boot.value.end(), [](const unsigned char ch) {
+			return std::isalnum(ch) || ch == '.' || ch == '-' || ch == '_';
+		})) {
+		set_error("RP9 boot image version contains invalid characters");
+		return false;
+	}
+	const auto path = find_boot_media(manifest.boot);
+	if (path.empty()) {
+		set_error("RP9 requires missing " + manifest.boot.type + " boot media version " + manifest.boot.value
+			+ " in the RP9/Shared data paths");
+		return false;
+	}
+	if (manifest.boot.type == "adf") {
+		prefs->nr_floppies = std::max(prefs->nr_floppies, 1);
+		copy_path(prefs->floppyslots[0].df, MAX_DPATH, path.string());
+		copy_path(prefs->dfxlist[0], MAX_DPATH, path.string());
+		prefs->floppyslots[0].forcedwriteprotect = manifest.boot.readonly;
+		return true;
+	}
+	const auto volume_name = manifest.boot.type == "dir" ? "System" : std::string {};
+	if (!add_harddrive(prefs, path, volume_name, manifest.boot.readonly, 127, device_number)) {
+		set_error("Could not attach RP9 boot image: " + path.string());
+		return false;
+	}
+	return true;
+}
+
+bool is_rdb_hardfile(const std::filesystem::path& path)
+{
+	auto file = zfile_fopen(path.string().c_str(), _T("rb"), ZFD_NORMAL);
+	if (!file)
+		return false;
+	std::array<unsigned char, 512> block {};
+	bool found = false;
+	for (int index = 0; index < 16; ++index) {
+		if (zfile_fread(block.data(), 1, block.size(), file) != block.size())
+			break;
+		if (memcmp(block.data(), "RDSK", 4) == 0 || memcmp(block.data(), "CDSK", 4) == 0) {
+			found = true;
+			break;
+		}
+	}
+	zfile_fclose(file);
+	return found;
+}
+
+bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
+	const std::unordered_map<std::string, std::filesystem::path>& files)
+{
+	int floppy_count = 0;
+	int device_number = 0;
+	std::array<bool, 4> floppy_drive_assigned {};
+	bool cd_attached = false;
+	bool snapshot_attached = false;
+	if (!apply_boot(prefs, manifest, device_number))
+		return false;
+
+	for (const auto& media : manifest.media) {
+		const auto path = resolve_media_path(media, files);
+		if (path.empty()) {
+			set_error("RP9 media was not found or uses an unsupported root: " + media.path);
+			return false;
+		}
+		const auto path_string = path.string();
+		switch (media.type) {
+		case rp9::MediaType::Floppy:
+			if (floppy_count < MAX_SPARE_DRIVES) {
+				copy_path(prefs->dfxlist[floppy_count], MAX_DPATH, path_string);
+				// RP9 priorities are one-based insertion preferences (priority 1
+				// means DF0). Images beyond the configured drives remain available
+				// in the disk swap list.
+				const auto preferred_drive = media.has_priority
+					? static_cast<std::uint64_t>(media.priority > 0 ? media.priority - 1 : 0)
+					: static_cast<std::uint64_t>(floppy_count);
+				if (preferred_drive < floppy_drive_assigned.size()
+					&& preferred_drive < static_cast<std::uint64_t>(prefs->nr_floppies)
+					&& !floppy_drive_assigned[preferred_drive]) {
+					copy_path(prefs->floppyslots[preferred_drive].df, MAX_DPATH, path_string);
+					prefs->floppyslots[preferred_drive].forcedwriteprotect = media.readonly;
+					floppy_drive_assigned[preferred_drive] = true;
+				}
+				++floppy_count;
+			}
+			break;
+		case rp9::MediaType::HardDrive:
+			if (!add_harddrive(prefs, path, media.volume_name, media.readonly, 0, device_number)) {
+				set_error("Could not attach RP9 hard drive: " + media.path);
+				return false;
+			}
+			break;
+		case rp9::MediaType::Cd:
+			if (!cd_attached) {
+				copy_path(prefs->cdslots[0].name, MAX_DPATH, path_string);
+				prefs->cdslots[0].inuse = true;
+				prefs->cdslots[0].type = SCSI_UNIT_DEFAULT;
+				cd_attached = true;
+			} else {
+				write_log(_T("RP9: additional CD available in extracted package: %s\n"), path_string.c_str());
+			}
+			break;
+		case rp9::MediaType::Tape: {
+			uaedev_config_info config {};
+			config.type = UAEDEV_TAPE;
+			config.readonly = media.readonly;
+			config.blocksize = 512;
+			copy_path(config.rootdir, MAX_DPATH, path_string);
+			if (!add_filesys_config(prefs, -1, &config)) {
+				set_error("Could not attach RP9 tape: " + media.path);
+				return false;
+			}
+			break;
+		}
+		case rp9::MediaType::Snapshot:
+			if (!snapshot_attached) {
+				copy_path(savestate_fname, MAX_DPATH, path_string);
+				savestate_state = STATE_DORESTORE;
+				snapshot_attached = true;
+			}
+			break;
+		}
+	}
+	return true;
+}
+}
+
+void rp9_init()
+{
+	loaded_path.clear();
+	last_error.clear();
+	loaded_has_clip = false;
+}
+
+void rp9_cleanup()
+{
+	std::error_code error;
+	for (auto it = temporary_directories.rbegin(); it != temporary_directories.rend(); ++it) {
+		std::filesystem::remove_all(*it, error);
+		error.clear();
+	}
+	temporary_directories.clear();
+	rp9_init();
+}
+
+bool rp9_parse_file(uae_prefs* prefs, const char* filename)
+{
+	last_error.clear();
+	loaded_path.clear();
+	loaded_has_clip = false;
+	if (!prefs || !filename || !filename[0]) {
+		set_error("No RP9 package was specified");
+		return false;
+	}
+
+	auto file = zfile_fopen(filename, _T("rb"));
+	if (!file) {
+		set_error("Could not open RP9 package: " + std::string(filename));
+		return false;
+	}
+	auto archive = unzOpen(file);
+	if (!archive) {
+		zfile_fclose(file);
+		set_error("RP9 package is not a valid ZIP archive: " + std::string(filename));
+		return false;
+	}
+
+	std::vector<char> manifest_data;
+	rp9::Manifest manifest;
+	std::string manifest_error;
+	bool result = read_manifest(archive, manifest_data)
+		&& rp9::parse_manifest(manifest_data.data(), manifest_data.size() - 1, manifest, manifest_error);
+	if (!result && last_error.empty())
+		set_error(manifest_error);
+
+	std::filesystem::path extraction_directory;
+	std::unordered_map<std::string, std::filesystem::path> extracted_files;
+	if (result) {
+		extraction_directory = create_extraction_directory();
+		if (extraction_directory.empty()) {
+			set_error("Could not create the RP9 temporary directory");
+			result = false;
+		} else {
+			result = extract_archive(archive, extraction_directory, extracted_files);
+		}
+	}
+	unzClose(archive);
+	zfile_fclose(file);
+
+	if (result)
+		result = set_default_system(prefs, manifest);
+	if (result) {
+		apply_compatibility(prefs, manifest);
+		apply_ram(prefs, manifest);
+		result = apply_peripherals(prefs, manifest);
+		if (result) {
+			apply_video_and_clip(prefs, manifest);
+			result = apply_media(prefs, manifest, extracted_files);
+		}
+		if (prefs->m68k_speed >= 0)
+			prefs->cachesize = 0;
+	}
+
+	if (!result) {
+		if (!extraction_directory.empty()) {
+			std::error_code error;
+			std::filesystem::remove_all(extraction_directory, error);
+		}
+		return false;
+	}
+
+	for (const auto& warning : manifest.warnings)
+		write_log(_T("RP9: %s\n"), warning.c_str());
+	temporary_directories.emplace_back(std::move(extraction_directory));
+	whdload_prefs.whdload_filename.clear();
+	loaded_path = filename;
+	loaded_has_clip = manifest.has_clip;
+	if (manifest.title.empty())
+		write_log(_T("RP9: loaded '%s'\n"), filename);
+	else
+		write_log(_T("RP9: loaded '%s' (%s)\n"), filename, manifest.title.c_str());
+	return true;
+}
+
+const std::string& rp9_get_loaded_path()
+{
+	return loaded_path;
+}
+
+const std::string& rp9_get_last_error()
+{
+	return last_error;
+}
+
+bool rp9_loaded_has_clip()
+{
+	return loaded_has_clip;
+}
+
+void rp9_clear_loaded_path()
+{
+	loaded_path.clear();
+	loaded_has_clip = false;
+}

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -1342,24 +1342,41 @@ int rp9_register_rom_directory(const char* directory)
 		return 0;
 
 	std::vector<std::filesystem::path> candidates;
-	for (std::filesystem::directory_iterator entry(root,
-		std::filesystem::directory_options::skip_permission_denied, error), end;
+	std::vector<std::filesystem::path> key_files;
+	constexpr auto options = std::filesystem::directory_options::skip_permission_denied;
+	for (std::filesystem::recursive_directory_iterator entry(root, options, error), end;
 		entry != end; entry.increment(error)) {
 		if (error)
 			break;
-		if (!entry->is_regular_file(error) || error) {
-			error.clear();
+
+		std::error_code type_error;
+		if (entry->is_directory(type_error)) {
+			const auto name = entry->path().filename().string();
+			if (!name.empty() && name.front() == '.')
+				entry.disable_recursion_pending();
 			continue;
 		}
-		const auto size = entry->file_size(error);
-		if (error || size >= maximum_scanned_rom_size) {
-			error.clear();
+		if (type_error || !entry->is_regular_file(type_error) || type_error)
 			continue;
-		}
-		if (_tcsicmp(entry->path().filename().string().c_str(), _T("rom.key")) != 0)
+
+		std::error_code size_error;
+		const auto size = entry->file_size(size_error);
+		if (size_error || size >= maximum_scanned_rom_size)
+			continue;
+
+		if (_tcsicmp(entry->path().filename().string().c_str(), _T("rom.key")) == 0)
+			key_files.push_back(entry->path());
+		else
 			candidates.push_back(entry->path());
 	}
+	if (error) {
+		write_log(_T("RP9: stopped scanning ROM directory '%s': %s\n"),
+			root.string().c_str(), error.message().c_str());
+	}
 
+	std::sort(key_files.begin(), key_files.end());
+	for (const auto& key_file : key_files)
+		addkeyfile(key_file.string().c_str());
 	std::sort(candidates.begin(), candidates.end());
 	int registered = 0;
 	for (const auto& candidate : candidates) {

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -46,6 +46,7 @@ constexpr int invalid_system_rom = -2;
 
 std::string loaded_path;
 std::string last_error;
+std::string loaded_snapshot_path;
 bool loaded_has_clip;
 std::vector<std::filesystem::path> temporary_directories;
 std::vector<std::string> loaded_cd_paths;
@@ -130,13 +131,11 @@ void cleanup_unused_temporary_directories(const uae_prefs* additional_prefs = nu
 	}
 }
 
-bool pending_snapshot_uses_temporary_directory()
+bool pending_snapshot_belongs_to_loaded_rp9()
 {
-	if (savestate_state != STATE_DORESTORE)
-		return false;
-	return std::any_of(temporary_directories.begin(), temporary_directories.end(), [](const auto& directory) {
-		return directory_contains_path(directory, savestate_fname);
-	});
+	return !loaded_snapshot_path.empty()
+		&& savestate_state == STATE_DORESTORE
+		&& loaded_snapshot_path == savestate_fname;
 }
 
 std::string lowercase(std::string value)
@@ -1273,6 +1272,7 @@ void rp9_init()
 {
 	loaded_path.clear();
 	last_error.clear();
+	loaded_snapshot_path.clear();
 	loaded_has_clip = false;
 	loaded_cd_paths.clear();
 }
@@ -1461,6 +1461,7 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 	if (!snapshot_path.empty()) {
 		copy_path(savestate_fname, MAX_DPATH, snapshot_path);
 		savestate_state = STATE_DORESTORE;
+		loaded_snapshot_path = savestate_fname;
 	}
 
 	for (const auto& warning : manifest.warnings)
@@ -1497,10 +1498,11 @@ bool rp9_loaded_has_clip()
 
 void rp9_clear_loaded_path()
 {
-	if (pending_snapshot_uses_temporary_directory()) {
+	if (pending_snapshot_belongs_to_loaded_rp9()) {
 		savestate_state = 0;
 		savestate_fname[0] = 0;
 	}
+	loaded_snapshot_path.clear();
 	loaded_path.clear();
 	loaded_has_clip = false;
 	loaded_cd_paths.clear();

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -596,10 +596,11 @@ std::filesystem::path resolve_media_path(const rp9::Media& media,
 		return found == files.end() ? std::filesystem::path {} : found->second;
 	}
 
-	std::filesystem::path path(media.path);
 	std::error_code error;
-	if (root == "absolute" || root == "external")
-		return path.is_absolute() && std::filesystem::exists(path, error) ? path : std::filesystem::path {};
+	if (root == "absolute" || root == "external") {
+		set_error("RP9 media uses a disallowed external host path: " + media.path);
+		return {};
+	}
 	if (root == "data" || root == "shared") {
 		const auto base = std::filesystem::path(get_rp9_path());
 		std::filesystem::path relative_path;
@@ -938,7 +939,8 @@ bool is_rdb_hardfile(const std::filesystem::path& path)
 
 bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
 	const std::unordered_map<std::string, std::filesystem::path>& files,
-	const std::string& deployment_id, std::string& snapshot_path)
+	const std::string& deployment_id, std::string& snapshot_path,
+	std::vector<std::string>& cd_paths)
 {
 	int device_number = 0;
 	bool cd_attached = false;
@@ -998,13 +1000,12 @@ bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
 			}
 			break;
 		case rp9::MediaType::Cd:
+			cd_paths.emplace_back(path_string);
 			if (!cd_attached) {
 				copy_path(prefs->cdslots[0].name, MAX_DPATH, path_string);
 				prefs->cdslots[0].inuse = true;
 				prefs->cdslots[0].type = SCSI_UNIT_DEFAULT;
 				cd_attached = true;
-			} else {
-				write_log(_T("RP9: additional CD available in extracted package: %s\n"), path_string.c_str());
 			}
 			break;
 		case rp9::MediaType::Tape: {
@@ -1028,6 +1029,20 @@ bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
 		}
 	}
 	return true;
+}
+
+void publish_cd_swap_list(const std::vector<std::string>& cd_paths)
+{
+	// Keep every package disc available in the existing CD selector. Remove
+	// duplicates first, then insert in reverse so priority 1 remains first.
+	for (const auto& path : cd_paths) {
+		lstMRUCDList.erase(std::remove(lstMRUCDList.begin(), lstMRUCDList.end(), path), lstMRUCDList.end());
+	}
+	for (auto path = cd_paths.rbegin(); path != cd_paths.rend(); ++path)
+		add_file_to_mru_list(lstMRUCDList, *path);
+	for (std::size_t index = 0; index < cd_paths.size(); ++index) {
+		write_log(_T("RP9: CD swap entry %u: %s\n"), static_cast<unsigned>(index + 1), cd_paths[index].c_str());
+	}
 }
 }
 
@@ -1104,6 +1119,7 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 
 	std::unique_ptr<uae_prefs> candidate;
 	std::string snapshot_path;
+	std::vector<std::string> cd_paths;
 	if (result) {
 		candidate = std::make_unique<uae_prefs>();
 		result = set_default_system(candidate.get(), manifest);
@@ -1114,7 +1130,8 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 		result = apply_peripherals(candidate.get(), manifest);
 		if (result) {
 			apply_video_and_clip(candidate.get(), manifest);
-			result = apply_media(candidate.get(), manifest, extracted_files, package_deployment_id, snapshot_path);
+			result = apply_media(candidate.get(), manifest, extracted_files, package_deployment_id, snapshot_path,
+				cd_paths);
 		}
 		if (candidate->m68k_speed >= 0)
 			candidate->cachesize = 0;
@@ -1148,6 +1165,7 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 		write_log(_T("RP9: %s\n"), warning.c_str());
 	temporary_directories.emplace_back(std::move(extraction_directory));
 	cleanup_unused_temporary_directories(prefs);
+	publish_cd_swap_list(cd_paths);
 	whdload_prefs.write_cache = false;
 	whdload_prefs.whdload_filename.clear();
 	loaded_path = filename;

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -668,6 +668,18 @@ void apply_compatibility(uae_prefs* prefs, const rp9::Manifest& manifest)
 	}
 }
 
+#ifdef JIT
+bool manifest_requests_jit(const rp9::Manifest& manifest)
+{
+	if (std::find(manifest.compatibility.begin(), manifest.compatibility.end(), "jit")
+		!= manifest.compatibility.end())
+		return true;
+	return std::any_of(manifest.peripherals.begin(), manifest.peripherals.end(), [](const auto& peripheral) {
+		return peripheral.name == "jit";
+	});
+}
+#endif
+
 void apply_ram(uae_prefs* prefs, const rp9::Manifest& manifest)
 {
 	for (const auto& ram : manifest.ram) {
@@ -1133,7 +1145,19 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 			result = apply_media(candidate.get(), manifest, extracted_files, package_deployment_id, snapshot_path,
 				cd_paths);
 		}
-		if (candidate->m68k_speed >= 0)
+#ifdef JIT
+		const bool jit_requested = manifest_requests_jit(manifest);
+		if (jit_requested) {
+			// An explicit JIT requirement takes precedence over cycle-exact
+			// defaults inherited from the selected canonical machine profile.
+			candidate->cpu_cycle_exact = false;
+			candidate->cpu_memory_cycle_exact = false;
+			candidate->blitter_cycle_exact = false;
+		}
+#else
+		constexpr bool jit_requested = false;
+#endif
+		if (candidate->m68k_speed >= 0 && !jit_requested)
 			candidate->cachesize = 0;
 	}
 

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -49,6 +49,7 @@ std::string last_error;
 std::string loaded_snapshot_path;
 bool loaded_has_clip;
 std::vector<std::filesystem::path> temporary_directories;
+std::vector<std::string> loaded_floppy_paths;
 std::vector<std::string> loaded_cd_paths;
 std::atomic<unsigned long long> directory_sequence { 0 };
 
@@ -105,6 +106,13 @@ bool loaded_cd_paths_reference_directory(const std::filesystem::path& directory)
 	});
 }
 
+bool loaded_floppy_paths_reference_directory(const std::filesystem::path& directory)
+{
+	return std::any_of(loaded_floppy_paths.begin(), loaded_floppy_paths.end(), [&directory](const auto& path) {
+		return directory_contains_path(directory, path.c_str());
+	});
+}
+
 void cleanup_unused_temporary_directories(const uae_prefs* additional_prefs = nullptr)
 {
 	for (auto directory = temporary_directories.begin(); directory != temporary_directories.end();) {
@@ -113,6 +121,7 @@ void cleanup_unused_temporary_directories(const uae_prefs* additional_prefs = nu
 			|| (additional_prefs != &currprefs && additional_prefs != &changed_prefs
 				&& prefs_reference_directory(additional_prefs, *directory))
 			|| pending_snapshot_references_directory(*directory)
+			|| loaded_floppy_paths_reference_directory(*directory)
 			|| loaded_cd_paths_reference_directory(*directory)) {
 			++directory;
 			continue;
@@ -1157,6 +1166,7 @@ bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
 	const std::unordered_map<std::string, std::filesystem::path>& files,
 	const std::string& deployment_id, const std::filesystem::path& extraction_directory,
 	std::string& snapshot_path,
+	std::vector<std::string>& floppy_paths,
 	std::vector<std::string>& cd_paths)
 {
 	int device_number = 0;
@@ -1192,6 +1202,7 @@ bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
 		const auto path_string = path.string();
 		switch (media.type) {
 		case rp9::MediaType::Floppy:
+			floppy_paths.emplace_back(path_string);
 			if (floppy_count < MAX_SPARE_DRIVES) {
 				copy_path(prefs->dfxlist[floppy_count], MAX_DPATH, path_string);
 				// RP9 priorities are one-based insertion preferences (priority 1
@@ -1274,6 +1285,7 @@ void rp9_init()
 	last_error.clear();
 	loaded_snapshot_path.clear();
 	loaded_has_clip = false;
+	loaded_floppy_paths.clear();
 	loaded_cd_paths.clear();
 }
 
@@ -1409,6 +1421,7 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 
 	std::unique_ptr<uae_prefs> candidate;
 	std::string snapshot_path;
+	std::vector<std::string> floppy_paths;
 	std::vector<std::string> cd_paths;
 	if (result) {
 		candidate = std::make_unique<uae_prefs>();
@@ -1421,7 +1434,7 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 		if (result) {
 			apply_video_and_clip(candidate.get(), manifest);
 			result = apply_media(candidate.get(), manifest, extracted_files, package_deployment_id,
-				extraction_directory, snapshot_path, cd_paths);
+				extraction_directory, snapshot_path, floppy_paths, cd_paths);
 		}
 #ifdef JIT
 		const bool jit_requested = manifest_requests_jit(manifest);
@@ -1466,6 +1479,7 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 
 	for (const auto& warning : manifest.warnings)
 		write_log(_T("RP9: %s\n"), warning.c_str());
+	loaded_floppy_paths = floppy_paths;
 	loaded_cd_paths = cd_paths;
 	temporary_directories.emplace_back(std::move(extraction_directory));
 	cleanup_unused_temporary_directories(prefs);
@@ -1491,6 +1505,16 @@ const std::string& rp9_get_last_error()
 	return last_error;
 }
 
+const std::vector<std::string>& rp9_get_loaded_floppy_paths()
+{
+	return loaded_floppy_paths;
+}
+
+const std::vector<std::string>& rp9_get_loaded_cd_paths()
+{
+	return loaded_cd_paths;
+}
+
 bool rp9_loaded_has_clip()
 {
 	return loaded_has_clip;
@@ -1505,5 +1529,6 @@ void rp9_clear_loaded_path()
 	loaded_snapshot_path.clear();
 	loaded_path.clear();
 	loaded_has_clip = false;
+	loaded_floppy_paths.clear();
 	loaded_cd_paths.clear();
 }

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -737,6 +737,44 @@ std::filesystem::path resolve_media_path(const rp9::Media& media,
 	return {};
 }
 
+std::filesystem::path prepare_undoable_hardfile(const rp9::Media& media,
+	const std::filesystem::path& source, const std::filesystem::path& extraction_directory,
+	const int device_number)
+{
+	// Embedded hardfiles already live in the disposable extraction directory.
+	// Read-only media cannot accumulate changes, so neither case needs a copy.
+	if (!media.undo || media.readonly
+		|| directory_contains_path(extraction_directory, source.string().c_str()))
+		return source;
+
+	std::error_code error;
+	if (!std::filesystem::is_regular_file(source, error) || error) {
+		set_error("RP9 undo is only supported for hardfile images: " + media.path);
+		return {};
+	}
+
+	const auto undo_directory = extraction_directory / "undo";
+	std::filesystem::create_directories(undo_directory, error);
+	if (error) {
+		set_error("Could not create the RP9 hardfile undo directory: " + error.message());
+		return {};
+	}
+
+	auto filename = source.filename().string();
+	if (filename.empty())
+		filename = "disk.hdf";
+	const auto destination = undo_directory
+		/ ("harddrive-" + std::to_string(device_number) + "-" + filename);
+	std::filesystem::copy_file(source, destination, std::filesystem::copy_options::none, error);
+	if (error) {
+		set_error("Could not create the RP9 hardfile undo copy: " + error.message());
+		return {};
+	}
+
+	write_log(_T("RP9: using temporary undo copy for hardfile: %s\n"), destination.string().c_str());
+	return destination;
+}
+
 void apply_compatibility(uae_prefs* prefs, const rp9::Manifest& manifest)
 {
 	for (const auto& value : manifest.compatibility) {
@@ -1057,7 +1095,8 @@ bool is_rdb_hardfile(const std::filesystem::path& path)
 
 bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
 	const std::unordered_map<std::string, std::filesystem::path>& files,
-	const std::string& deployment_id, std::string& snapshot_path,
+	const std::string& deployment_id, const std::filesystem::path& extraction_directory,
+	std::string& snapshot_path,
 	std::vector<std::string>& cd_paths)
 {
 	int device_number = 0;
@@ -1111,12 +1150,17 @@ bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
 				++floppy_count;
 			}
 			break;
-		case rp9::MediaType::HardDrive:
-			if (!add_harddrive(prefs, path, media.volume_name, media.readonly, 0, device_number)) {
+		case rp9::MediaType::HardDrive: {
+			const auto hardfile_path = prepare_undoable_hardfile(media, path, extraction_directory,
+				device_number);
+			if (hardfile_path.empty())
+				return false;
+			if (!add_harddrive(prefs, hardfile_path, media.volume_name, media.readonly, 0, device_number)) {
 				set_error("Could not attach RP9 hard drive: " + media.path);
 				return false;
 			}
 			break;
+		}
 		case rp9::MediaType::Cd:
 			cd_paths.emplace_back(path_string);
 			if (!cd_attached) {
@@ -1276,8 +1320,8 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 		result = apply_peripherals(candidate.get(), manifest);
 		if (result) {
 			apply_video_and_clip(candidate.get(), manifest);
-			result = apply_media(candidate.get(), manifest, extracted_files, package_deployment_id, snapshot_path,
-				cd_paths);
+			result = apply_media(candidate.get(), manifest, extracted_files, package_deployment_id,
+				extraction_directory, snapshot_path, cd_paths);
 		}
 #ifdef JIT
 		const bool jit_requested = manifest_requests_jit(manifest);

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -46,6 +46,86 @@ bool loaded_has_clip;
 std::vector<std::filesystem::path> temporary_directories;
 std::atomic<unsigned long long> directory_sequence { 0 };
 
+bool directory_contains_path(const std::filesystem::path& directory, const TCHAR* value)
+{
+	if (!value || !value[0])
+		return false;
+	const auto normalized_directory = directory.lexically_normal();
+	const auto normalized_path = std::filesystem::path(value).lexically_normal();
+	auto directory_component = normalized_directory.begin();
+	auto path_component = normalized_path.begin();
+	while (directory_component != normalized_directory.end() && path_component != normalized_path.end()) {
+		if (*directory_component != *path_component)
+			return false;
+		++directory_component;
+		++path_component;
+	}
+	return directory_component == normalized_directory.end();
+}
+
+bool prefs_reference_directory(const uae_prefs* prefs, const std::filesystem::path& directory)
+{
+	if (!prefs)
+		return false;
+	for (const auto& slot : prefs->floppyslots) {
+		if (directory_contains_path(directory, slot.df))
+			return true;
+	}
+	for (const auto& path : prefs->dfxlist) {
+		if (directory_contains_path(directory, path))
+			return true;
+	}
+	for (const auto& slot : prefs->cdslots) {
+		if (slot.inuse && directory_contains_path(directory, slot.name))
+			return true;
+	}
+	const auto mount_count = std::clamp(prefs->mountitems, 0, MOUNT_CONFIG_SIZE);
+	for (int index = 0; index < mount_count; ++index) {
+		if (directory_contains_path(directory, prefs->mountconfig[index].ci.rootdir))
+			return true;
+	}
+	return false;
+}
+
+bool pending_snapshot_references_directory(const std::filesystem::path& directory)
+{
+	return savestate_state != 0 && directory_contains_path(directory, savestate_fname);
+}
+
+void cleanup_unused_temporary_directories(const uae_prefs* additional_prefs = nullptr)
+{
+	for (auto directory = temporary_directories.begin(); directory != temporary_directories.end();) {
+		if (prefs_reference_directory(&currprefs, *directory)
+			|| prefs_reference_directory(&changed_prefs, *directory)
+			|| (additional_prefs != &currprefs && additional_prefs != &changed_prefs
+				&& prefs_reference_directory(additional_prefs, *directory))
+			|| pending_snapshot_references_directory(*directory)) {
+			++directory;
+			continue;
+		}
+
+		std::error_code error;
+		std::filesystem::remove_all(*directory, error);
+		if (error) {
+			write_log(_T("RP9: could not remove unused temporary directory '%s': %s\n"),
+				directory->string().c_str(), error.message().c_str());
+			++directory;
+		} else {
+			write_log(_T("RP9: removed unused temporary directory: %s\n"), directory->string().c_str());
+			directory = temporary_directories.erase(directory);
+		}
+	}
+}
+
+bool pending_snapshot_uses_temporary_directory()
+{
+	if (savestate_state != STATE_DORESTORE)
+		return false;
+	return std::any_of(temporary_directories.begin(), temporary_directories.end(), [](const auto& directory) {
+		return directory_contains_path(directory, savestate_fname);
+	});
+}
+
 std::string lowercase(std::string value)
 {
 	std::transform(value.begin(), value.end(), value.begin(), [](const unsigned char ch) {
@@ -821,7 +901,20 @@ bool apply_media(uae_prefs* prefs, const rp9::Manifest& manifest,
 	std::array<bool, 4> floppy_drive_assigned {};
 	floppy_drive_assigned[0] = boot_floppy_attached;
 
-	for (const auto& media : manifest.media) {
+	std::vector<const rp9::Media*> ordered_media;
+	ordered_media.reserve(manifest.media.size());
+	for (const auto& media : manifest.media)
+		ordered_media.emplace_back(&media);
+	// Priority 1 is the first attachment/insertion preference. Preserve XML
+	// order when priorities are equal or omitted.
+	std::stable_sort(ordered_media.begin(), ordered_media.end(), [](const auto* left, const auto* right) {
+		if (left->has_priority != right->has_priority)
+			return left->has_priority;
+		return left->has_priority && left->priority < right->priority;
+	});
+
+	for (const auto* media_entry : ordered_media) {
+		const auto& media = *media_entry;
 		const auto path = resolve_media_path(media, files, deployment_id);
 		if (path.empty()) {
 			if (last_error.empty())
@@ -908,11 +1001,15 @@ void rp9_cleanup()
 	rp9_init();
 }
 
+void rp9_cleanup_unused()
+{
+	cleanup_unused_temporary_directories();
+}
+
 bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 {
 	last_error.clear();
-	loaded_path.clear();
-	loaded_has_clip = false;
+	rp9_clear_loaded_path();
 	if (!prefs || !filename || !filename[0]) {
 		set_error("No RP9 package was specified");
 		return false;
@@ -983,6 +1080,7 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 	for (const auto& warning : manifest.warnings)
 		write_log(_T("RP9: %s\n"), warning.c_str());
 	temporary_directories.emplace_back(std::move(extraction_directory));
+	cleanup_unused_temporary_directories(prefs);
 	whdload_prefs.whdload_filename.clear();
 	loaded_path = filename;
 	loaded_has_clip = manifest.has_clip;
@@ -1010,6 +1108,10 @@ bool rp9_loaded_has_clip()
 
 void rp9_clear_loaded_path()
 {
+	if (pending_snapshot_uses_temporary_directory()) {
+		savestate_state = 0;
+		savestate_fname[0] = 0;
+	}
 	loaded_path.clear();
 	loaded_has_clip = false;
 }

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -27,6 +27,7 @@
 #include "memory.h"
 #include "newcpu.h"
 #include "options.h"
+#include "rommgr.h"
 #include "rp9_manifest.h"
 #include "savestate.h"
 #include "target.h"
@@ -1184,6 +1185,32 @@ void rp9_cleanup()
 void rp9_cleanup_unused()
 {
 	cleanup_unused_temporary_directories();
+}
+
+bool rp9_register_rom_override(const char* filename)
+{
+	if (!filename || !filename[0])
+		return false;
+	if (getromdatabypath(filename))
+		return true;
+
+	// Cloanto-encrypted ROMs need the sibling key before their identity can be
+	// checked. This is harmless for plain ROMs and mirrors normal ROM scanning.
+	const auto key_path = std::filesystem::path(filename).parent_path() / "rom.key";
+	std::error_code error;
+	if (std::filesystem::is_regular_file(key_path, error) && !error)
+		addkeyfile(key_path.string().c_str());
+
+	auto* file = zfile_fopen(filename, _T("rb"), ZFD_NORMAL);
+	if (!file)
+		return false;
+	auto* const rom = scan_single_rom_file(file);
+	zfile_fclose(file);
+	if (!rom)
+		return false;
+
+	romlist_add(filename, rom);
+	return true;
 }
 
 bool rp9_parse_file(uae_prefs* prefs, const char* filename)

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -189,22 +189,127 @@ int system_rom_code(const std::string& value)
 	return parse_integer(normalized, result) ? result : invalid_system_rom;
 }
 
-std::string deployment_id(const char* manifest, const std::size_t size)
+struct ArchiveMediaFingerprint
 {
-	// Keep deployments stable if an RP9 is moved while separating packages that
-	// happen to use the same embedded media names. The manifest is small and is
-	// the package's stable identity for this purpose.
+	std::uint64_t size;
+	std::uint32_t crc;
+};
+
+void update_deployment_hash(std::uint64_t& hash, const unsigned char value)
+{
+	hash ^= value;
+	hash *= 1099511628211ULL;
+}
+
+void update_deployment_hash(std::uint64_t& hash, const std::uint64_t value)
+{
+	for (unsigned int shift = 0; shift < 64; shift += 8)
+		update_deployment_hash(hash, static_cast<unsigned char>(value >> shift));
+}
+
+bool deployment_id(unzFile archive, const char* manifest, const std::size_t size,
+	const rp9::Manifest& parsed_manifest, std::string& result)
+{
 	std::uint64_t hash = 14695981039346656037ULL;
-	for (std::size_t index = 0; index < size; ++index) {
-		hash ^= static_cast<unsigned char>(manifest[index]);
-		hash *= 1099511628211ULL;
+	for (std::size_t index = 0; index < size; ++index)
+		update_deployment_hash(hash, static_cast<unsigned char>(manifest[index]));
+
+	std::unordered_set<std::string> deployed_paths;
+	for (const auto& media : parsed_manifest.media) {
+		if (!media.deploy && lowercase(media.root) != "deploy")
+			continue;
+		std::string normalized;
+		if (!rp9::normalize_package_path(media.path, normalized)) {
+			set_error("Unsafe deployed-media path in RP9 manifest: " + media.path);
+			return false;
+		}
+		deployed_paths.emplace(lowercase(normalized));
+	}
+
+	std::unordered_map<std::string, ArchiveMediaFingerprint> fingerprints;
+	if (!deployed_paths.empty()) {
+		unz_global_info global {};
+		if (unzGetGlobalInfo(archive, &global) != UNZ_OK || global.number_entry > maximum_archive_entries) {
+			set_error("RP9 archive has an invalid or excessive number of entries");
+			return false;
+		}
+		if (unzGoToFirstFile(archive) != UNZ_OK) {
+			set_error("RP9 archive contains no readable entries");
+			return false;
+		}
+
+		for (unsigned long index = 0; index < global.number_entry; ++index) {
+			unz_file_info info {};
+			if (unzGetCurrentFileInfo(archive, &info, nullptr, 0, nullptr, 0, nullptr, 0) != UNZ_OK
+				|| info.size_filename == 0 || info.size_filename > maximum_entry_name) {
+				set_error("RP9 archive contains an invalid entry");
+				return false;
+			}
+			std::vector<char> name(static_cast<std::size_t>(info.size_filename) + 1);
+			if (unzGetCurrentFileInfo(archive, &info, name.data(), static_cast<unsigned long>(name.size()),
+				nullptr, 0, nullptr, 0) != UNZ_OK) {
+				set_error("Could not read an RP9 archive entry name");
+				return false;
+			}
+			const std::string entry_name(name.data(), static_cast<std::size_t>(info.size_filename));
+			if (entry_name.find('\0') != std::string::npos) {
+				set_error("RP9 archive contains an entry name with an embedded null byte");
+				return false;
+			}
+
+			std::string normalized;
+			if (!rp9::normalize_package_path(entry_name, normalized)) {
+				set_error("Unsafe path in RP9 archive: " + entry_name);
+				return false;
+			}
+			auto path_key = lowercase(normalized);
+			if (!path_key.empty() && path_key.back() == '/')
+				path_key.pop_back();
+			const bool is_directory = entry_name.back() == '/' || entry_name.back() == '\\';
+			if (!is_directory && deployed_paths.find(path_key) != deployed_paths.end()) {
+				if (!fingerprints.emplace(path_key, ArchiveMediaFingerprint {
+					static_cast<std::uint64_t>(info.uncompressed_size), static_cast<std::uint32_t>(info.crc)
+				}).second) {
+					set_error("RP9 archive contains a duplicate deployed-media path: " + entry_name);
+					return false;
+				}
+			}
+			if (index + 1 < global.number_entry && unzGoToNextFile(archive) != UNZ_OK) {
+				set_error("RP9 archive ended before all entries were read");
+				return false;
+			}
+		}
+	}
+
+	// ZIP CRC and size describe the uncompressed source media, so the identity
+	// remains stable after moves, repacking, and guest writes to the deployed
+	// copy while changing when a package supplies different persistent media.
+	for (const auto& media : parsed_manifest.media) {
+		if (!media.deploy && lowercase(media.root) != "deploy")
+			continue;
+		std::string normalized;
+		if (!rp9::normalize_package_path(media.path, normalized))
+			return false;
+		const auto path_key = lowercase(normalized);
+		update_deployment_hash(hash, static_cast<std::uint64_t>(path_key.size()));
+		for (const auto value : path_key)
+			update_deployment_hash(hash, static_cast<unsigned char>(value));
+		const auto fingerprint = fingerprints.find(path_key);
+		update_deployment_hash(hash, static_cast<unsigned char>(fingerprint != fingerprints.end()));
+		if (fingerprint != fingerprints.end()) {
+			update_deployment_hash(hash, fingerprint->second.size);
+			update_deployment_hash(hash, static_cast<std::uint64_t>(fingerprint->second.crc));
+		}
 	}
 	std::array<char, 16> buffer {};
 	const auto [end, error] = std::to_chars(buffer.data(), buffer.data() + buffer.size(), hash, 16);
-	if (error != std::errc {})
-		return "package";
-	return std::string(16 - static_cast<std::size_t>(end - buffer.data()), '0')
+	if (error != std::errc {}) {
+		set_error("Could not create the RP9 deployment identity");
+		return false;
+	}
+	result = std::string(16 - static_cast<std::size_t>(end - buffer.data()), '0')
 		+ std::string(buffer.data(), end);
+	return true;
 }
 
 bool deployed_media_path(const rp9::Media& media, const std::string& package_id,
@@ -1106,9 +1211,11 @@ bool rp9_parse_file(uae_prefs* prefs, const char* filename)
 	std::string manifest_error;
 	bool result = read_manifest(archive, manifest_data)
 		&& rp9::parse_manifest(manifest_data.data(), manifest_data.size() - 1, manifest, manifest_error);
-	const auto package_deployment_id = result
-		? deployment_id(manifest_data.data(), manifest_data.size() - 1)
-		: std::string {};
+	std::string package_deployment_id;
+	if (result) {
+		result = deployment_id(archive, manifest_data.data(), manifest_data.size() - 1, manifest,
+			package_deployment_id);
+	}
 	const auto existing_deployments = result
 		? find_existing_deployments(manifest, package_deployment_id)
 		: std::unordered_map<std::string, std::filesystem::path> {};

--- a/src/osdep/amiberry_rp9.cpp
+++ b/src/osdep/amiberry_rp9.cpp
@@ -512,6 +512,27 @@ std::filesystem::path create_extraction_directory()
 	return {};
 }
 
+bool register_extracted_path(std::unordered_map<std::string, std::filesystem::path>& files,
+	const std::string& package_path, const std::filesystem::path& host_path)
+{
+	const auto [existing, inserted] = files.emplace(lowercase(package_path), host_path);
+	if (inserted || existing->second.lexically_normal() == host_path.lexically_normal())
+		return true;
+	set_error("RP9 archive contains colliding paths: " + package_path);
+	return false;
+}
+
+bool register_extracted_directories(std::unordered_map<std::string, std::filesystem::path>& files,
+	const std::filesystem::path& root, std::filesystem::path relative_directory)
+{
+	while (!relative_directory.empty()) {
+		if (!register_extracted_path(files, relative_directory.generic_string(), root / relative_directory))
+			return false;
+		relative_directory = relative_directory.parent_path();
+	}
+	return true;
+}
+
 bool extract_archive(unzFile archive, const std::filesystem::path& directory,
 	std::unordered_map<std::string, std::filesystem::path>& files,
 	const std::unordered_map<std::string, std::filesystem::path>& skipped_files)
@@ -548,24 +569,34 @@ bool extract_archive(unzFile archive, const std::filesystem::path& directory,
 			return false;
 		}
 
+		const bool is_directory = entry_name.back() == '/' || entry_name.back() == '\\';
 		std::string normalized;
 		if (!rp9::normalize_package_path(entry_name, normalized)) {
 			set_error("Unsafe path in RP9 archive: " + entry_name);
 			return false;
 		}
+		if (is_directory && normalized.back() == '/')
+			normalized.pop_back();
 		auto path_key = lowercase(normalized);
-		if (!path_key.empty() && path_key.back() == '/')
-			path_key.pop_back();
 		if (!seen_paths.emplace(path_key).second) {
 			set_error("RP9 archive contains a duplicate path: " + entry_name);
 			return false;
 		}
-		const bool is_directory = entry_name.back() == '/' || entry_name.back() == '\\';
 		const auto destination = directory / std::filesystem::path(normalized);
 		std::error_code error;
 		if (is_directory) {
 			std::filesystem::create_directories(destination, error);
+			if (!error && !register_extracted_directories(files, directory, std::filesystem::path(normalized)))
+				return false;
 		} else if (lowercase(normalized) != manifest_name) {
+			std::filesystem::create_directories(destination.parent_path(), error);
+			if (error) {
+				set_error("Could not create an RP9 extraction directory: " + error.message());
+				return false;
+			}
+			if (!register_extracted_directories(files, directory,
+				std::filesystem::path(normalized).parent_path()))
+				return false;
 			if (skipped_files.find(path_key) != skipped_files.end()) {
 				write_log(_T("RP9: skipping embedded copy of deployed media: %s\n"), normalized.c_str());
 			} else {
@@ -580,11 +611,6 @@ bool extract_archive(unzFile archive, const std::filesystem::path& directory,
 				}
 				if (error) {
 					set_error("Could not validate an RP9 extraction path: " + error.message());
-					return false;
-				}
-				std::filesystem::create_directories(destination.parent_path(), error);
-				if (error) {
-					set_error("Could not create an RP9 extraction directory: " + error.message());
 					return false;
 				}
 				auto output = uae_fopen(destination.string().c_str(), _T("wbe"));
@@ -630,7 +656,8 @@ bool extract_archive(unzFile archive, const std::filesystem::path& directory,
 					set_error("RP9 entry failed its integrity check: " + normalized);
 					return false;
 				}
-				files.emplace(lowercase(normalized), destination);
+				if (!register_extracted_path(files, normalized, destination))
+					return false;
 			}
 		}
 		if (error) {

--- a/src/osdep/amiberry_rp9.h
+++ b/src/osdep/amiberry_rp9.h
@@ -8,6 +8,7 @@ void rp9_init();
 void rp9_cleanup();
 void rp9_cleanup_unused();
 bool rp9_register_rom_override(const char* filename);
+int rp9_register_rom_directory(const char* directory);
 bool rp9_parse_file(struct uae_prefs* prefs, const char* filename);
 const std::string& rp9_get_loaded_path();
 const std::string& rp9_get_last_error();

--- a/src/osdep/amiberry_rp9.h
+++ b/src/osdep/amiberry_rp9.h
@@ -6,6 +6,7 @@ struct uae_prefs;
 
 void rp9_init();
 void rp9_cleanup();
+void rp9_cleanup_unused();
 bool rp9_parse_file(struct uae_prefs* prefs, const char* filename);
 const std::string& rp9_get_loaded_path();
 const std::string& rp9_get_last_error();

--- a/src/osdep/amiberry_rp9.h
+++ b/src/osdep/amiberry_rp9.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+struct uae_prefs;
+
+void rp9_init();
+void rp9_cleanup();
+bool rp9_parse_file(struct uae_prefs* prefs, const char* filename);
+const std::string& rp9_get_loaded_path();
+const std::string& rp9_get_last_error();
+bool rp9_loaded_has_clip();
+void rp9_clear_loaded_path();

--- a/src/osdep/amiberry_rp9.h
+++ b/src/osdep/amiberry_rp9.h
@@ -7,6 +7,7 @@ struct uae_prefs;
 void rp9_init();
 void rp9_cleanup();
 void rp9_cleanup_unused();
+bool rp9_register_rom_override(const char* filename);
 bool rp9_parse_file(struct uae_prefs* prefs, const char* filename);
 const std::string& rp9_get_loaded_path();
 const std::string& rp9_get_last_error();

--- a/src/osdep/amiberry_rp9.h
+++ b/src/osdep/amiberry_rp9.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 struct uae_prefs;
 
@@ -12,5 +13,7 @@ int rp9_register_rom_directory(const char* directory);
 bool rp9_parse_file(struct uae_prefs* prefs, const char* filename);
 const std::string& rp9_get_loaded_path();
 const std::string& rp9_get_last_error();
+const std::vector<std::string>& rp9_get_loaded_floppy_paths();
+const std::vector<std::string>& rp9_get_loaded_cd_paths();
 bool rp9_loaded_has_clip();
 void rp9_clear_loaded_path();

--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -40,6 +40,7 @@
 #include "tinyxml2.h"
 #include "file_dialog.h"
 #include "macos_window.h"
+#include "amiberry_rp9.h"
 
 #ifdef USE_IMGUI
 #include "imgui.h"
@@ -2694,13 +2695,17 @@ void run_gui()
 		ImGui::SameLine();
 		if (AmigaButton(ICON_FA_ARROWS_ROTATE " Reload", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT))) {
 			char tmp[MAX_DPATH] = {0};
-			get_configuration_path(tmp, sizeof tmp);
-			if (strlen(last_loaded_config) > 0) {
-				strncat(tmp, last_loaded_config, MAX_DPATH - 1);
-				strncat(tmp, ".uae", MAX_DPATH - 10);
+			if (!rp9_get_loaded_path().empty()) {
+				strncpy(tmp, rp9_get_loaded_path().c_str(), MAX_DPATH - 1);
 			} else {
-				strncat(tmp, OPTIONSFILENAME, MAX_DPATH - 1);
-				strncat(tmp, ".uae", MAX_DPATH - 10);
+				get_configuration_path(tmp, sizeof tmp);
+				if (strlen(last_loaded_config) > 0) {
+					strncat(tmp, last_loaded_config, MAX_DPATH - 1);
+					strncat(tmp, ".uae", MAX_DPATH - 10);
+				} else {
+					strncat(tmp, OPTIONSFILENAME, MAX_DPATH - 1);
+					strncat(tmp, ".uae", MAX_DPATH - 10);
+				}
 			}
 			uae_restart(&changed_prefs, -1, tmp);
 			gui_running = false;

--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -1898,9 +1898,9 @@ static void handle_drop_file_event(const SDL_Event& event)
 	const char* dropped_file = event.drop.data;
 	const auto ext = get_filename_extension(dropped_file);
 
-	if (strcasecmp(ext.c_str(), ".uae") == 0)
+	if (strcasecmp(ext.c_str(), ".uae") == 0 || strcasecmp(ext.c_str(), ".rp9") == 0)
 	{
-		// Load configuration file
+		// Load configuration or self-contained RP9 package
 		uae_restart(&currprefs, -1, dropped_file);
 		gui_running = false;
 	}

--- a/src/osdep/imgui/play.cpp
+++ b/src/osdep/imgui/play.cpp
@@ -433,6 +433,8 @@ PlayContentType selected_action_type()
 void mark_content_applied()
 {
 	applied_content_type = selected_action_type();
+	if (applied_content_type != PlayContentType::Rp9)
+		rp9_clear_loaded_path();
 	applied_content_attachment_path = current_attachment_path_for_type(applied_content_type);
 	applied_config_summary = describe_current_config();
 	selected_content_applied = true;
@@ -626,8 +628,6 @@ bool apply_cd_content()
 
 bool apply_selected_content(const PlayContentType type)
 {
-	if (type != PlayContentType::Rp9)
-		rp9_clear_loaded_path();
 	switch (type) {
 	case PlayContentType::Configuration:
 		return apply_configuration_content();

--- a/src/osdep/imgui/play.cpp
+++ b/src/osdep/imgui/play.cpp
@@ -9,6 +9,7 @@
 
 #include "file_dialog.h"
 #include "filesys.h"
+#include "amiberry_rp9.h"
 #include "gui/gui_handling.h"
 #include "imgui_panels.h"
 #include "custom.h"
@@ -93,6 +94,8 @@ const char* suggested_profile_text(const PlayContentType type, const PlaySuggest
 {
 	if (type == PlayContentType::Configuration)
 		return "Configuration file settings";
+	if (type == PlayContentType::Rp9)
+		return "Machine and media settings from the RP9 manifest";
 	if (type == PlayContentType::WhdLoad)
 		return "WHDLoad autoload; the database/slave can adjust the exact machine";
 	if (model == PlaySuggestedModel::A1200Expanded)
@@ -402,6 +405,8 @@ std::string current_attachment_path_for_type(const PlayContentType type)
 		return changed_prefs.floppyslots[0].df;
 	case PlayContentType::WhdLoad:
 		return whdload_prefs.whdload_filename;
+	case PlayContentType::Rp9:
+		return rp9_get_loaded_path();
 	case PlayContentType::Cd:
 		return changed_prefs.cdslots[0].inuse ? changed_prefs.cdslots[0].name : "";
 	case PlayContentType::Hardfile:
@@ -508,6 +513,42 @@ bool apply_configuration_content()
 	return true;
 }
 
+bool apply_rp9_content()
+{
+	if (!rp9_parse_file(&changed_prefs, selected_content.original_path.c_str())) {
+		ShowMessageBox("Load RP9", rp9_get_last_error().c_str());
+		return false;
+	}
+
+	const bool has_clip = rp9_loaded_has_clip();
+	const bool manual_crop = changed_prefs.gfx_manual_crop;
+	const int crop_width = changed_prefs.gfx_manual_crop_width;
+	const int crop_height = changed_prefs.gfx_manual_crop_height;
+	const int crop_x = changed_prefs.gfx_horizontal_offset;
+	const int crop_y = changed_prefs.gfx_vertical_offset;
+	apply_display_defaults_to_changed_prefs();
+	if (has_clip) {
+		changed_prefs.gfx_auto_crop = false;
+		changed_prefs.gfx_manual_crop = manual_crop;
+		changed_prefs.gfx_manual_crop_width = crop_width;
+		changed_prefs.gfx_manual_crop_height = crop_height;
+		changed_prefs.gfx_horizontal_offset = crop_x;
+		changed_prefs.gfx_vertical_offset = crop_y;
+	}
+
+	for (int drive = 0; drive < changed_prefs.nr_floppies && drive < 4; ++drive) {
+		if (changed_prefs.floppyslots[drive].df[0]) {
+			disk_insert(drive, changed_prefs.floppyslots[drive].df);
+			add_file_to_mru_list(lstMRUDiskList, changed_prefs.floppyslots[drive].df);
+		}
+	}
+	if (changed_prefs.cdslots[0].inuse && changed_prefs.cdslots[0].name[0])
+		add_file_to_mru_list(lstMRUCDList, changed_prefs.cdslots[0].name);
+	set_last_active_config(selected_content.original_path.c_str());
+	mark_content_applied();
+	return true;
+}
+
 bool apply_floppy_content()
 {
 	apply_quickstart_model_unless_overridden(suggested_model_for_action(PlayContentType::Floppy));
@@ -585,9 +626,13 @@ bool apply_cd_content()
 
 bool apply_selected_content(const PlayContentType type)
 {
+	if (type != PlayContentType::Rp9)
+		rp9_clear_loaded_path();
 	switch (type) {
 	case PlayContentType::Configuration:
 		return apply_configuration_content();
+	case PlayContentType::Rp9:
+		return apply_rp9_content();
 	case PlayContentType::Floppy:
 		return apply_floppy_content();
 	case PlayContentType::WhdLoad:
@@ -768,7 +813,7 @@ void render_content_picker()
 {
 	if (AmigaButton(ICON_FA_FOLDER_OPEN " Choose content...", ImVec2(BUTTON_WIDTH * 2.0f, BUTTON_HEIGHT))) {
 		OpenFileDialogKey("PLAY_CONTENT", "Choose Amiga content",
-			"Amiga Content (*.uae,*.adf,*.adz,*.dms,*.fdi,*.scp,*.wrp,*.dsq,*.ipf,*.zip,*.7z,*.lha,*.lzh,*.lzx,*.cue,*.bin,*.iso,*.ccd,*.mds,*.chd,*.nrg,*.hdf,*.hdz,*.hda,*.vhd,*.img,*.gz,*.xz){.uae,.adf,.adz,.dms,.fdi,.scp,.wrp,.dsq,.ipf,.zip,.7z,.lha,.lzh,.lzx,.cue,.bin,.iso,.ccd,.mds,.chd,.nrg,.hdf,.hdz,.hda,.vhd,.img,.gz,.xz},All Files (*){.*}",
+			"Amiga Content (*.uae,*.rp9,*.adf,*.adz,*.dms,*.fdi,*.scp,*.wrp,*.dsq,*.ipf,*.zip,*.7z,*.lha,*.lzh,*.lzx,*.cue,*.bin,*.iso,*.ccd,*.mds,*.chd,*.nrg,*.hdf,*.hdz,*.hda,*.vhd,*.img,*.gz,*.xz){.uae,.rp9,.adf,.adz,.dms,.fdi,.scp,.wrp,.dsq,.ipf,.zip,.7z,.lha,.lzh,.lzx,.cue,.bin,.iso,.ccd,.mds,.chd,.nrg,.hdf,.hdz,.hda,.vhd,.img,.gz,.xz},All Files (*){.*}",
 			get_floppy_path());
 	}
 	if (AmigaButton(ICON_FA_FOLDER_OPEN " Choose folder...", ImVec2(BUTTON_WIDTH * 2.0f, BUTTON_HEIGHT)))
@@ -818,10 +863,12 @@ void render_content_picker()
 					play_prepare_selected_content_for_start();
 				ImGui::SameLine();
 			}
-			if (AmigaButton(ICON_FA_ROCKET " Change model...", ImVec2(BUTTON_WIDTH * 1.8f, BUTTON_HEIGHT))) {
-				mark_selected_content_pending();
-				begin_quickstart_override_tracking();
-				gui_show_panel("quickstart", true);
+			if (action_type != PlayContentType::Rp9) {
+				if (AmigaButton(ICON_FA_ROCKET " Change model...", ImVec2(BUTTON_WIDTH * 1.8f, BUTTON_HEIGHT))) {
+					mark_selected_content_pending();
+					begin_quickstart_override_tracking();
+					gui_show_panel("quickstart", true);
+				}
 			}
 			if (action_type == PlayContentType::Hardfile) {
 				ImGui::SameLine();

--- a/src/osdep/imgui/play_content_detection.cpp
+++ b/src/osdep/imgui/play_content_detection.cpp
@@ -91,6 +91,10 @@ PlayContentDetection play_detect_content(const std::string& path, bool is_direct
 		detection.type = PlayContentType::Configuration;
 		return detection;
 	}
+	if (extension == ".rp9") {
+		detection.type = PlayContentType::Rp9;
+		return detection;
+	}
 
 	if (is_one_of(extension, { ".adf", ".adz", ".ipf", ".dms", ".fdi", ".scp", ".wrp", ".dsq", ".gz", ".xz" })) {
 		detection.type = PlayContentType::Floppy;
@@ -170,6 +174,8 @@ const char* play_content_type_name(const PlayContentType type)
 	switch (type) {
 		case PlayContentType::Configuration:
 			return "Configuration";
+		case PlayContentType::Rp9:
+			return "RP9 package";
 		case PlayContentType::WhdLoad:
 			return "WHDLoad";
 		case PlayContentType::Floppy:

--- a/src/osdep/imgui/play_content_detection.h
+++ b/src/osdep/imgui/play_content_detection.h
@@ -6,6 +6,7 @@
 enum class PlayContentType
 {
 	Configuration,
+	Rp9,
 	WhdLoad,
 	Floppy,
 	Cd,

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -199,6 +199,13 @@ static void clear_play_content_if_quickstart_source() {
         play_clear_content_selection();
 }
 
+static void reset_rp9_to_quickstart_defaults() {
+    rp9_clear_loaded_path();
+    default_prefs(&changed_prefs, true, 0);
+    Quickstart_ApplyDefaults();
+    rp9_cleanup_unused();
+}
+
 void render_panel_quickstart() {
     // Apply defaults on first show only when no configuration or media setup is active.
     static bool initial_sync_done = false;
@@ -744,7 +751,8 @@ void render_panel_quickstart() {
     ImGui::SameLine();
     if (AmigaButton(ICON_FA_EJECT "##QSRP9", ImVec2(SMALL_BUTTON_WIDTH, 0))) {
         play_clear_content_selection();
-        rp9_clear_loaded_path();
+        if (!rp9_get_loaded_path().empty())
+            reset_rp9_to_quickstart_defaults();
     }
 
     ImGui::SameLine();
@@ -765,8 +773,10 @@ void render_panel_quickstart() {
 
     ImGui::Spacing();
     if (AmigaButton(ICON_FA_CHECK " Set Configuration", ImVec2(BUTTON_WIDTH * 2, BUTTON_HEIGHT))) {
-        rp9_clear_loaded_path();
-        apply_quickstart_defaults_from_quickstart();
+        if (!rp9_get_loaded_path().empty())
+            reset_rp9_to_quickstart_defaults();
+        else
+            apply_quickstart_defaults_from_quickstart();
     }
 
     {

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -790,6 +790,8 @@ void render_panel_quickstart() {
         std::string filePath;
         if (ConsumeFileDialogResultKey("QUICKSTART", filePath)) {
             play_clear_content_selection();
+            if (!qs_pending_rp9 && !filePath.empty() && !rp9_get_loaded_path().empty())
+                reset_rp9_to_quickstart_defaults();
             if (qs_pending_floppy_drive >= 0 && qs_pending_floppy_drive < 2) {
                 int i = qs_pending_floppy_drive;
                 if (!filePath.empty()) {
@@ -846,9 +848,6 @@ void render_panel_quickstart() {
                     }
                 }
             }
-            if (!qs_pending_rp9 && !filePath.empty())
-                rp9_clear_loaded_path();
-
             qs_pending_floppy_drive = -1;
             qs_pending_cd = false;
             qs_pending_whd = false;

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -1,4 +1,5 @@
 #include "sysdeps.h"
+#include "amiberry_rp9.h"
 #include "blkdev.h"
 #include "imgui.h"
 #include "options.h"
@@ -230,6 +231,7 @@ void render_panel_quickstart() {
     static int qs_pending_floppy_drive = -1;
     static bool qs_pending_cd = false;
     static bool qs_pending_whd = false;
+    static bool qs_pending_rp9 = false;
 
     bool df1_visible = true;
     bool cd_visible = false;
@@ -732,6 +734,28 @@ void render_panel_quickstart() {
 
     ImGui::Spacing();
 
+    BeginGroupBox("RP9 package:");
+    if (AmigaButton(ICON_FA_FOLDER_OPEN " Select file##QSRP9", ImVec2(BUTTON_WIDTH * 1.33f, 0))) {
+        const std::string initial_path = rp9_get_loaded_path().empty() ? get_rp9_path() : rp9_get_loaded_path();
+        OpenFileDialogKey("QUICKSTART", "Select RP9 package", ".rp9,.*", initial_path);
+        qs_pending_rp9 = true;
+    }
+
+    ImGui::SameLine();
+    if (AmigaButton(ICON_FA_EJECT "##QSRP9", ImVec2(SMALL_BUTTON_WIDTH, 0))) {
+        play_clear_content_selection();
+        rp9_clear_loaded_path();
+    }
+
+    ImGui::SameLine();
+    if (rp9_get_loaded_path().empty())
+        ImGui::TextUnformatted("<empty>");
+    else
+        ImGui::TextWrapped("%s", rp9_get_loaded_path().c_str());
+    EndGroupBox("RP9 package:");
+
+    ImGui::Spacing();
+
     BeginGroupBox("Mode");
     bool qs_mode = amiberry_options.quickstart_start;
     if (AmigaCheckbox("Start in Quickstart mode", &qs_mode))
@@ -741,6 +765,7 @@ void render_panel_quickstart() {
 
     ImGui::Spacing();
     if (AmigaButton(ICON_FA_CHECK " Set Configuration", ImVec2(BUTTON_WIDTH * 2, BUTTON_HEIGHT))) {
+        rp9_clear_loaded_path();
         apply_quickstart_defaults_from_quickstart();
     }
 
@@ -787,11 +812,31 @@ void render_panel_quickstart() {
                     add_file_to_mru_list(lstMRUWhdloadList, whdload_prefs.whdload_filename);
                     whdload_auto_prefs(&changed_prefs, whdload_prefs.whdload_filename.c_str());
                 }
+            } else if (qs_pending_rp9) {
+                if (!filePath.empty()) {
+                    whdload_prefs.whdload_filename.clear();
+                    if (rp9_parse_file(&changed_prefs, filePath.c_str())) {
+                        for (int drive = 0; drive < changed_prefs.nr_floppies && drive < 4; ++drive) {
+                            if (changed_prefs.floppyslots[drive].df[0]) {
+                                disk_insert(drive, changed_prefs.floppyslots[drive].df);
+                                add_file_to_mru_list(lstMRUDiskList, changed_prefs.floppyslots[drive].df);
+                            }
+                        }
+                        if (changed_prefs.cdslots[0].inuse && changed_prefs.cdslots[0].name[0])
+                            add_file_to_mru_list(lstMRUCDList, changed_prefs.cdslots[0].name);
+                        set_last_active_config(filePath.c_str());
+                    } else {
+                        ShowMessageBox("Load RP9", rp9_get_last_error().c_str());
+                    }
+                }
             }
+            if (!qs_pending_rp9 && !filePath.empty())
+                rp9_clear_loaded_path();
 
             qs_pending_floppy_drive = -1;
             qs_pending_cd = false;
             qs_pending_whd = false;
+            qs_pending_rp9 = false;
         }
     }
     ImGui::Unindent(5.0f);

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -824,7 +824,6 @@ void render_panel_quickstart() {
                 }
             } else if (qs_pending_rp9) {
                 if (!filePath.empty()) {
-                    whdload_prefs.whdload_filename.clear();
                     if (rp9_parse_file(&changed_prefs, filePath.c_str())) {
                         for (int drive = 0; drive < changed_prefs.nr_floppies && drive < 4; ++drive) {
                             if (changed_prefs.floppyslots[drive].df[0]) {

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -248,6 +248,9 @@ void render_panel_quickstart() {
     ImGui::Indent(4.0f);
 
     BeginGroupBox("Emulated Hardware");
+    const bool rp9_active = !rp9_get_loaded_path().empty();
+    if (rp9_active)
+        ImGui::BeginDisabled();
     if (ImGui::BeginTable("QuickstartModelTable", 2, ImGuiTableFlags_SizingStretchProp,
                           ImVec2(ImGui::GetContentRegionAvail().x - 15.0f, 0.0f))) {
         ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed, BUTTON_WIDTH * 1.33f);
@@ -358,6 +361,10 @@ void render_panel_quickstart() {
 
         ImGui::EndTable();
     }
+    if (rp9_active)
+        ImGui::EndDisabled();
+    if (rp9_active)
+        ImGui::TextDisabled("Eject the RP9 package to change its hardware configuration.");
     EndGroupBox("Emulated Hardware");
 
     ImGui::Spacing();

--- a/src/osdep/rp9_manifest.cpp
+++ b/src/osdep/rp9_manifest.cpp
@@ -1,0 +1,425 @@
+#include "rp9_manifest.h"
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <cctype>
+#include <filesystem>
+#include <limits>
+#include <string_view>
+
+#include "tinyxml2.h"
+
+namespace rp9
+{
+namespace
+{
+constexpr Version supported_player_version { 10, 0, 3, 0 };
+
+std::string trim(std::string value)
+{
+	const auto not_space = [](const unsigned char ch) { return !std::isspace(ch); };
+	value.erase(value.begin(), std::find_if(value.begin(), value.end(), not_space));
+	value.erase(std::find_if(value.rbegin(), value.rend(), not_space).base(), value.end());
+	return value;
+}
+
+std::string lowercase(std::string value)
+{
+	std::transform(value.begin(), value.end(), value.begin(), [](const unsigned char ch) {
+		return static_cast<char>(std::tolower(ch));
+	});
+	return value;
+}
+
+std::string_view local_name(const char* name)
+{
+	if (!name)
+		return {};
+	const std::string_view view(name);
+	const auto colon = view.find_last_of(':');
+	return colon == std::string_view::npos ? view : view.substr(colon + 1);
+}
+
+bool has_name(const tinyxml2::XMLElement* element, const std::string_view expected)
+{
+	return element && local_name(element->Name()) == expected;
+}
+
+const tinyxml2::XMLElement* child(const tinyxml2::XMLElement* parent, const std::string_view name)
+{
+	if (!parent)
+		return nullptr;
+	for (auto element = parent->FirstChildElement(); element; element = element->NextSiblingElement()) {
+		if (has_name(element, name))
+			return element;
+	}
+	return nullptr;
+}
+
+std::string text(const tinyxml2::XMLElement* element)
+{
+	return element && element->GetText() ? trim(element->GetText()) : std::string {};
+}
+
+std::string attribute(const tinyxml2::XMLElement* element, const char* name)
+{
+	if (!element)
+		return {};
+	const auto value = element->Attribute(name);
+	return value ? trim(value) : std::string {};
+}
+
+template<typename T>
+bool parse_unsigned(const std::string& value, T& result)
+{
+	static_assert(std::is_unsigned_v<T>);
+	if (value.empty())
+		return false;
+	T parsed = 0;
+	const auto [end, error] = std::from_chars(value.data(), value.data() + value.size(), parsed);
+	if (error != std::errc {} || end != value.data() + value.size())
+		return false;
+	result = parsed;
+	return true;
+}
+
+bool parse_bool(const std::string& value, bool& result)
+{
+	const auto normalized = lowercase(trim(value));
+	if (normalized == "true" || normalized == "1" || normalized == "yes") {
+		result = true;
+		return true;
+	}
+	if (normalized == "false" || normalized == "0" || normalized == "no") {
+		result = false;
+		return true;
+	}
+	return false;
+}
+
+bool parse_optional_bool(const tinyxml2::XMLElement* element, const char* name, bool& value,
+	std::string& error)
+{
+	const auto raw = attribute(element, name);
+	if (raw.empty())
+		return true;
+	if (!parse_bool(raw, value)) {
+		error = std::string("Invalid boolean value for ") + name + ": " + raw;
+		return false;
+	}
+	return true;
+}
+
+bool parse_required_clip_value(const tinyxml2::XMLElement* element, const char* name,
+	unsigned int& result, std::string& error)
+{
+	const auto raw = attribute(element, name);
+	if (!parse_unsigned(raw, result)) {
+		error = std::string("RP9 clip has an invalid or missing '") + name + "' value";
+		return false;
+	}
+	return true;
+}
+
+bool version_greater(const Version& left, const Version& right)
+{
+	const std::array<unsigned int, 4> lhs { left.major, left.minor, left.patch, left.build };
+	const std::array<unsigned int, 4> rhs { right.major, right.minor, right.patch, right.build };
+	return lhs > rhs;
+}
+
+bool is_portable_package_component(const std::string_view component)
+{
+	if (component.empty())
+		return true;
+	if (component == ".")
+		return true;
+	if (component == ".." || component.size() > 255
+		|| component.back() == '.' || component.back() == ' ')
+		return false;
+	for (const unsigned char ch : component) {
+		if (ch < 0x20 || ch == ':')
+			return false;
+	}
+
+	auto device_name = lowercase(std::string(component.substr(0, component.find('.'))));
+	if (device_name == "con" || device_name == "prn" || device_name == "aux" || device_name == "nul"
+		|| device_name == "conin$" || device_name == "conout$")
+		return false;
+	return !(device_name.size() == 4
+		&& (device_name.rfind("com", 0) == 0 || device_name.rfind("lpt", 0) == 0)
+		&& device_name[3] >= '1' && device_name[3] <= '9');
+}
+
+bool parse_configuration(const tinyxml2::XMLElement* configuration, Manifest& manifest, std::string& error)
+{
+	for (auto element = configuration->FirstChildElement(); element; element = element->NextSiblingElement()) {
+		const auto name = local_name(element->Name());
+		if (name == "system") {
+			manifest.system = lowercase(text(element));
+		} else if (name == "video") {
+			manifest.video = lowercase(text(element));
+		} else if (name == "rom") {
+			manifest.system_rom = text(element);
+		} else if (name == "ram") {
+			Ram ram;
+			ram.type = lowercase(attribute(element, "type"));
+			const auto raw_size = text(element);
+			if (!parse_unsigned(raw_size, ram.size)) {
+				error = "Invalid RP9 RAM size: " + raw_size;
+				return false;
+			}
+			manifest.ram.emplace_back(std::move(ram));
+		} else if (name == "boot") {
+			manifest.has_boot = true;
+			manifest.boot.type = lowercase(attribute(element, "type"));
+			manifest.boot.value = text(element);
+			if (!parse_optional_bool(element, "readonly", manifest.boot.readonly, error))
+				return false;
+		} else if (name == "peripheral") {
+			Peripheral peripheral;
+			peripheral.name = lowercase(text(element));
+			peripheral.type = lowercase(attribute(element, "type"));
+			peripheral.speed = lowercase(attribute(element, "speed"));
+			peripheral.layout = lowercase(attribute(element, "layout"));
+			peripheral.path = attribute(element, "path");
+			peripheral.device = attribute(element, "device");
+			peripheral.device_name = attribute(element, "devicename");
+			peripheral.volume_name = attribute(element, "volumename");
+
+			const auto unit = attribute(element, "unit");
+			if (!unit.empty()) {
+				unsigned int parsed = 0;
+				if (!parse_unsigned(unit, parsed) || parsed > static_cast<unsigned int>(std::numeric_limits<int>::max())) {
+					error = "Invalid RP9 peripheral unit: " + unit;
+					return false;
+				}
+				peripheral.unit = static_cast<int>(parsed);
+			}
+
+			const auto memory = attribute(element, "memory");
+			if (!memory.empty()) {
+				if (!parse_unsigned(memory, peripheral.memory)) {
+					error = "Invalid RP9 peripheral memory size: " + memory;
+					return false;
+				}
+				peripheral.has_memory = true;
+			}
+
+			const auto fpu = attribute(element, "fpu");
+			if (!fpu.empty()) {
+				if (!parse_bool(fpu, peripheral.fpu)) {
+					error = "Invalid RP9 peripheral fpu value: " + fpu;
+					return false;
+				}
+				peripheral.has_fpu = true;
+			}
+			manifest.peripherals.emplace_back(std::move(peripheral));
+		} else if (name == "compatibility") {
+			const auto value = lowercase(text(element));
+			if (!value.empty())
+				manifest.compatibility.emplace_back(value);
+		} else if (name == "clip") {
+			manifest.has_clip = true;
+			if (!parse_required_clip_value(element, "left", manifest.clip.left, error)
+				|| !parse_required_clip_value(element, "top", manifest.clip.top, error)
+				|| !parse_required_clip_value(element, "width", manifest.clip.width, error)
+				|| !parse_required_clip_value(element, "height", manifest.clip.height, error))
+				return false;
+			if (manifest.clip.width == 0 || manifest.clip.height == 0) {
+				error = "RP9 clip width and height must be greater than zero";
+				return false;
+			}
+		} else {
+			manifest.warnings.emplace_back("Unsupported RP9 configuration element: " + std::string(name));
+		}
+	}
+
+	if (manifest.system.empty()) {
+		error = "RP9 manifest is missing application/configuration/system";
+		return false;
+	}
+	return true;
+}
+
+bool parse_media(const tinyxml2::XMLElement* media_element, Manifest& manifest, std::string& error)
+{
+	if (!media_element)
+		return true;
+
+	for (auto element = media_element->FirstChildElement(); element; element = element->NextSiblingElement()) {
+		const auto name = local_name(element->Name());
+		Media media;
+		if (name == "floppy")
+			media.type = MediaType::Floppy;
+		else if (name == "harddrive")
+			media.type = MediaType::HardDrive;
+		else if (name == "cd")
+			media.type = MediaType::Cd;
+		else if (name == "tape")
+			media.type = MediaType::Tape;
+		else if (name == "snapshot")
+			media.type = MediaType::Snapshot;
+		else {
+			manifest.warnings.emplace_back("Unsupported RP9 media element: " + std::string(name));
+			continue;
+		}
+
+		media.root = lowercase(attribute(element, "root"));
+		media.path = trim(text(element));
+		if (media.path.empty() && media.root != "shared") {
+			error = "RP9 media entry has an empty path";
+			return false;
+		}
+		media.format = lowercase(attribute(element, "type"));
+		media.volume_name = attribute(element, "volumename");
+		const auto priority = attribute(element, "priority");
+		if (!priority.empty()) {
+			if (!parse_unsigned(priority, media.priority)) {
+				error = "Invalid RP9 media priority: " + priority;
+				return false;
+			}
+			media.has_priority = true;
+		}
+		if (!parse_optional_bool(element, "readonly", media.readonly, error))
+			return false;
+		const auto undo = attribute(element, "undo");
+		if (!undo.empty()) {
+			if (!parse_bool(undo, media.undo)) {
+				error = "Invalid RP9 media undo value: " + undo;
+				return false;
+			}
+			media.has_undo = true;
+		}
+		if (!parse_optional_bool(element, "deploy", media.deploy, error))
+			return false;
+		manifest.media.emplace_back(std::move(media));
+	}
+	return true;
+}
+}
+
+bool parse_version(const std::string& value, Version& version)
+{
+	std::array<unsigned int, 4> parts {};
+	std::size_t start = 0;
+	for (std::size_t index = 0; index < parts.size(); ++index) {
+		const auto end = value.find('.', start);
+		const auto part = value.substr(start, end == std::string::npos ? std::string::npos : end - start);
+		if (!parse_unsigned(part, parts[index]))
+			return false;
+		if (index + 1 < parts.size()) {
+			if (end == std::string::npos)
+				return false;
+			start = end + 1;
+		} else if (end != std::string::npos) {
+			return false;
+		}
+	}
+	version = { parts[0], parts[1], parts[2], parts[3] };
+	return true;
+}
+
+bool is_supported_version(const Version& version)
+{
+	return !version_greater(version, supported_player_version);
+}
+
+bool normalize_package_path(const std::string& original, std::string& normalized)
+{
+	normalized.clear();
+	if (original.empty() || original.size() > 4096)
+		return false;
+	std::string portable = original;
+	std::replace(portable.begin(), portable.end(), '\\', '/');
+	if (portable.front() == '/')
+		return false;
+	if (portable.size() >= 2 && std::isalpha(static_cast<unsigned char>(portable[0])) && portable[1] == ':')
+		return false;
+	std::size_t component_start = 0;
+	for (;;) {
+		const auto separator = portable.find('/', component_start);
+		const auto component = std::string_view(portable).substr(component_start,
+			separator == std::string::npos ? std::string::npos : separator - component_start);
+		if (!is_portable_package_component(component))
+			return false;
+		if (separator == std::string::npos)
+			break;
+		component_start = separator + 1;
+	}
+
+	std::filesystem::path path(portable);
+	path = path.lexically_normal();
+	if (path.empty() || path.is_absolute() || path.has_root_name() || path.has_root_directory())
+		return false;
+	for (const auto& part : path) {
+		if (part == "..")
+			return false;
+	}
+	normalized = path.generic_string();
+	return normalized != "." && !normalized.empty();
+}
+
+bool parse_manifest(const char* xml, const std::size_t size, Manifest& manifest, std::string& error)
+{
+	manifest = {};
+	error.clear();
+	if (!xml || size == 0) {
+		error = "RP9 manifest is empty";
+		return false;
+	}
+	if (size > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+		error = "RP9 manifest is too large";
+		return false;
+	}
+
+	tinyxml2::XMLDocument document;
+	const auto result = document.Parse(xml, size);
+	if (result != tinyxml2::XML_SUCCESS) {
+		error = "Invalid RP9 manifest XML";
+		if (document.ErrorStr())
+			error += std::string(": ") + document.ErrorStr();
+		return false;
+	}
+
+	const auto root = document.RootElement();
+	if (!has_name(root, "rp9")) {
+		error = "RP9 manifest root element must be 'rp9'";
+		return false;
+	}
+
+	const auto requirements = child(root, "requirements");
+	manifest.host = text(child(requirements, "host"));
+	const auto version_text = text(child(requirements, "playerversion"));
+	if (manifest.host.empty() || version_text.empty()) {
+		error = "RP9 manifest is missing requirements/host or requirements/playerversion";
+		return false;
+	}
+	if (!parse_version(version_text, manifest.player_version)) {
+		error = "Invalid RP9 player version: " + version_text;
+		return false;
+	}
+	if (!is_supported_version(manifest.player_version)) {
+		error = "RP9 requires a newer player version than Amiberry supports: " + version_text;
+		return false;
+	}
+
+	const auto application = child(root, "application");
+	if (!application) {
+		error = "RP9 manifest is missing application";
+		return false;
+	}
+	const auto description = child(application, "description");
+	manifest.title = text(child(description, "title"));
+
+	const auto configuration = child(application, "configuration");
+	if (!configuration) {
+		error = "RP9 manifest is missing application/configuration";
+		return false;
+	}
+	if (!parse_configuration(configuration, manifest, error))
+		return false;
+	return parse_media(child(application, "media"), manifest, error);
+}
+}

--- a/src/osdep/rp9_manifest.cpp
+++ b/src/osdep/rp9_manifest.cpp
@@ -161,7 +161,8 @@ bool parse_configuration(const tinyxml2::XMLElement* configuration, Manifest& ma
 		} else if (name == "video") {
 			manifest.video = lowercase(text(element));
 		} else if (name == "rom") {
-			manifest.system_rom = text(element);
+			if (lowercase(attribute(element, "type")) == "system")
+				manifest.system_rom = text(element);
 		} else if (name == "ram") {
 			Ram ram;
 			ram.type = lowercase(attribute(element, "type"));

--- a/src/osdep/rp9_manifest.h
+++ b/src/osdep/rp9_manifest.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace rp9
+{
+struct Version
+{
+	unsigned int major = 0;
+	unsigned int minor = 0;
+	unsigned int patch = 0;
+	unsigned int build = 0;
+};
+
+enum class MediaType
+{
+	Floppy,
+	HardDrive,
+	Cd,
+	Tape,
+	Snapshot
+};
+
+struct Ram
+{
+	std::string type;
+	std::uint64_t size = 0;
+};
+
+struct Peripheral
+{
+	std::string name;
+	std::string type;
+	std::string speed;
+	std::string layout;
+	std::string path;
+	std::string device;
+	std::string device_name;
+	std::string volume_name;
+	int unit = -1;
+	std::uint64_t memory = 0;
+	bool has_memory = false;
+	bool fpu = false;
+	bool has_fpu = false;
+};
+
+struct Boot
+{
+	std::string type;
+	std::string value;
+	bool readonly = false;
+};
+
+struct Clip
+{
+	unsigned int left = 0;
+	unsigned int top = 0;
+	unsigned int width = 0;
+	unsigned int height = 0;
+};
+
+struct Media
+{
+	MediaType type = MediaType::Floppy;
+	std::string path;
+	std::string root;
+	std::string format;
+	std::string volume_name;
+	unsigned int priority = 0;
+	bool has_priority = false;
+	bool readonly = false;
+	bool undo = false;
+	bool has_undo = false;
+	bool deploy = false;
+};
+
+struct Manifest
+{
+	std::string host;
+	Version player_version;
+	std::string title;
+	std::string system;
+	std::string system_rom;
+	std::string video;
+	std::vector<Ram> ram;
+	std::vector<Peripheral> peripherals;
+	std::vector<std::string> compatibility;
+	std::vector<Media> media;
+	Boot boot;
+	bool has_boot = false;
+	Clip clip;
+	bool has_clip = false;
+	std::vector<std::string> warnings;
+};
+
+bool parse_version(const std::string& text, Version& version);
+bool is_supported_version(const Version& version);
+bool normalize_package_path(const std::string& original, std::string& normalized);
+bool parse_manifest(const char* xml, std::size_t size, Manifest& manifest, std::string& error);
+}

--- a/tests/libretro_crop_policy_test.cpp
+++ b/tests/libretro_crop_policy_test.cpp
@@ -110,12 +110,30 @@ static void test_libretro_stabilizer_uses_short_mode_change_delays()
 		"Shrinking crops should not wait a full second");
 }
 
+static void test_rp9_manifest_clip_owns_automatic_crop()
+{
+	expect_true(!libretro_should_queue_auto_crop_options(true, true),
+		"RP9 automatic crop options must wait until after the manifest is parsed");
+	expect_true(libretro_should_queue_auto_crop_options(true, false),
+		"Non-RP9 content must keep automatic crop startup options");
+	expect_true(!libretro_should_queue_auto_crop_options(false, true),
+		"Disabled or fixed crop modes must not queue automatic crop options");
+
+	expect_true(libretro_should_preserve_rp9_clip(true, true),
+		"Automatic crop must preserve an RP9 manifest clip");
+	expect_true(!libretro_should_preserve_rp9_clip(true, false),
+		"RP9 packages without a clip must use normal automatic crop");
+	expect_true(!libretro_should_preserve_rp9_clip(false, true),
+		"Explicit disabled or fixed crop modes must override an RP9 clip");
+}
+
 int main()
 {
 	test_expands_to_visible_pixels_below_crop();
 	test_ignores_isolated_outside_pixels();
 	test_fixed_crop_shifts_to_keep_content_visible();
 	test_libretro_stabilizer_uses_short_mode_change_delays();
+	test_rp9_manifest_clip_owns_automatic_crop();
 
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/play_content_detection_test.cpp
+++ b/tests/play_content_detection_test.cpp
@@ -35,6 +35,16 @@ static void test_configurations_keep_existing_model()
 		".uae must keep the existing model");
 }
 
+static void test_rp9_uses_manifest_machine()
+{
+	const auto detection = play_detect_content("Game.RP9", false);
+
+	expect_eq(detection.type, PlayContentType::Rp9, ".RP9 must be detected as an RP9 package");
+	expect_eq(detection.suggested_model, PlaySuggestedModel::KeepExisting,
+		"RP9 must use the machine described by its manifest");
+	expect_eq(detection.follow_up, PlayFollowUp::None, "RP9 must not ask for an archive type");
+}
+
 static void test_floppy_extensions_suggest_a500()
 {
 	const auto adf = play_detect_content("Disk.ADF", false);
@@ -173,6 +183,7 @@ static void test_directories_are_whdload_candidates()
 int main()
 {
 	test_configurations_keep_existing_model();
+	test_rp9_uses_manifest_machine();
 	test_floppy_extensions_suggest_a500();
 	test_compressed_floppy_extensions_suggest_a500();
 	test_aga_floppy_names_suggest_a1200();

--- a/tests/rp9_manifest_test.cpp
+++ b/tests/rp9_manifest_test.cpp
@@ -99,6 +99,19 @@ void test_real_world_22_manifest_shape()
 	expect(manifest.compatibility.size() == 2, "real-world compatibility hints must be preserved");
 }
 
+void test_only_system_rom_is_selected()
+{
+	constexpr auto xml = R"xml(<rp9><requirements><host>RetroPlatform</host><playerversion>3.0.0.0</playerversion></requirements>
+  <application><configuration><system>cd32</system>
+    <rom type="system">310-cd32</rom><rom type="extended">CD32 Extended ROM</rom><rom>untyped</rom>
+  </configuration></application></rp9>)xml";
+	rp9::Manifest manifest;
+	std::string error;
+	expect(parse(xml, manifest, error), "multiple typed ROM entries must be accepted");
+	expect(manifest.system_rom == "310-cd32",
+		"only type=system ROM entries may select the required Kickstart");
+}
+
 void test_real_world_30_harddrive_attributes()
 {
 	constexpr auto xml = R"xml(<rp9 xmlns="http://www.retroplatform.com">
@@ -226,6 +239,7 @@ int main(const int argc, char** argv)
 	test_current_namespaced_manifest();
 	test_prefixed_namespace();
 	test_real_world_22_manifest_shape();
+	test_only_system_rom_is_selected();
 	test_real_world_30_harddrive_attributes();
 	test_empty_shared_root_media();
 	test_medialess_package();

--- a/tests/rp9_manifest_test.cpp
+++ b/tests/rp9_manifest_test.cpp
@@ -1,0 +1,237 @@
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+
+#include "rp9_manifest.h"
+
+namespace
+{
+int failures;
+
+void expect(const bool condition, const char* message)
+{
+	if (!condition) {
+		std::cerr << message << '\n';
+		++failures;
+	}
+}
+
+bool parse(const char* xml, rp9::Manifest& manifest, std::string& error)
+{
+	return rp9::parse_manifest(xml, std::strlen(xml), manifest, error);
+}
+
+void test_current_namespaced_manifest()
+{
+	constexpr auto xml = R"xml(<?xml version="1.0"?>
+<rp9 xmlns="http://www.retroplatform.com">
+  <requirements><host>AmigaForever</host><playerversion>10.0.3.0</playerversion></requirements>
+  <application>
+    <description><title>Standards Test</title><systemrom>3.1</systemrom></description>
+    <configuration>
+      <system>a-1200</system><video>PAL</video>
+      <ram type="chip">2097152</ram>
+      <peripheral unit="1">input-joystick</peripheral>
+      <compatibility>turbo-floppy</compatibility>
+      <clip left="112" top="0" width="1280" height="512"/>
+    </configuration>
+    <media>
+      <floppy root="embedded" readonly="true">Disks/Disk 1.adf</floppy>
+      <floppy root="embedded">Disks/Disk 2.adf</floppy>
+      <cd root="deploy">CD/game.cue</cd>
+    </media>
+  </application>
+</rp9>)xml";
+
+	rp9::Manifest manifest;
+	std::string error;
+	expect(parse(xml, manifest, error), error.c_str());
+	expect(manifest.host == "AmigaForever", "host must be preserved");
+	expect(manifest.system == "a-1200", "system must be normalized");
+	expect(manifest.system_rom.empty(), "description/systemrom must not override playback configuration");
+	expect(manifest.ram.size() == 1 && manifest.ram[0].size == 2097152, "RAM size must be parsed exactly");
+	expect(manifest.peripherals.size() == 1 && manifest.peripherals[0].unit == 1,
+		"peripheral unit must be parsed");
+	expect(manifest.has_clip && manifest.clip.width == 1280, "clip must be parsed");
+	expect(manifest.media.size() == 3, "all media entries must be preserved");
+	expect(manifest.media[0].path == "Disks/Disk 1.adf" && manifest.media[1].path == "Disks/Disk 2.adf",
+		"floppy manifest order must be preserved");
+	expect(manifest.media[0].readonly, "media readonly attribute must be parsed");
+}
+
+void test_prefixed_namespace()
+{
+	constexpr auto xml = R"xml(<rp:rp9 xmlns:rp="http://www.retroplatform.com">
+  <rp:requirements><rp:host>RetroPlatform</rp:host><rp:playerversion>2.2.0.0</rp:playerversion></rp:requirements>
+  <rp:application><rp:description><rp:title>Prefix</rp:title></rp:description>
+    <rp:configuration><rp:system>a-500</rp:system></rp:configuration><rp:media/>
+  </rp:application>
+</rp:rp9>)xml";
+	rp9::Manifest manifest;
+	std::string error;
+	expect(parse(xml, manifest, error), "prefixed RP9 namespaces must be accepted");
+	expect(manifest.system == "a-500", "prefixed system element must be parsed");
+}
+
+void test_real_world_22_manifest_shape()
+{
+	const char* xml = "\xEF\xBB\xBF" R"xml(<?xml version="1.0" encoding="utf-8"?>
+<rp9 xmlns="http://www.retroplatform.com">
+  <requirements><host>Cloanto RetroPlatform Player</host><playerversion>2.2.0.0</playerversion></requirements>
+  <application user-edited="true">
+    <description><title>Real-world Sample</title><systemrom>130</systemrom></description>
+    <configuration>
+      <system>a-500</system><rom type="system">130</rom><ram type="fast">1048576</ram>
+      <compatibility>flexible-blitter-cycles</compatibility><compatibility>turbo-cpu</compatibility>
+      <video>ntsc</video><peripheral speed="max">cpu</peripheral>
+    </configuration>
+    <media><floppy>Sample.adf</floppy></media>
+  </application>
+</rp9>)xml";
+	rp9::Manifest manifest;
+	std::string error;
+	expect(parse(xml, manifest, error), "UTF-8 BOM and real-world 2.2 manifests must be accepted");
+	expect(manifest.system_rom == "130", "configuration ROM must override the description value");
+	expect(manifest.peripherals.size() == 1 && manifest.peripherals[0].type.empty()
+		&& manifest.peripherals[0].speed == "max", "speed-only CPU peripherals must be preserved");
+	expect(manifest.compatibility.size() == 2, "real-world compatibility hints must be preserved");
+}
+
+void test_real_world_30_harddrive_attributes()
+{
+	constexpr auto xml = R"xml(<rp9 xmlns="http://www.retroplatform.com">
+  <requirements><host>RetroPlatform</host><playerversion>3.0.0.0</playerversion></requirements>
+  <application><description><title>Hard Drives</title></description><configuration>
+    <system>a-4000</system><peripheral layout="en-gb">keyboard</peripheral>
+    <compatibility>mouseintegration</compatibility><compatibility>hostio</compatibility>
+  </configuration><media>
+    <harddrive priority="1" type="file" undo="false" deploy="true">disk-1.hdf</harddrive>
+    <harddrive priority="2" type="file" undo="true" readonly="true">disk-2.hdf</harddrive>
+  </media></application>
+</rp9>)xml";
+	rp9::Manifest manifest;
+	std::string error;
+	expect(parse(xml, manifest, error), "real-world RP9 3.0 hard-drive attributes must be accepted");
+	expect(manifest.peripherals.size() == 1 && manifest.peripherals[0].layout == "en-gb",
+		"keyboard layout must be preserved");
+	expect(manifest.media.size() == 2, "hard-drive media must be preserved");
+	expect(manifest.media[0].has_priority && manifest.media[0].priority == 1
+		&& manifest.media[0].format == "file", "hard-drive priority and type must be parsed");
+	expect(manifest.media[0].has_undo && !manifest.media[0].undo && manifest.media[0].deploy,
+		"hard-drive undo and deploy attributes must be parsed");
+	expect(manifest.media[1].undo && manifest.media[1].readonly,
+		"true hard-drive boolean attributes must be parsed");
+}
+
+void test_empty_shared_root_media()
+{
+	constexpr auto xml = R"xml(<rp9><requirements><host>RetroPlatform</host><playerversion>10.0.3.0</playerversion></requirements>
+  <application><configuration><system>a-4000</system></configuration><media>
+    <harddrive root="shared" volumename="Shared" priority="1"/>
+  </media></application></rp9>)xml";
+	rp9::Manifest manifest;
+	std::string error;
+	expect(parse(xml, manifest, error), "an empty shared-root mount must be accepted");
+	expect(manifest.media.size() == 1 && manifest.media[0].path.empty()
+		&& manifest.media[0].root == "shared", "empty shared-root media must be preserved");
+}
+
+void test_medialess_package()
+{
+	constexpr auto xml = R"xml(<rp9><requirements><host>RetroPlatform</host><playerversion>2.2.0.0</playerversion></requirements>
+  <application><description><title>Medialess</title></description>
+    <configuration><system>a-500</system></configuration>
+  </application></rp9>)xml";
+	rp9::Manifest manifest;
+	std::string error;
+	expect(parse(xml, manifest, error), "medialess RP9 packages must be accepted");
+	expect(manifest.media.empty(), "medialess RP9 must not synthesize media");
+}
+
+void test_future_version_is_blocked()
+{
+	constexpr auto xml = R"xml(<rp9><requirements><host>RetroPlatform</host><playerversion>10.0.4.0</playerversion></requirements>
+  <application><configuration><system>a-500</system></configuration></application></rp9>)xml";
+	rp9::Manifest manifest;
+	std::string error;
+	expect(!parse(xml, manifest, error), "future RP9 player requirements must be rejected");
+	expect(error.find("newer player version") != std::string::npos, "future-version error must be actionable");
+}
+
+void test_missing_requirements_are_blocked()
+{
+	constexpr auto xml = R"xml(<rp9><application><configuration><system>a-500</system></configuration></application></rp9>)xml";
+	rp9::Manifest manifest;
+	std::string error;
+	expect(!parse(xml, manifest, error), "missing RP9 host/player requirements must be rejected");
+}
+
+void test_invalid_numbers_are_blocked()
+{
+	constexpr auto invalid_ram = R"xml(<rp9><requirements><host>RetroPlatform</host><playerversion>2.2.0.0</playerversion></requirements>
+  <application><configuration><system>a-500</system><ram type="chip">2MB</ram></configuration></application></rp9>)xml";
+	constexpr auto invalid_clip = R"xml(<rp9><requirements><host>RetroPlatform</host><playerversion>2.2.0.0</playerversion></requirements>
+  <application><configuration><system>a-500</system><clip left="112" top="0" width="0" height="512"/></configuration></application></rp9>)xml";
+	rp9::Manifest manifest;
+	std::string error;
+	expect(!parse(invalid_ram, manifest, error), "non-numeric RP9 RAM must be rejected");
+	expect(!parse(invalid_clip, manifest, error), "zero-sized RP9 clips must be rejected");
+}
+
+void test_package_paths_are_normalized_safely()
+{
+	std::string normalized;
+	expect(rp9::normalize_package_path("Disks\\Disk 1.adf", normalized)
+		&& normalized == "Disks/Disk 1.adf", "package paths must normalize separators");
+	expect(rp9::normalize_package_path("Disks/./Disk 2.adf", normalized)
+		&& normalized == "Disks/Disk 2.adf", "package paths must normalize dot components");
+	expect(!rp9::normalize_package_path("../escape.adf", normalized), "parent traversal must be rejected");
+	expect(!rp9::normalize_package_path("Disks/../../escape.adf", normalized), "nested traversal must be rejected");
+	expect(!rp9::normalize_package_path("Disks/../escape.adf", normalized),
+		"parent components must be rejected even when normalization would stay inside the package");
+	expect(!rp9::normalize_package_path("/absolute.adf", normalized), "absolute POSIX paths must be rejected");
+	expect(!rp9::normalize_package_path("C:\\absolute.adf", normalized), "absolute Windows paths must be rejected");
+	expect(!rp9::normalize_package_path("Disks/data:stream.adf", normalized),
+		"Windows alternate-data-stream paths must be rejected");
+	expect(!rp9::normalize_package_path("Disks/NUL.adf", normalized),
+		"Windows device names must be rejected on every host");
+	expect(!rp9::normalize_package_path("Disks/trailing. ", normalized),
+		"non-portable trailing dots and spaces must be rejected");
+}
+}
+
+int main(const int argc, char** argv)
+{
+	if (argc > 1) {
+		for (int index = 1; index < argc; ++index) {
+			std::ifstream file;
+			std::istream* input = &std::cin;
+			if (std::strcmp(argv[index], "-") != 0) {
+				file.open(argv[index], std::ios::binary);
+				input = &file;
+			}
+			const std::string xml((std::istreambuf_iterator<char>(*input)), std::istreambuf_iterator<char>());
+			rp9::Manifest manifest;
+			std::string error;
+			if (!*input || !rp9::parse_manifest(xml.data(), xml.size(), manifest, error)) {
+				std::cerr << argv[index] << ": " << (*input ? error : "could not read manifest") << '\n';
+				++failures;
+			}
+		}
+		return failures == 0 ? 0 : 1;
+	}
+
+	test_current_namespaced_manifest();
+	test_prefixed_namespace();
+	test_real_world_22_manifest_shape();
+	test_real_world_30_harddrive_attributes();
+	test_empty_shared_root_media();
+	test_medialess_package();
+	test_future_version_is_blocked();
+	test_missing_requirements_are_blocked();
+	test_invalid_numbers_are_blocked();
+	test_package_paths_are_normalized_safely();
+	return failures == 0 ? 0 : 1;
+}

--- a/tests/test_libretro_content_staging_cleanup.sh
+++ b/tests/test_libretro_content_staging_cleanup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="libretro/libretro.cpp"
+
+if grep -F -q 'filestream_delete(directory.c_str());' "$source_file"; then
+	echo "Libretro staging directories must not use the frontend file-removal callback" >&2
+	exit 1
+fi
+
+if ! awk '
+	/static int remove_empty_content_directory\(/ { in_remove = 1 }
+	in_remove && /_rmdir\(directory\.c_str\(\)\)/ { windows = 1 }
+	in_remove && /::rmdir\(directory\.c_str\(\)\)/ { posix = 1 }
+	in_remove && /retro_vfs_file_remove_impl\(directory\.c_str\(\)\)/ { fallback = 1 }
+	in_remove && /^}/ { exit }
+	END { exit windows && posix && fallback ? 0 : 1 }
+' "$source_file"; then
+	echo "Libretro staging cleanup must remove empty directories on Windows, POSIX, and virtual paths" >&2
+	exit 1
+fi
+
+if ! grep -F -q 'remove_empty_content_directory(directory);' "$source_file"; then
+	echo "Libretro staging cleanup must use the directory-specific removal helper" >&2
+	exit 1
+fi

--- a/tests/test_libretro_rp9_disk_control.sh
+++ b/tests/test_libretro_rp9_disk_control.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rp9_source="src/osdep/amiberry_rp9.cpp"
+rp9_header="src/osdep/amiberry_rp9.h"
+libretro_source="libretro/libretro.cpp"
+
+for getter in rp9_get_loaded_floppy_paths rp9_get_loaded_cd_paths
+do
+	if ! grep -F -q "const std::vector<std::string>& $getter()" "$rp9_header" ||
+		! grep -F -q "const std::vector<std::string>& $getter()" "$rp9_source"; then
+		echo "RP9 must publish resolved removable-media paths for libretro disk control" >&2
+		exit 1
+	fi
+done
+
+if ! grep -F -q 'floppy_paths.emplace_back(path_string);' "$rp9_source" ||
+	! grep -F -q 'loaded_floppy_paths = floppy_paths;' "$rp9_source"; then
+	echo "RP9 must retain every resolved manifest floppy in priority order" >&2
+	exit 1
+fi
+
+if ! awk '
+	/static void sync_rp9_disk_control_media\(\)/ { in_sync = 1 }
+	in_sync && /rp9_get_loaded_floppy_paths\(\)/ { floppies = 1 }
+	in_sync && /rp9_get_loaded_cd_paths\(\)/ { cds = 1 }
+	in_sync && /disk_images\.push_back/ { publishes = 1 }
+	in_sync && /content_is_cd = use_cd_paths/ { media_type = 1 }
+	in_sync && /^}/ { exit }
+	END { exit floppies && cds && publishes && media_type ? 0 : 1 }
+' "$libretro_source"; then
+	echo "Libretro must replace RP9 package entries with resolved floppy or CD media" >&2
+	exit 1
+fi
+
+if ! awk '
+	/if \(!package_path\.empty\(\)\)/ { in_package = 1 }
+	in_package && /if \(!is_rp9\)/ { excludes_rp9 = 1 }
+	in_package && excludes_rp9 && /disk_images\.push_back\(image\)/ { guarded_publish = 1 }
+	in_package && /return true;/ { exit }
+	END { exit excludes_rp9 && guarded_publish ? 0 : 1 }
+' "$libretro_source"; then
+	echo "Libretro must not expose the RP9 archive as an insertable disk image" >&2
+	exit 1
+fi
+
+if ! awk '
+	/void retro_run\(void\)/ { in_run = 1 }
+	in_run && /co_switch\(core_fiber\)/ { started = 1 }
+	in_run && started && /sync_rp9_disk_control_media\(\)/ { synced = 1 }
+	in_run && /core_started = true/ { exit }
+	END { exit started && synced ? 0 : 1 }
+' "$libretro_source"; then
+	echo "Libretro must publish RP9 media after manifest parsing completes" >&2
+	exit 1
+fi

--- a/tests/test_libretro_rp9_disk_control.sh
+++ b/tests/test_libretro_rp9_disk_control.sh
@@ -21,6 +21,17 @@ if ! grep -F -q 'floppy_paths.emplace_back(path_string);' "$rp9_source" ||
 fi
 
 if ! awk '
+	/bool apply_media\(/ { in_media = 1 }
+	in_media && /apply_boot\(prefs, manifest, device_number\)/ { boot_applied = 1 }
+	in_media && boot_applied && /floppy_paths\.emplace_back\(prefs->floppyslots\[0\]\.df\)/ { boot_published = 1 }
+	in_media && /std::vector<const rp9::Media\*> ordered_media/ { exit }
+	END { exit boot_applied && boot_published ? 0 : 1 }
+' "$rp9_source"; then
+	echo "RP9 must publish an attached boot ADF before manifest floppies" >&2
+	exit 1
+fi
+
+if ! awk '
 	/static void sync_rp9_disk_control_media\(\)/ { in_sync = 1 }
 	in_sync && /rp9_get_loaded_floppy_paths\(\)/ { floppies = 1 }
 	in_sync && /rp9_get_loaded_cd_paths\(\)/ { cds = 1 }

--- a/tests/test_play_use_content_logic.sh
+++ b/tests/test_play_use_content_logic.sh
@@ -68,6 +68,27 @@ if ! grep -F -q 'selected_content_still_attached()' "$source_file"; then
 	exit 1
 fi
 
+if ! awk '
+	/void mark_content_applied\(\)/ { in_mark = 1 }
+	in_mark && /applied_content_type != PlayContentType::Rp9/ { guarded = 1 }
+	in_mark && guarded && /rp9_clear_loaded_path\(\);/ { found = 1; exit }
+	in_mark && /^}/ { exit }
+	END { exit found ? 0 : 1 }
+' "$source_file"; then
+	echo "Successful non-RP9 Play applies must clear stale RP9 reload state" >&2
+	exit 1
+fi
+
+if awk '
+	/bool apply_selected_content\(/ { in_apply = 1 }
+	in_apply && /rp9_clear_loaded_path\(\);/ { found = 1 }
+	in_apply && /^}/ { exit }
+	END { exit found ? 0 : 1 }
+' "$source_file"; then
+	echo "Play must not clear RP9 reload state before replacement content applies successfully" >&2
+	exit 1
+fi
+
 if grep -F -q 'play_mark_selected_content_pending();' "$quickstart_source_file"; then
 	echo "Quickstart defaults must not globally mark Play content pending" >&2
 	exit 1

--- a/tests/test_rp9_cd_swap_retention.sh
+++ b/tests/test_rp9_cd_swap_retention.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="src/osdep/amiberry_rp9.cpp"
+
+assignment_line=$(grep -n -F 'loaded_cd_paths = cd_paths;' "$source_file" | head -1 | cut -d: -f1)
+cleanup_line=$(grep -n -F 'cleanup_unused_temporary_directories(prefs);' "$source_file" | tail -1 | cut -d: -f1)
+if [ -z "$assignment_line" ] || [ -z "$cleanup_line" ] || [ "$assignment_line" -ge "$cleanup_line" ]; then
+	echo "RP9 CD swap paths must be retained before temporary-directory cleanup" >&2
+	exit 1
+fi
+
+if ! grep -F -q 'loaded_cd_paths_reference_directory(*directory)' "$source_file"; then
+	echo "RP9 temporary-directory cleanup must retain swap-only CD paths" >&2
+	exit 1
+fi
+
+if ! awk '
+	/void rp9_clear_loaded_path\(/ { in_clear = 1 }
+	in_clear && /loaded_cd_paths\.clear\(\);/ { cleared = 1; exit }
+	in_clear && /^}/ { exit }
+	END { exit cleared ? 0 : 1 }
+' "$source_file"; then
+	echo "RP9 CD swap retention must end when the loaded package is cleared" >&2
+	exit 1
+fi

--- a/tests/test_rp9_directory_media.sh
+++ b/tests/test_rp9_directory_media.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="src/osdep/amiberry_rp9.cpp"
+
+if ! grep -F -q 'register_extracted_directories(files, directory, std::filesystem::path(normalized))' "$source_file"; then
+	echo "RP9 extraction must register explicit embedded directory entries" >&2
+	exit 1
+fi
+
+if ! grep -F -q 'std::filesystem::path(normalized).parent_path()))' "$source_file"; then
+	echo "RP9 extraction must register directories synthesized for nested files" >&2
+	exit 1
+fi
+
+if ! grep -F -q 'register_extracted_path(files, normalized, destination)' "$source_file"; then
+	echo "RP9 extraction must reject portable file/directory path collisions" >&2
+	exit 1
+fi

--- a/tests/test_rp9_external_media.sh
+++ b/tests/test_rp9_external_media.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="src/osdep/amiberry_rp9.cpp"
+
+if grep -F -q 'RP9 media uses a disallowed external host path' "$source_file"; then
+	echo "RP9 Absolute/External media roots must not be rejected unconditionally" >&2
+	exit 1
+fi
+
+if ! awk '
+	/std::filesystem::path resolve_media_path\(/ { in_resolve = 1 }
+	in_resolve && /root == "absolute" \|\| root == "external"/ { in_external = 1 }
+	in_external && /std::filesystem::path path\(media\.path\)/ { path = 1 }
+	in_external && /!path\.is_absolute\(\)/ { absolute = 1 }
+	in_external && /std::filesystem::status\(path, error\)/ { status = 1 }
+	in_external && /std::filesystem::is_regular_file\(status\)/ { regular = 1 }
+	in_external && /std::filesystem::is_directory\(status\)/ { directory = 1 }
+	in_external && /return resolved;/ { returned = 1; exit }
+	in_resolve && /^}/ { exit }
+	END { exit path && absolute && status && regular && directory && returned ? 0 : 1 }
+' "$source_file"; then
+	echo "RP9 external media must resolve existing absolute regular files and directories" >&2
+	exit 1
+fi

--- a/tests/test_rp9_file_associations.sh
+++ b/tests/test_rp9_file_associations.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_text() {
+	local file="$1"
+	local text="$2"
+	if ! grep -Fq "$text" "$file"; then
+		printf 'Missing RP9 association in %s: %s\n' "$file" "$text" >&2
+		exit 1
+	fi
+}
+
+mime_type="application/vnd.cloanto.rp9"
+
+require_text packaging/linux/mime/amiberry.xml "<mime-type type=\"$mime_type\">"
+require_text packaging/linux/mime/amiberry.xml '<glob pattern="*.rp9"'
+require_text packaging/linux/Amiberry.desktop "$mime_type;"
+require_text packaging/linux/Amiberry.metainfo.xml "<mediatype>$mime_type</mediatype>"
+
+for plist in packaging/MacOSXBundleInfo.plist.in packaging/ios/iOSBundleInfo.plist.in; do
+	require_text "$plist" '<string>rp9</string>'
+	require_text "$plist" "<string>$mime_type</string>"
+done
+
+require_text packaging/windows/fileassoc.iss 'Name: "fileassoc\rp9"'
+require_text packaging/windows/fileassoc.iss 'ValueName: "Amiberry.rp9"'
+require_text packaging/windows/fileassoc.iss "ValueData: \"$mime_type\""
+
+require_text android/app/src/main/AndroidManifest.xml 'android:pathPattern=".*\\.rp9"'
+require_text android/app/src/main/AndroidManifest.xml "android:mimeType=\"$mime_type\""
+
+if command -v xmllint >/dev/null 2>&1; then
+	xmllint --noout packaging/linux/mime/amiberry.xml
+	xmllint --noout packaging/linux/Amiberry.metainfo.xml
+	xmllint --noout android/app/src/main/AndroidManifest.xml
+fi
+
+if command -v plutil >/dev/null 2>&1; then
+	plutil -lint packaging/MacOSXBundleInfo.plist.in >/dev/null
+	plutil -lint packaging/ios/iOSBundleInfo.plist.in >/dev/null
+fi

--- a/tests/test_rp9_manifest.sh
+++ b/tests/test_rp9_manifest.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cxx="${CXX:-c++}"
+out="${TMPDIR:-/tmp}/rp9_manifest_test.$$"
+trap 'rm -f "$out"' EXIT
+
+"$cxx" -std=c++17 -Wall -Wextra -Werror \
+	-Isrc/include -Isrc/osdep \
+	-o "$out" \
+	tests/rp9_manifest_test.cpp \
+	src/osdep/rp9_manifest.cpp \
+	src/tinyxml2.cpp
+"$out" "$@"

--- a/tests/test_rp9_quickstart_transition.sh
+++ b/tests/test_rp9_quickstart_transition.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="src/osdep/imgui/quickstart.cpp"
+
+if ! awk '
+	/ConsumeFileDialogResultKey\("QUICKSTART"/ { in_result = 1 }
+	in_result && /!qs_pending_rp9 && !filePath\.empty\(\) && !rp9_get_loaded_path\(\)\.empty\(\)/ { guarded = 1 }
+	in_result && guarded && /reset_rp9_to_quickstart_defaults\(\);/ { reset = 1 }
+	in_result && /if \(qs_pending_floppy_drive/ { media = 1; exit }
+	END { exit guarded && reset && media ? 0 : 1 }
+' "$source_file"; then
+	echo "Quickstart must reset active RP9 preferences before applying non-RP9 media" >&2
+	exit 1
+fi
+
+if awk '
+	/ConsumeFileDialogResultKey\("QUICKSTART"/ { in_result = 1 }
+	in_result && /rp9_clear_loaded_path\(\);/ { found = 1; exit }
+	in_result && /qs_pending_floppy_drive = -1;/ { exit }
+	END { exit found ? 0 : 1 }
+' "$source_file"; then
+	echo "Quickstart must not clear RP9 state without resetting its preferences" >&2
+	exit 1
+fi

--- a/tests/test_rp9_ram_policy.sh
+++ b/tests/test_rp9_ram_policy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="src/osdep/amiberry_rp9.cpp"
+
+if ! awk '
+	/void apply_ram\(/ { in_apply = 1 }
+	in_apply && /ram.type == "z3"/ { in_z3 = 1 }
+	in_apply && in_z3 && /address_space_24 = false;/ { addressing = 1 }
+	in_apply && in_z3 && /z3fastmem\[0\]\.size/ { memory = 1; exit }
+	in_apply && /^}/ { exit }
+	END { exit addressing && memory ? 0 : 1 }
+' "$source_file"; then
+	echo "RP9 Z3 RAM must enable 32-bit addressing before assigning memory" >&2
+	exit 1
+fi

--- a/tests/test_rp9_ram_policy.sh
+++ b/tests/test_rp9_ram_policy.sh
@@ -14,3 +14,15 @@ if ! awk '
 	echo "RP9 Z3 RAM must enable 32-bit addressing before assigning memory" >&2
 	exit 1
 fi
+
+if ! awk '
+	/bool apply_peripherals\(/ { in_peripherals = 1 }
+	in_peripherals && /peripheral.name == "rtg" && peripheral.type == "picasso-iv"/ { in_picasso = 1 }
+	in_peripherals && in_picasso && /address_space_24 = false;/ { addressing = 1 }
+	in_peripherals && in_picasso && /rtgmem_type = GFXBOARD_ID_PICASSO4_Z3/ { board = 1; exit }
+	in_peripherals && /^}/ { exit }
+	END { exit addressing && board ? 0 : 1 }
+' "$source_file"; then
+	echo "RP9 Picasso IV must enable 32-bit addressing before selecting its Z3 board" >&2
+	exit 1
+fi

--- a/tests/test_rp9_recursive_rom_scan.sh
+++ b/tests/test_rp9_recursive_rom_scan.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="src/osdep/amiberry_rp9.cpp"
+
+if ! awk '
+	/int rp9_register_rom_directory\(/ { in_scan = 1 }
+	in_scan && /recursive_directory_iterator/ { recursive = 1 }
+	in_scan && /directory_options::skip_permission_denied/ { permissions = 1 }
+	in_scan && /disable_recursion_pending\(\)/ { hidden = 1 }
+	in_scan && /^}/ { exit }
+	END { exit recursive && permissions && hidden ? 0 : 1 }
+' "$source_file"; then
+	echo "RP9 ROM registration must recursively scan accessible, non-hidden subdirectories" >&2
+	exit 1
+fi
+
+if ! awk '
+	/int rp9_register_rom_directory\(/ { in_scan = 1 }
+	in_scan && /key_files\.push_back/ { collects_keys = 1 }
+	in_scan && /std::sort\(key_files\.begin\(\), key_files\.end\(\)\)/ { sorts_keys = 1 }
+	in_scan && /addkeyfile\(key_file\.string\(\)\.c_str\(\)\)/ { loads_keys = 1 }
+	in_scan && /std::sort\(candidates\.begin\(\), candidates\.end\(\)\)/ { sorts_roms = 1 }
+	in_scan && /^}/ { exit }
+	END { exit collects_keys && sorts_keys && loads_keys && sorts_roms ? 0 : 1 }
+' "$source_file"; then
+	echo "RP9 recursive ROM registration must load keys before deterministically scanning ROM candidates" >&2
+	exit 1
+fi

--- a/tests/test_rp9_rom_override_order.sh
+++ b/tests/test_rp9_rom_override_order.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 main_source="src/main.cpp"
+host_source="src/osdep/amiberry.cpp"
 libretro_source="libretro/libretro.cpp"
 rp9_source="src/osdep/amiberry_rp9.cpp"
 
@@ -30,6 +31,26 @@ prescan_line=$(grep -n -F 'register_cmdline_rp9_rom_sources(argc, argv);' "$main
 host_autoload_line=$(grep -n -F '_T("--autoload")' "$main_source" | head -1 | cut -d: -f1)
 if [ -z "$prescan_line" ] || [ -z "$host_autoload_line" ] || [ "$prescan_line" -ge "$host_autoload_line" ]; then
 	echo "All host ROM sources must be registered before RP9 autoload validation" >&2
+	exit 1
+fi
+
+if ! awk '
+	/static void register_rp9_rom_sources_from_prefs\(/ { in_register = 1 }
+	in_register && /prefs->path_rom\.path/ { directory = 1 }
+	in_register && /prefs->romfile, prefs->romextfile, prefs->romextfile2/ { overrides = 1 }
+	in_register && directory && /rp9_register_rom_directory\(path\)/ { registered_directory = 1 }
+	in_register && overrides && /rp9_register_rom_override\(path\)/ { registered_override = 1; exit }
+	in_register && /^}/ { exit }
+	END { exit registered_directory && registered_override ? 0 : 1 }
+' "$host_source"; then
+	echo "ROM sources from preceding configs must be registered for RP9 validation" >&2
+	exit 1
+fi
+
+config_sources_line=$(grep -n -F 'register_rp9_rom_sources_from_prefs(p);' "$host_source" | head -1 | cut -d: -f1)
+rp9_parse_line=$(grep -n -F 'result = rp9_parse_file(p, filename)' "$host_source" | head -1 | cut -d: -f1)
+if [ -z "$config_sources_line" ] || [ -z "$rp9_parse_line" ] || [ "$config_sources_line" -ge "$rp9_parse_line" ]; then
+	echo "Configured ROM sources must be registered before parsing the RP9 package" >&2
 	exit 1
 fi
 

--- a/tests/test_rp9_rom_override_order.sh
+++ b/tests/test_rp9_rom_override_order.sh
@@ -27,6 +27,13 @@ if ! grep -F -q 'rp9_register_rom_directory(path)' "$main_source"; then
 	exit 1
 fi
 
+if ! grep -F -q 'TARGET_NAME _T(".rom_path=")' "$main_source" ||
+	! grep -F -q '_tcsnicmp(argument, qualified_rom_path_prefix, qualified_rom_path_prefix_length)' "$main_source" ||
+	! grep -F -q 'path_argument = argument + qualified_rom_path_prefix_length;' "$main_source"; then
+	echo "Section-qualified command-line ROM paths must be registered for RP9 validation" >&2
+	exit 1
+fi
+
 prescan_line=$(grep -n -F 'register_cmdline_rp9_rom_sources(argc, argv);' "$main_source" | head -1 | cut -d: -f1)
 host_autoload_line=$(grep -n -F '_T("--autoload")' "$main_source" | head -1 | cut -d: -f1)
 if [ -z "$prescan_line" ] || [ -z "$host_autoload_line" ] || [ "$prescan_line" -ge "$host_autoload_line" ]; then

--- a/tests/test_rp9_rom_override_order.sh
+++ b/tests/test_rp9_rom_override_order.sh
@@ -5,8 +5,15 @@ main_source="src/main.cpp"
 libretro_source="libretro/libretro.cpp"
 rp9_source="src/osdep/amiberry_rp9.cpp"
 
-if ! grep -F -q 'rp9_register_rom_override(currprefs.romfile)' "$main_source"; then
-	echo "A command-line -r override must be registered for RP9 validation" >&2
+if ! grep -F -q 'rp9_register_rom_override(path)' "$main_source"; then
+	echo "Command-line -r overrides must be registered for RP9 validation" >&2
+	exit 1
+fi
+
+prescan_line=$(grep -n -F 'register_cmdline_rom_overrides(argc, argv);' "$main_source" | head -1 | cut -d: -f1)
+host_autoload_line=$(grep -n -F '_T("--autoload")' "$main_source" | head -1 | cut -d: -f1)
+if [ -z "$prescan_line" ] || [ -z "$host_autoload_line" ] || [ "$prescan_line" -ge "$host_autoload_line" ]; then
+	echo "All host -r overrides must be registered before RP9 autoload validation" >&2
 	exit 1
 fi
 

--- a/tests/test_rp9_rom_override_order.sh
+++ b/tests/test_rp9_rom_override_order.sh
@@ -10,6 +10,17 @@ if ! grep -F -q 'rp9_register_rom_override(path)' "$main_source"; then
 	exit 1
 fi
 
+if ! grep -F -q "argv[index][1] == 'r' || argv[index][1] == 'K'" "$main_source"; then
+	echo "Command-line -K overrides must be registered for RP9 validation" >&2
+	exit 1
+fi
+
+if ! grep -F -q '_T("kickstart_rom_file=")' "$main_source" ||
+	! grep -F -q '_T("kickstart_ext_rom_file=")' "$main_source"; then
+	echo "Command-line Kickstart configuration overrides must be registered for RP9 validation" >&2
+	exit 1
+fi
+
 if ! grep -F -q 'rp9_register_rom_directory(path)' "$main_source"; then
 	echo "Command-line ROM directories must be registered for RP9 validation" >&2
 	exit 1

--- a/tests/test_rp9_rom_override_order.sh
+++ b/tests/test_rp9_rom_override_order.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+main_source="src/main.cpp"
+libretro_source="libretro/libretro.cpp"
+rp9_source="src/osdep/amiberry_rp9.cpp"
+
+if ! grep -F -q 'rp9_register_rom_override(currprefs.romfile)' "$main_source"; then
+	echo "A command-line -r override must be registered for RP9 validation" >&2
+	exit 1
+fi
+
+if ! grep -F -q 'romlist_add(filename, rom);' "$rp9_source"; then
+	echo "RP9 ROM overrides must be published to the detected ROM list" >&2
+	exit 1
+fi
+
+early_override_line=$(grep -n -F 'safe_strdup(kick_path);' "$libretro_source" | head -1 | cut -d: -f1)
+autoload_line=$(grep -n -F 'safe_strdup("--autoload");' "$libretro_source" | head -1 | cut -d: -f1)
+late_override_line=$(grep -n -F 'safe_strdup(deferred_rp9_kickstart.c_str());' "$libretro_source" | head -1 | cut -d: -f1)
+
+if [ -z "$early_override_line" ] || [ -z "$autoload_line" ] || [ -z "$late_override_line" ] ||
+	[ "$early_override_line" -ge "$autoload_line" ] || [ "$late_override_line" -le "$autoload_line" ]; then
+	echo "Libretro RP9 Kickstart overrides must register before autoload and reapply afterward" >&2
+	exit 1
+fi

--- a/tests/test_rp9_rom_override_order.sh
+++ b/tests/test_rp9_rom_override_order.sh
@@ -10,15 +10,25 @@ if ! grep -F -q 'rp9_register_rom_override(path)' "$main_source"; then
 	exit 1
 fi
 
-prescan_line=$(grep -n -F 'register_cmdline_rom_overrides(argc, argv);' "$main_source" | head -1 | cut -d: -f1)
+if ! grep -F -q 'rp9_register_rom_directory(path)' "$main_source"; then
+	echo "Command-line ROM directories must be registered for RP9 validation" >&2
+	exit 1
+fi
+
+prescan_line=$(grep -n -F 'register_cmdline_rp9_rom_sources(argc, argv);' "$main_source" | head -1 | cut -d: -f1)
 host_autoload_line=$(grep -n -F '_T("--autoload")' "$main_source" | head -1 | cut -d: -f1)
 if [ -z "$prescan_line" ] || [ -z "$host_autoload_line" ] || [ "$prescan_line" -ge "$host_autoload_line" ]; then
-	echo "All host -r overrides must be registered before RP9 autoload validation" >&2
+	echo "All host ROM sources must be registered before RP9 autoload validation" >&2
 	exit 1
 fi
 
 if ! grep -F -q 'romlist_add(filename, rom);' "$rp9_source"; then
 	echo "RP9 ROM overrides must be published to the detected ROM list" >&2
+	exit 1
+fi
+
+if ! grep -F -q 'push_s_option(rom_path);' "$libretro_source"; then
+	echo "Libretro must publish its detected ROM directory to the RP9 pre-scan" >&2
 	exit 1
 fi
 

--- a/tests/test_rp9_snapshot_cleanup.sh
+++ b/tests/test_rp9_snapshot_cleanup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="src/osdep/amiberry_rp9.cpp"
+
+if ! grep -F -q 'std::string loaded_snapshot_path;' "$source_file" ||
+	! grep -F -q 'loaded_snapshot_path = savestate_fname;' "$source_file"; then
+	echo "RP9 snapshot ownership must be tracked independently of its storage root" >&2
+	exit 1
+fi
+
+if ! awk '
+	/bool pending_snapshot_belongs_to_loaded_rp9\(\)/ { in_check = 1 }
+	in_check && /savestate_state == STATE_DORESTORE/ { pending = 1 }
+	in_check && /loaded_snapshot_path == savestate_fname/ { owned = 1 }
+	in_check && /^}/ { exit }
+	END { exit pending && owned ? 0 : 1 }
+' "$source_file"; then
+	echo "Only the still-pending snapshot owned by the loaded RP9 may be cleared" >&2
+	exit 1
+fi
+
+if ! awk '
+	/void rp9_clear_loaded_path\(\)/ { in_clear = 1 }
+	in_clear && /pending_snapshot_belongs_to_loaded_rp9\(\)/ { ownership_check = 1 }
+	in_clear && ownership_check && /savestate_state = 0;/ { state = 1 }
+	in_clear && ownership_check && /savestate_fname\[0\] = 0;/ { filename = 1 }
+	in_clear && /loaded_snapshot_path\.clear\(\);/ { tracking = 1 }
+	in_clear && /^}/ { exit }
+	END { exit state && filename && tracking ? 0 : 1 }
+' "$source_file"; then
+	echo "Clearing RP9 content must discard its pending snapshot regardless of media root" >&2
+	exit 1
+fi

--- a/tests/test_rp9_startup_directory.sh
+++ b/tests/test_rp9_startup_directory.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="src/osdep/amiberry.cpp"
+
+if ! awk '
+	/static void ensure_amiberry_user_directories\(\)/ { in_function = 1 }
+	in_function && /ensure_directory_exists_if_missing\(rp9_path\);/ { found = 1; exit }
+	in_function && /^}/ { exit }
+	END { exit found ? 0 : 1 }
+' "$source_file"; then
+	echo "The configured RP9 content directory must be created during startup" >&2
+	exit 1
+fi

--- a/tests/test_rp9_undoable_hardfile.sh
+++ b/tests/test_rp9_undoable_hardfile.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="src/osdep/amiberry_rp9.cpp"
+
+if ! grep -F -q 'prepare_undoable_hardfile(media, path, extraction_directory' "$source_file"; then
+	echo "RP9 hard drives must pass through undo preparation before mounting" >&2
+	exit 1
+fi
+
+if ! awk '
+	/prepare_undoable_hardfile\(/ { in_prepare = 1 }
+	in_prepare && /!media.undo \|\| media.readonly/ { guarded = 1 }
+	in_prepare && guarded && /directory_contains_path\(extraction_directory/ { temporary = 1 }
+	in_prepare && temporary && /std::filesystem::copy_file\(source, destination/ { copied = 1; exit }
+	in_prepare && /^}/ { exit }
+	END { exit copied ? 0 : 1 }
+' "$source_file"; then
+	echo "Writable persistent RP9 hardfiles with undo enabled must use a temporary copy" >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary

- add a namespace-aware RP9 manifest parser and hardened ZIP package extractor
- apply RP9 machine, ROM, RAM, peripheral, video, clip, boot, and media settings without WHDBooter metadata
- support RP9 from positional CLI arguments, `--autoload`, Quickstart, Play, drag-and-drop, Android, and libretro
- handle embedded and external floppy, hard-disk, CD, tape, snapshot, shared-data, and boot media
- register `.rp9` and `application/vnd.cloanto.rp9` across Linux/FreeBSD/Flatpak, macOS, iOS, Windows, and Android packages
- add focused parser, Play detection, and cross-platform file-association tests

## Why

RP9 packages contain both media and the complete machine configuration required to run them. Treating them like WHDLoad archives would incorrectly depend on WHDBooter JSON and lose the configuration encoded by the package.

The implementation follows the current RetroPlatform manifest, external-content, media-priority, shared-data, and SuperHires/interlaced clipping conventions. Archive extraction also rejects traversal, filesystem collisions, non-portable names, excessive entries, and oversized expansion.

## Validation

- parsed all 248 supplied Amiga Forever packages: 229 runnable packages accepted and 19 gallery/video-only packages rejected as non-emulation content, with no unexpected results
- manually launched floppy, multidisk, embedded HDF, deploy HDF, CD32, and CDTV samples, including Asteroids, Gravitoids, Team 17 Development System, Nippon Safes, and Flight of the Amazon Queen
- visually verified RP9 clipping with the full top-left content visible
- macOS CMake build and generated bundle/codesign verification
- Android `testDebugUnitTest` and ARM64 native build
- full libretro build
- `tests/test_rp9_manifest.sh`
- `tests/test_rp9_file_associations.sh`
- `tests/test_play_content_detection.sh`
- `tests/test_play_start_logic.sh`
- `tests/test_play_use_content_logic.sh`
- `git diff --check`

## References

- https://web.archive.org/web/20230601014251/https://www.retroplatform.com/reference/
- https://www.retroplatform.com/kb/15-122
- https://www.retroplatform.com/kb/19-109
- https://www.retroplatform.com/kb/19-112
- https://www.retroplatform.com/kb/19-115
