### PR TITLE
fix: list top-level external shaders

### DIFF
--- a/src/osdep/imgui/filter.cpp
+++ b/src/osdep/imgui/filter.cpp
@@ -106,12 +106,13 @@ static void scan_shaders()
 
 				if (!is_glsl && !is_glslp) continue;
 
+				fs::path rel = fs::relative(entry.path(), base_path);
+
 				// For .glsl files, only include those at the top level
 				// (subdirectory .glsl files are shader components, not standalone)
-				if (is_glsl && entry.path().parent_path() != base_path) continue;
+				if (is_glsl && !rel.parent_path().empty()) continue;
 
 				// Store path relative to shaders base dir
-				fs::path rel = fs::relative(entry.path(), base_path);
 				std::string rel_str = rel.generic_string(); // use forward slashes
 				shader_names.push_back(rel_str);
 			}


### PR DESCRIPTION
## Summary

- list top-level `.glsl` files from the configured Shaders directory
- keep nested `.glsl` shader components excluded
- preserve recursive `.glslp` preset discovery

## Root cause

`get_shaders_path()` returns the directory with a trailing separator. Comparing
that path directly with `entry.path().parent_path()` therefore rejects
top-level `.glsl` files even though both paths refer to the same directory.

Use the already-needed relative path to identify whether a `.glsl` file is at
the shader directory's top level.

## Validation

- `cmake -B build -DCMAKE_BUILD_TYPE=Debug -DUSE_IPC_SOCKET=ON`
- `cmake --build build --parallel`
- focused `std::filesystem` check covering top-level and nested shader paths
