### PR TITLE
fix: show shader parameter editor in shared GUI

### DIFF
--- a/src/osdep/imgui/filter.cpp
+++ b/src/osdep/imgui/filter.cpp
@@ -168,16 +168,8 @@ static void render_shader_parameters_popup()
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 2.0f);
 	ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.6f, 0.6f, 0.6f, 1.0f));
 	if (ImGui::Begin("Shader Parameters", &show_shader_params_popup)) {
-		std::vector<ShaderParameter>* params = nullptr;
-
-		auto* gl_renderer = g_renderer ? dynamic_cast<OpenGLRenderer*>(g_renderer.get()) : nullptr;
-		ShaderState* shader = gl_renderer ? &gl_renderer->shader_state() : nullptr;
-
-		if (shader && shader->preset && shader->preset->is_valid()) {
-			params = &shader->preset->get_all_parameters();
-		} else if (shader && shader->external && shader->external->is_valid()) {
-			params = const_cast<std::vector<ShaderParameter>*>(&shader->external->get_parameters());
-		}
+		auto* gl_renderer = get_opengl_renderer();
+		auto* params = gl_renderer ? gl_renderer->shader_parameters() : nullptr;
 
 		if (params && !params->empty()) {
 			ImGui::Text("Adjust shader parameters:");
@@ -193,12 +185,7 @@ static void render_shader_parameters_popup()
 				ImGui::SetNextItemWidth(-1);
 				if (ImGui::SliderFloat("##val", &param.current_value,
 					param.min_value, param.max_value, "%.3f")) {
-					// Apply the parameter change
-					if (shader && shader->preset) {
-						shader->preset->set_parameter(param.name, param.current_value);
-					} else if (shader && shader->external) {
-						shader->external->set_parameter(param.name, param.current_value);
-					}
+					gl_renderer->set_shader_parameter(param.name, param.current_value);
 				}
 				AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
 				ImGui::PopID();
@@ -209,11 +196,7 @@ static void render_shader_parameters_popup()
 			if (AmigaButton(ICON_FA_ARROW_ROTATE_LEFT " Reset to Defaults")) {
 				for (auto& param : *params) {
 					param.current_value = param.default_value;
-					if (shader && shader->preset) {
-						shader->preset->set_parameter(param.name, param.default_value);
-					} else if (shader && shader->external) {
-						shader->external->set_parameter(param.name, param.default_value);
-					}
+					gl_renderer->set_shader_parameter(param.name, param.default_value);
 				}
 			}
 		} else {

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -277,6 +277,7 @@ bool OpenGLRenderer::alloc_texture(int monid, int w, int h)
 			shader_name = "none";
 		} else {
 			write_log("Shader preset loaded successfully (%d passes)\n", m_shader.preset->get_pass_count());
+			restore_shader_parameters(shader_name);
 			return true;
 		}
 	}
@@ -290,6 +291,7 @@ bool OpenGLRenderer::alloc_texture(int monid, int w, int h)
 			shader_name = "none";
 		} else {
 			write_log("External shader loaded successfully\n");
+			restore_shader_parameters(shader_name);
 			return true;
 		}
 	}
@@ -913,6 +915,10 @@ void OpenGLRenderer::render_external_shader(ExternalShader* shader, const int mo
 
 void OpenGLRenderer::destroy_shaders()
 {
+	// Shared-window GUI entry must release the GL shader objects, but the
+	// parameter editor still needs their CPU-side metadata and current values.
+	cache_shader_parameters();
+
 	// Clear tracked name so next alloc_texture call will recreate
 	m_shader.loaded_name.clear();
 
@@ -1008,13 +1014,37 @@ bool OpenGLRenderer::has_valid_shader() const
 
 bool OpenGLRenderer::has_shader_parameters() const
 {
-	if (m_shader.preset && m_shader.preset->is_valid() &&
-		!m_shader.preset->get_all_parameters().empty())
-		return true;
-	if (m_shader.external && m_shader.external->is_valid() &&
-		!m_shader.external->get_parameters().empty())
-		return true;
-	return false;
+	const auto* params = shader_parameters();
+	return params && !params->empty();
+}
+
+void OpenGLRenderer::cache_shader_parameters()
+{
+	const std::vector<ShaderParameter>* params = nullptr;
+	if (m_shader.preset && m_shader.preset->is_valid()) {
+		params = &m_shader.preset->get_all_parameters();
+	} else if (m_shader.external && m_shader.external->is_valid()) {
+		params = &m_shader.external->get_parameters();
+	}
+
+	if (params) {
+		m_shader.parameter_cache_name = m_shader.loaded_name;
+		m_shader.parameter_cache = *params;
+	}
+}
+
+void OpenGLRenderer::restore_shader_parameters(const char* shader_name)
+{
+	if (!shader_name || m_shader.parameter_cache_name != shader_name)
+		return;
+
+	for (const auto& param : m_shader.parameter_cache) {
+		if (m_shader.preset) {
+			m_shader.preset->set_parameter(param.name, param.current_value);
+		} else if (m_shader.external) {
+			m_shader.external->set_parameter(param.name, param.current_value);
+		}
+	}
 }
 
 // --- Bezel overlay ---
@@ -1684,6 +1714,52 @@ ShaderState& OpenGLRenderer::shader_state()
 const ShaderState& OpenGLRenderer::shader_state() const
 {
 	return m_shader;
+}
+
+std::vector<ShaderParameter>* OpenGLRenderer::shader_parameters()
+{
+	return const_cast<std::vector<ShaderParameter>*>(
+		static_cast<const OpenGLRenderer*>(this)->shader_parameters());
+}
+
+const std::vector<ShaderParameter>* OpenGLRenderer::shader_parameters() const
+{
+	const char* selected_name = get_selected_shader_name(&AMonitors[0]);
+	if (m_shader.loaded_name == selected_name) {
+		if (m_shader.preset && m_shader.preset->is_valid())
+			return &m_shader.preset->get_all_parameters();
+		if (m_shader.external && m_shader.external->is_valid())
+			return &m_shader.external->get_parameters();
+	}
+
+	if (m_shader.parameter_cache_name == selected_name)
+		return &m_shader.parameter_cache;
+
+	return nullptr;
+}
+
+bool OpenGLRenderer::set_shader_parameter(const std::string& name, float value)
+{
+	bool updated = false;
+	const char* selected_name = get_selected_shader_name(&AMonitors[0]);
+	if (m_shader.loaded_name == selected_name) {
+		if (m_shader.preset && m_shader.preset->is_valid())
+			updated = m_shader.preset->set_parameter(name, value) || updated;
+		else if (m_shader.external && m_shader.external->is_valid())
+			updated = m_shader.external->set_parameter(name, value) || updated;
+	}
+
+	if (m_shader.parameter_cache_name == selected_name) {
+		for (auto& param : m_shader.parameter_cache) {
+			if (param.name == name) {
+				param.current_value = std::max(param.min_value, std::min(param.max_value, value));
+				updated = true;
+				break;
+			}
+		}
+	}
+
+	return updated;
 }
 
 GLOverlayState& OpenGLRenderer::overlay_state()

--- a/src/osdep/opengl_renderer.h
+++ b/src/osdep/opengl_renderer.h
@@ -14,12 +14,13 @@
 
 #include "irenderer.h"
 #include "gl_platform.h"
+#include "external_shader.h"
 #include <SDL3/SDL.h>
 #include <string>
+#include <vector>
 
 // Forward declarations
 struct crtemu_t;
-class ExternalShader;
 class ShaderPreset;
 
 // Shader lifecycle and caching state (owned by OpenGLRenderer)
@@ -29,6 +30,8 @@ struct ShaderState {
 	ShaderPreset* preset = nullptr;
 	std::string external_name;
 	std::string loaded_name;      // cache key to avoid recreation
+	std::string parameter_cache_name;
+	std::vector<ShaderParameter> parameter_cache;
 	GLenum texture_filter_mode = GL_LINEAR;
 	bool bezel_enabled = false;
 };
@@ -128,6 +131,9 @@ public:
 	// Access shader state for filter.cpp parameter editing
 	ShaderState& shader_state();
 	const ShaderState& shader_state() const;
+	std::vector<ShaderParameter>* shader_parameters();
+	const std::vector<ShaderParameter>* shader_parameters() const;
+	bool set_shader_parameter(const std::string& name, float value);
 
 	// Access overlay state for overlay rendering functions
 	GLOverlayState& overlay_state();
@@ -149,6 +155,8 @@ private:
 	// Private helpers for overlay rendering
 	bool init_osd_shader();
 	bool load_bezel_texture(const char* bezel_name);
+	void cache_shader_parameters();
+	void restore_shader_parameters(const char* shader_name);
 
 	// Private helper for external shader rendering
 	void render_external_shader(ExternalShader* shader, int monid,


### PR DESCRIPTION
## Summary

- preserve shader parameter metadata while entering the shared-window GUI
- route Filter panel parameter changes through the OpenGL renderer
- restore edited values after the shader is recreated on resume

## Root cause

Shared-window GUI entry releases the emulation shader objects before rendering
the Filter panel. Button visibility depended on those live objects, so the
Shader Parameters button was always hidden on the affected path.

Shaders without adjustable `#pragma parameter` entries remain intentionally
unchanged and do not show the button.

## User impact

Users can open the shader parameter editor from the shared-window GUI, adjust
values, and resume emulation without losing those changes.

## Validation

- `cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"`
- forced shared-window runtime test with `Pi500-TV.glsl`: opened the editor,
  changed a parameter, resumed emulation, and re-entered the GUI
- `git diff --check`
