### PR TITLE
Fix Linux exclusive-fullscreen aspect ratio

### DIFF
--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -2035,11 +2035,28 @@ void auto_crop_image()
 		amiberry_gfx_auto_crop_presentation_dimensions(
 			source_width, source_height, is_ntsc, currprefs.gfx_correct_aspect != 0,
 			currprefs.scaling_method == 2, sdl_mode.w, sdl_mode.h, width, height);
+		int presentation_width = width;
+		int presentation_height = height;
 		// SDL software path needs logical size update
 		if (mon->amiga_renderer) {
+#if defined(__linux__) && !defined(__ANDROID__)
+			if (currprefs.gfx_correct_aspect && isfullscreen() > 0) {
+				int output_width = 0;
+				int output_height = 0;
+				SDL_GetCurrentRenderOutputSize(mon->amiga_renderer, &output_width, &output_height);
+				const float desired_aspect = amiberry_gfx_fullscreen_framebuffer_aspect(
+					height > 0 ? static_cast<float>(width) / height : 0.0f,
+					output_width, output_height, mon->desktop_width, mon->desktop_height);
+				if (desired_aspect > 0.0f && presentation_height > 0) {
+					presentation_width = std::max(1,
+						static_cast<int>(presentation_height * desired_aspect + 0.5f));
+				}
+			}
+#endif
 			const auto presentation = currprefs.scaling_method == 2
 				? SDL_LOGICAL_PRESENTATION_INTEGER_SCALE : SDL_LOGICAL_PRESENTATION_LETTERBOX;
-			SDL_SetRenderLogicalPresentation(mon->amiga_renderer, width, height, presentation);
+			SDL_SetRenderLogicalPresentation(mon->amiga_renderer,
+				presentation_width, presentation_height, presentation);
 		}
 
 		IRenderer* renderer = get_renderer(0);
@@ -2050,7 +2067,7 @@ void auto_crop_image()
 		renderer->crop_display_h = height;
 		write_log(_T("auto_crop: raw=%dx%d+%d+%d final=%dx%d+%d+%d hres=%d vres=%d ntsc=%d (vblank=%.1fHz) => display %dx%d aspect=%.4f\n"),
 			raw_cw, raw_ch, raw_cx, raw_cy, cw, ch, cx, cy, hres, vres, is_ntsc, vblank_hz, width, height, renderer->crop_aspect);
-		rq = { dx, dy, width, height };
+		rq = { dx, dy, presentation_width, presentation_height };
 		cr = crop_rect;
 
 		// ImGui OSK does not need position updates from texture

--- a/src/osdep/amiberry_gfx.h
+++ b/src/osdep/amiberry_gfx.h
@@ -119,6 +119,8 @@ struct AmigaMonitor {
 	bool ratio_sizing;
 	bool render_ok, wait_render;
 	int dpi;
+	int desktop_width = 0;
+	int desktop_height = 0;
 
 	int in_sizemove;
 	bool focus_transitioning;

--- a/src/osdep/amiberry_gfx_geometry.h
+++ b/src/osdep/amiberry_gfx_geometry.h
@@ -52,4 +52,57 @@ static inline float amiberry_gfx_fullscreen_framebuffer_aspect(
 	return content_aspect * framebuffer_aspect / desktop_aspect;
 }
 
+static inline void amiberry_gfx_correct_aspect_integer_dimensions(
+	const int render_width, const int render_height, const int source_width,
+	const int display_height, const float target_aspect,
+	int& dest_width, int& dest_height)
+{
+	if (render_width <= 0 || render_height <= 0 || source_width <= 0
+		|| display_height <= 0 || target_aspect <= 0.0f) {
+		dest_width = 1;
+		dest_height = 1;
+		return;
+	}
+
+	// Start with a bounded aspect-correct fit. If even 1x integer scaling does
+	// not fit, retain this fractional fallback instead of clipping the viewport.
+	dest_width = render_width;
+	dest_height = static_cast<int>(render_width / target_aspect);
+	if (dest_height > render_height) {
+		dest_height = render_height;
+		dest_width = static_cast<int>(render_height * target_aspect);
+	}
+	if (dest_width < 1) dest_width = 1;
+	if (dest_height < 1) dest_height = 1;
+
+	const int vertical_scale = dest_height / display_height;
+	if (vertical_scale < 1 || source_width > render_width) {
+		return;
+	}
+
+	const float ideal_width = display_height * vertical_scale * target_aspect;
+	int lower_scale = static_cast<int>(ideal_width / source_width);
+	if (lower_scale < 1) lower_scale = 1;
+	const int upper_scale = lower_scale + 1;
+	const float lower_aspect = static_cast<float>(source_width * lower_scale)
+		/ (display_height * vertical_scale);
+	const float upper_aspect = static_cast<float>(source_width * upper_scale)
+		/ (display_height * vertical_scale);
+	const float lower_delta = lower_aspect > target_aspect
+		? lower_aspect - target_aspect : target_aspect - lower_aspect;
+	const float upper_delta = upper_aspect > target_aspect
+		? upper_aspect - target_aspect : target_aspect - upper_aspect;
+
+	int horizontal_scale = lower_scale;
+	if (source_width * upper_scale <= render_width && upper_delta < lower_delta) {
+		horizontal_scale = upper_scale;
+	}
+	while (source_width * horizontal_scale > render_width && horizontal_scale > 1) {
+		horizontal_scale--;
+	}
+
+	dest_width = source_width * horizontal_scale;
+	dest_height = display_height * vertical_scale;
+}
+
 #endif // AMIBERRY_GFX_GEOMETRY_H

--- a/src/osdep/amiberry_gfx_geometry.h
+++ b/src/osdep/amiberry_gfx_geometry.h
@@ -81,8 +81,10 @@ static inline void amiberry_gfx_correct_aspect_integer_dimensions(
 	}
 
 	const float ideal_width = display_height * vertical_scale * target_aspect;
-	int lower_scale = static_cast<int>(ideal_width / source_width);
-	if (lower_scale < 1) lower_scale = 1;
+	const int lower_scale = static_cast<int>(ideal_width / source_width);
+	if (lower_scale < 1) {
+		return;
+	}
 	const int upper_scale = lower_scale + 1;
 	const float lower_aspect = static_cast<float>(source_width * lower_scale)
 		/ (display_height * vertical_scale);

--- a/src/osdep/amiberry_gfx_geometry.h
+++ b/src/osdep/amiberry_gfx_geometry.h
@@ -35,4 +35,21 @@ static inline int amiberry_gfx_native_integer_scale(
 		: 1;
 }
 
+static inline float amiberry_gfx_fullscreen_framebuffer_aspect(
+	const float content_aspect, const int framebuffer_width, const int framebuffer_height,
+	const int desktop_width, const int desktop_height)
+{
+	if (content_aspect <= 0.0f || framebuffer_width <= 0 || framebuffer_height <= 0
+		|| desktop_width <= 0 || desktop_height <= 0) {
+		return content_aspect;
+	}
+
+	// Exclusive modes can be stretched to the desktop's physical output area.
+	// Pre-compensate in framebuffer coordinates so the stretched result retains
+	// the requested content aspect on the display.
+	const float framebuffer_aspect = static_cast<float>(framebuffer_width) / framebuffer_height;
+	const float desktop_aspect = static_cast<float>(desktop_width) / desktop_height;
+	return content_aspect * framebuffer_aspect / desktop_aspect;
+}
+
 #endif // AMIBERRY_GFX_GEOMETRY_H

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -669,6 +669,16 @@ static int create_windows(struct AmigaMonitor* mon)
 			md = md2;
 	}
 	mon->md = md;
+	mon->desktop_width = 0;
+	mon->desktop_height = 0;
+	if (md && md->display_id) {
+		const SDL_DisplayMode* desktop_mode = SDL_GetDesktopDisplayMode(md->display_id);
+		if (desktop_mode) {
+			mon->desktop_width = desktop_mode->w;
+			mon->desktop_height = desktop_mode->h;
+			sdl_mode = *desktop_mode;
+		}
+	}
 
 	if (mon->amiga_window) {
 		SDL_Rect r;
@@ -977,14 +987,6 @@ static int create_windows(struct AmigaMonitor* mon)
 		}
 	}
 
-    // Cache current display mode for scaling heuristics
-    {
-        SDL_DisplayID disp_id = SDL_GetDisplayForWindow(mon->amiga_window);
-        const SDL_DisplayMode* dm = disp_id ? SDL_GetDesktopDisplayMode(disp_id) : nullptr;
-        if (dm) {
-            sdl_mode = *dm;
-        }
-    }
 	updatewinrect(mon, true);
 	GetWindowRect(mon->amiga_window, &mon->mainwin_rect);
 	if (fullscreen || fullwindow)

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -610,35 +610,9 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 				destW = display_w * scale;
 				destH = display_h * scale;
 			} else {
-				// Vertical integer scale, constrained by the aspect-corrected destH
-				int h_scale = destH / display_h;
-				if (h_scale < 1) h_scale = 1;
-
-				// Per-axis scaling: widen toward 4:3 when content is narrower,
-				// but never narrow content that's already wider than 4:3.
-				// At 2160p this gives exact 4:3 (9x horiz, 8x vert = 2880x2160).
-				float target_aspect = integer_target_aspect;
-				float ideal_w = display_h * h_scale * target_aspect;
-				int w_lo = std::max(1, static_cast<int>(ideal_w / src_w));
-				int w_hi = w_lo + 1;
-
-				// Pick the candidate closest to target aspect; prefer narrower on tie
-				float aspect_lo = static_cast<float>(src_w * w_lo) / (display_h * h_scale);
-				float aspect_hi = static_cast<float>(src_w * w_hi) / (display_h * h_scale);
-
-				int w_scale;
-				if (src_w * w_hi <= renderAreaW &&
-					fabsf(aspect_hi - target_aspect) < fabsf(aspect_lo - target_aspect)) {
-					w_scale = w_hi;
-				} else {
-					w_scale = w_lo;
-				}
-
-				// Clamp to render area
-				while (src_w * w_scale > renderAreaW && w_scale > 1) w_scale--;
-
-				destW = src_w * w_scale;
-				destH = display_h * h_scale;
+				amiberry_gfx_correct_aspect_integer_dimensions(
+					renderAreaW, renderAreaH, src_w, display_h,
+					integer_target_aspect, destW, destH);
 			}
 		}
 

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -473,6 +473,17 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 		desired_aspect = calculate_desired_aspect(mon);
 	}
 	if (desired_aspect <= 0.0f) desired_aspect = 4.0f / 3.0f;
+	float integer_target_aspect = std::max(desired_aspect, 4.0f / 3.0f);
+#if defined(__linux__) && !defined(__ANDROID__)
+	if (!mon->screen_is_picasso && currprefs.gfx_correct_aspect && isfullscreen() > 0) {
+		// Linux exclusive modes may be stretched to the desktop output aspect.
+		// Convert the physical target aspect into framebuffer coordinates.
+		desired_aspect = amiberry_gfx_fullscreen_framebuffer_aspect(desired_aspect,
+			drawableWidth, drawableHeight, mon->desktop_width, mon->desktop_height);
+		integer_target_aspect = amiberry_gfx_fullscreen_framebuffer_aspect(integer_target_aspect,
+			drawableWidth, drawableHeight, mon->desktop_width, mon->desktop_height);
+	}
+#endif
 
 	const auto& filter_prefs = get_active_filter_prefs();
 
@@ -606,7 +617,7 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 				// Per-axis scaling: widen toward 4:3 when content is narrower,
 				// but never narrow content that's already wider than 4:3.
 				// At 2160p this gives exact 4:3 (9x horiz, 8x vert = 2880x2160).
-				float target_aspect = std::max(desired_aspect, 4.0f / 3.0f);
+				float target_aspect = integer_target_aspect;
 				float ideal_w = display_h * h_scale * target_aspect;
 				int w_lo = std::max(1, static_cast<int>(ideal_w / src_w));
 				int w_hi = w_lo + 1;

--- a/src/osdep/sdl_renderer.cpp
+++ b/src/osdep/sdl_renderer.cpp
@@ -18,6 +18,7 @@
 
 #include "sdl_renderer.h"
 #include "amiberry_gfx.h"
+#include "amiberry_gfx_geometry.h"
 #include "display_modes.h"
 #include "gfx_platform_internal.h"
 #include "imgui_overlay.h"
@@ -156,9 +157,6 @@ static bool ar_is_exact(const SDL_DisplayMode* mode, const int width, const int 
 void SDLRenderer::set_scaling(int monid, const uae_prefs* p, int w, int h)
 {
 	AmigaMonitor* mon = &AMonitors[monid];
-	if (mon->amiga_renderer)
-		SDL_SetRenderLogicalPresentation(mon->amiga_renderer, w, h, SDL_LOGICAL_PRESENTATION_LETTERBOX);
-
 	if (currprefs.headless) return;
 
 	SDL_ScaleMode scale_mode = SDL_SCALEMODE_NEAREST;
@@ -175,15 +173,34 @@ void SDLRenderer::set_scaling(int monid, const uae_prefs* p, int w, int h)
 	default: scale_mode = SDL_SCALEMODE_LINEAR; break;
 	}
 
+	int logical_width = w;
+	int logical_height = h;
+#if defined(__linux__) && !defined(__ANDROID__)
+	if (mon->amiga_renderer && !mon->screen_is_picasso && currprefs.gfx_correct_aspect
+		&& isfullscreen() > 0) {
+		int output_width = 0;
+		int output_height = 0;
+		SDL_GetCurrentRenderOutputSize(mon->amiga_renderer, &output_width, &output_height);
+		float desired_aspect = ((currprefs.gfx_auto_crop || currprefs.gfx_manual_crop) && crop_aspect > 0.0f)
+			? crop_aspect : calculate_desired_aspect(mon);
+		desired_aspect = amiberry_gfx_fullscreen_framebuffer_aspect(desired_aspect,
+			output_width, output_height, mon->desktop_width, mon->desktop_height);
+		if (desired_aspect > 0.0f && logical_height > 0) {
+			logical_width = std::max(1, static_cast<int>(logical_height * desired_aspect + 0.5f));
+			render_quad = { 0, 0, logical_width, logical_height };
+		}
+	}
+#endif
+
 	// SDL3: scale mode is per-texture, set on the amiga texture
 	if (m_amiga_texture)
 		SDL_SetTextureScaleMode(m_amiga_texture, scale_mode);
 
 	// SDL3: integer scaling via logical presentation mode
 	if (integer_scale)
-		SDL_SetRenderLogicalPresentation(mon->amiga_renderer, w, h, SDL_LOGICAL_PRESENTATION_INTEGER_SCALE);
+		SDL_SetRenderLogicalPresentation(mon->amiga_renderer, logical_width, logical_height, SDL_LOGICAL_PRESENTATION_INTEGER_SCALE);
 	else
-		SDL_SetRenderLogicalPresentation(mon->amiga_renderer, w, h, SDL_LOGICAL_PRESENTATION_LETTERBOX);
+		SDL_SetRenderLogicalPresentation(mon->amiga_renderer, logical_width, logical_height, SDL_LOGICAL_PRESENTATION_LETTERBOX);
 }
 
 // --- OSD texture synchronization ---

--- a/src/osdep/vulkan_renderer.cpp
+++ b/src/osdep/vulkan_renderer.cpp
@@ -20,7 +20,6 @@
 #include "gfx_platform_internal.h"
 
 #include <algorithm>
-#include <cmath>
 #include <cstring>
 #include <set>
 #include <limits>
@@ -1542,23 +1541,9 @@ void VulkanRenderer::record_and_submit(uint32_t slot_index)
 					destW = display_w * scale;
 					destH = display_h * scale;
 				} else {
-					int h_scale = destH / display_h;
-					if (h_scale < 1) h_scale = 1;
-
-					const float ideal_w = display_h * h_scale * integer_target_aspect;
-					const int w_lo = std::max(1, static_cast<int>(ideal_w / src_w));
-					const int w_hi = w_lo + 1;
-					const float aspect_lo = static_cast<float>(src_w * w_lo) / (display_h * h_scale);
-					const float aspect_hi = static_cast<float>(src_w * w_hi) / (display_h * h_scale);
-					int w_scale = w_lo;
-					if (src_w * w_hi <= render_area_w
-						&& std::fabs(aspect_hi - integer_target_aspect) < std::fabs(aspect_lo - integer_target_aspect)) {
-						w_scale = w_hi;
-					}
-					while (src_w * w_scale > render_area_w && w_scale > 1) w_scale--;
-
-					destW = src_w * w_scale;
-					destH = display_h * h_scale;
+					amiberry_gfx_correct_aspect_integer_dimensions(
+						render_area_w, render_area_h, src_w, display_h,
+						integer_target_aspect, destW, destH);
 				}
 			}
 

--- a/src/osdep/vulkan_renderer.cpp
+++ b/src/osdep/vulkan_renderer.cpp
@@ -20,6 +20,7 @@
 #include "gfx_platform_internal.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <set>
 #include <limits>
@@ -1049,6 +1050,10 @@ bool VulkanRenderer::render_frame(int monid, int /*mode*/, int /*immediate*/)
 	slot.scalepicasso = mon->scalepicasso;
 	slot.screen_is_picasso = mon->screen_is_picasso;
 	slot.rtg_integer_scale_limit = filter_prefs.gf[GF_RTG].gfx_filter_integerscalelimit;
+	slot.correct_native_aspect = !mon->screen_is_picasso && currprefs.gfx_correct_aspect;
+	slot.exclusive_fullscreen = isfullscreen() > 0;
+	slot.desktop_width = mon->desktop_width;
+	slot.desktop_height = mon->desktop_height;
 	if ((currprefs.gfx_auto_crop || currprefs.gfx_manual_crop) && !mon->screen_is_picasso && crop_aspect > 0.0f) {
 		slot.desired_aspect = crop_aspect;
 	} else {
@@ -1477,6 +1482,15 @@ void VulkanRenderer::record_and_submit(uint32_t slot_index)
 	if (drawable_w > 0 && drawable_h > 0 && slot.texture_width > 0 && slot.texture_height > 0) {
 		float desired_aspect = slot.desired_aspect;
 		if (desired_aspect <= 0.0f) desired_aspect = 4.0f / 3.0f;
+		float integer_target_aspect = std::max(desired_aspect, 4.0f / 3.0f);
+#if defined(__linux__) && !defined(__ANDROID__)
+		if (slot.correct_native_aspect && slot.exclusive_fullscreen) {
+			desired_aspect = amiberry_gfx_fullscreen_framebuffer_aspect(desired_aspect,
+				drawable_w, drawable_h, slot.desktop_width, slot.desktop_height);
+			integer_target_aspect = amiberry_gfx_fullscreen_framebuffer_aspect(integer_target_aspect,
+				drawable_w, drawable_h, slot.desktop_width, slot.desktop_height);
+		}
+#endif
 
 		bool use_center = slot.screen_is_picasso && slot.scalepicasso == RTG_MODE_CENTER;
 		bool use_integer = slot.screen_is_picasso
@@ -1522,11 +1536,29 @@ void VulkanRenderer::record_and_submit(uint32_t slot_index)
 						display_w, display_h, slot.rtg_integer_scale_limit);
 					destW = std::max(1, static_cast<int>(static_cast<float>(display_w) * scale + 0.5f));
 					destH = std::max(1, static_cast<int>(static_cast<float>(display_h) * scale + 0.5f));
-				} else {
+				} else if (!slot.correct_native_aspect) {
 					const int scale = amiberry_gfx_native_integer_scale(
 						render_area_w, render_area_h, display_w, display_h);
 					destW = display_w * scale;
 					destH = display_h * scale;
+				} else {
+					int h_scale = destH / display_h;
+					if (h_scale < 1) h_scale = 1;
+
+					const float ideal_w = display_h * h_scale * integer_target_aspect;
+					const int w_lo = std::max(1, static_cast<int>(ideal_w / src_w));
+					const int w_hi = w_lo + 1;
+					const float aspect_lo = static_cast<float>(src_w * w_lo) / (display_h * h_scale);
+					const float aspect_hi = static_cast<float>(src_w * w_hi) / (display_h * h_scale);
+					int w_scale = w_lo;
+					if (src_w * w_hi <= render_area_w
+						&& std::fabs(aspect_hi - integer_target_aspect) < std::fabs(aspect_lo - integer_target_aspect)) {
+						w_scale = w_hi;
+					}
+					while (src_w * w_scale > render_area_w && w_scale > 1) w_scale--;
+
+					destW = src_w * w_scale;
+					destH = display_h * h_scale;
 				}
 			}
 

--- a/src/osdep/vulkan_renderer.h
+++ b/src/osdep/vulkan_renderer.h
@@ -170,6 +170,10 @@ private:
 		int scalepicasso = 0;
 		int rtg_integer_scale_limit = 0;
 		float desired_aspect = 4.0f / 3.0f;
+		bool correct_native_aspect = false;
+		bool exclusive_fullscreen = false;
+		int desktop_width = 0;
+		int desktop_height = 0;
 
 		// Zero-copy RTG path
 		bool zerocopy = false;

--- a/tests/gfx_geometry_test.cpp
+++ b/tests/gfx_geometry_test.cpp
@@ -12,6 +12,14 @@ static void expect_int_eq(const int actual, const int expected, const char* mess
 	}
 }
 
+static void expect_float_near(const float actual, const float expected, const float tolerance, const char* message)
+{
+	if (actual < expected - tolerance || actual > expected + tolerance) {
+		std::cerr << message << ": expected " << expected << ", got " << actual << '\n';
+		failures++;
+	}
+}
+
 static void test_ntsc_integer_scaling_without_aspect_uses_crop_geometry()
 {
 	int width = 0;
@@ -50,10 +58,30 @@ static void test_integer_scaling_never_fractionally_downscales()
 		"integer scaling must retain a 1x source when the render area is smaller");
 }
 
+static void test_exclusive_fullscreen_compensates_for_display_mode_stretch()
+{
+	expect_float_near(amiberry_gfx_fullscreen_framebuffer_aspect(
+		4.0f / 3.0f, 800, 600, 1920, 1080), 1.0f, 0.0001f,
+		"4:3 content in a stretched 800x600 mode must use a square framebuffer viewport");
+
+	expect_float_near(amiberry_gfx_fullscreen_framebuffer_aspect(
+		4.0f / 3.0f, 1280, 720, 1920, 1080), 4.0f / 3.0f, 0.0001f,
+		"a fullscreen mode matching the desktop aspect must not change the content aspect");
+
+	expect_float_near(amiberry_gfx_fullscreen_framebuffer_aspect(
+		1.25f, 800, 600, 1920, 1080), 0.9375f, 0.0001f,
+		"cropped content aspect must receive the same fullscreen stretch compensation");
+
+	expect_float_near(amiberry_gfx_fullscreen_framebuffer_aspect(
+		4.0f / 3.0f, 0, 600, 1920, 1080), 4.0f / 3.0f, 0.0001f,
+		"invalid fullscreen dimensions must leave the requested aspect unchanged");
+}
+
 int main()
 {
 	test_ntsc_integer_scaling_without_aspect_uses_crop_geometry();
 	test_ntsc_aspect_correction_and_legacy_stretch_remain_distinct();
 	test_integer_scaling_never_fractionally_downscales();
+	test_exclusive_fullscreen_compensates_for_display_mode_stretch();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/gfx_geometry_test.cpp
+++ b/tests/gfx_geometry_test.cpp
@@ -96,6 +96,13 @@ static void test_corrected_integer_scaling_stays_within_fullscreen_mode()
 		"compensated 720-tall presentation must use the bounded aspect fit");
 
 	amiberry_gfx_correct_aspect_integer_dimensions(
+		800, 600, 640, 480, 1.0f, width, height);
+	expect_int_eq(width, 600,
+		"a compensated target narrower than 1x must retain the bounded width");
+	expect_int_eq(height, 600,
+		"a compensated target narrower than 1x must retain the target aspect");
+
+	amiberry_gfx_correct_aspect_integer_dimensions(
 		3840, 2160, 320, 270, 4.0f / 3.0f, width, height);
 	expect_int_eq(width, 2880,
 		"integer scaling must retain the closest bounded horizontal scale");

--- a/tests/gfx_geometry_test.cpp
+++ b/tests/gfx_geometry_test.cpp
@@ -77,11 +77,38 @@ static void test_exclusive_fullscreen_compensates_for_display_mode_stretch()
 		"invalid fullscreen dimensions must leave the requested aspect unchanged");
 }
 
+static void test_corrected_integer_scaling_stays_within_fullscreen_mode()
+{
+	int width = 0;
+	int height = 0;
+	amiberry_gfx_correct_aspect_integer_dimensions(
+		800, 600, 640, 640, 1.0f, width, height);
+	expect_int_eq(width, 600,
+		"compensated 640-wide content must fit within an 800x600 fullscreen mode");
+	expect_int_eq(height, 600,
+		"compensated 640-tall presentation must not be clipped by a 600-line mode");
+
+	amiberry_gfx_correct_aspect_integer_dimensions(
+		800, 600, 720, 720, 1.0f, width, height);
+	expect_int_eq(width, 600,
+		"compensated 720-wide content must use the bounded aspect fit");
+	expect_int_eq(height, 600,
+		"compensated 720-tall presentation must use the bounded aspect fit");
+
+	amiberry_gfx_correct_aspect_integer_dimensions(
+		3840, 2160, 320, 270, 4.0f / 3.0f, width, height);
+	expect_int_eq(width, 2880,
+		"integer scaling must retain the closest bounded horizontal scale");
+	expect_int_eq(height, 2160,
+		"integer scaling must retain the largest bounded vertical scale");
+}
+
 int main()
 {
 	test_ntsc_integer_scaling_without_aspect_uses_crop_geometry();
 	test_ntsc_aspect_correction_and_legacy_stretch_remain_distinct();
 	test_integer_scaling_never_fractionally_downscales();
 	test_exclusive_fullscreen_compensates_for_display_mode_stretch();
+	test_corrected_integer_scaling_stays_within_fullscreen_mode();
 	return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## What changed

- Cache the desktop display dimensions before entering an exclusive fullscreen mode.
- Compensate native PAL/NTSC presentation geometry when Linux stretches the exclusive-mode framebuffer to the desktop output aspect.
- Apply the correction consistently to OpenGL, SDL, and Vulkan, including auto-crop and integer scaling.
- Add regression coverage for mismatched fullscreen and desktop aspect ratios.

## Why

Linux exclusive fullscreen can switch Amiberry to a lower-resolution mode such as 800x600 and then stretch that framebuffer over a widescreen output. The renderer previously produced the requested 4:3 image in framebuffer coordinates, so the display's subsequent stretch distorted it physically.

The compensation is Linux-only and remains gated by **Correct aspect ratio**. Full-window, RTG, other platforms, and configurations with aspect correction disabled retain their existing behavior.

## Validation

- `tests/test_gfx_geometry.sh`
- Linux Debug OpenGL build
- Linux Debug SDL-only build
- Vulkan-enabled `vulkan_renderer.cpp` build
- OpenGL and SDL startup smoke tests with `--dump-paths`
- `git diff --check`

Visual confirmation on hardware performing an actual Linux exclusive display-mode switch is still recommended.
