### PR TITLE
Save Native and RTG shader parameters

### DIFF
--- a/src/include/options.h
+++ b/src/include/options.h
@@ -1379,6 +1379,14 @@ struct amiberry_gui_theme
 	amiberry_gui_color foreground_color;
 };
 
+struct amiberry_shader_parameter
+{
+	bool rtg = false;
+	std::string shader;
+	std::string name;
+	float value = 0.0f;
+};
+
 struct amiberry_options
 {
 	bool quickstart_start = true;
@@ -1444,6 +1452,7 @@ struct amiberry_options
 	char gui_theme[128] = "Default.theme";
 	char shader[128] = "none";
 	char shader_rtg[128] = "none";
+	std::vector<amiberry_shader_parameter> shader_parameters;
 	bool use_bezel = false;
 	bool use_custom_bezel = false;
 	char custom_bezel[256] = "none";

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #endif
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <cctype>
@@ -6413,6 +6414,13 @@ bool save_amiberry_settings_with_result()
 
 	// Shader to use for RTG modes (if any)
 	write_string_option("shader_rtg", amiberry_options.shader_rtg);
+	for (const auto& parameter : amiberry_options.shader_parameters)
+	{
+		_sntprintf(buffer, MAX_DPATH, "shader_parameter=%s|%s|%s|%.9g\n",
+			parameter.rtg ? "rtg" : "native", parameter.shader.c_str(),
+			parameter.name.c_str(), parameter.value);
+		fputs(buffer, f);
+	}
 
 	// Show CRT bezel frame overlay
 	write_bool_option("use_bezel", amiberry_options.use_bezel);
@@ -6511,6 +6519,56 @@ static void trim_wsa(char* s)
 	auto len = strlen(s);
 	while (len > 0 && strcspn(s + len - 1, "\t \r\n") == 0)
 		s[--len] = '\0';
+}
+
+static bool parse_shader_parameter_setting(const char* value)
+{
+	const std::string serialized(value);
+	const auto target_end = serialized.find('|');
+	const auto shader_end = target_end == std::string::npos
+		? std::string::npos
+		: serialized.find('|', target_end + 1);
+	const auto name_end = shader_end == std::string::npos
+		? std::string::npos
+		: serialized.find('|', shader_end + 1);
+	if (target_end == std::string::npos || target_end == 0
+		|| shader_end == std::string::npos || shader_end == target_end + 1
+		|| name_end == std::string::npos || name_end == shader_end + 1
+		|| name_end + 1 >= serialized.size())
+	{
+		return false;
+	}
+
+	const auto target = serialized.substr(0, target_end);
+	if (target != "native" && target != "rtg")
+		return false;
+
+	const bool rtg = target == "rtg";
+	const auto shader = serialized.substr(target_end + 1, shader_end - target_end - 1);
+	const auto name = serialized.substr(shader_end + 1, name_end - shader_end - 1);
+	const auto value_string = serialized.substr(name_end + 1);
+	try
+	{
+		size_t consumed = 0;
+		const float parameter_value = std::stof(value_string, &consumed);
+		if (consumed != value_string.size() || !std::isfinite(parameter_value))
+			return false;
+
+		auto& parameters = amiberry_options.shader_parameters;
+		const auto existing = std::find_if(parameters.begin(), parameters.end(),
+			[&](const amiberry_shader_parameter& parameter) {
+				return parameter.rtg == rtg && parameter.shader == shader && parameter.name == name;
+			});
+		if (existing != parameters.end())
+			existing->value = parameter_value;
+		else
+			parameters.push_back({rtg, shader, name, parameter_value});
+		return true;
+	}
+	catch (const std::exception&)
+	{
+		return false;
+	}
 }
 
 static bool parse_base_content_path_line(const char* path, char* linea, std::string& value_out)
@@ -6743,6 +6801,8 @@ static int parse_amiberry_settings_line(const char *path, char *linea)
 		ret |= cfgfile_string(option, value, "gui_theme", amiberry_options.gui_theme, sizeof amiberry_options.gui_theme);
 		ret |= cfgfile_string(option, value, "shader", amiberry_options.shader, sizeof amiberry_options.shader);
 		ret |= cfgfile_string(option, value, "shader_rtg", amiberry_options.shader_rtg, sizeof amiberry_options.shader_rtg);
+		if (_tcscmp(option, _T("shader_parameter")) == 0)
+			ret |= parse_shader_parameter_setting(value) ? 1 : 0;
 		ret |= cfgfile_yesno(option, value, "use_bezel", &amiberry_options.use_bezel);
 		ret |= cfgfile_yesno(option, value, "use_custom_bezel", &amiberry_options.use_custom_bezel);
 		ret |= cfgfile_string(option, value, "custom_bezel", amiberry_options.custom_bezel, sizeof amiberry_options.custom_bezel);

--- a/src/osdep/imgui/filter.cpp
+++ b/src/osdep/imgui/filter.cpp
@@ -144,6 +144,10 @@ static int find_shader_index(const char* shader_name)
 }
 
 static bool show_shader_params_popup = false;
+#ifdef USE_OPENGL
+static bool shader_params_popup_rtg = false;
+static std::string shader_params_popup_name;
+#endif
 
 static void save_filter_defaults()
 {
@@ -159,6 +163,15 @@ static void save_filter_defaults()
 	save_amiberry_settings();
 }
 
+#ifdef USE_OPENGL
+static void open_shader_parameters_popup(const char* shader_name, const bool rtg)
+{
+	shader_params_popup_name = shader_name ? shader_name : "none";
+	shader_params_popup_rtg = rtg;
+	show_shader_params_popup = true;
+}
+#endif
+
 static void render_shader_parameters_popup()
 {
 	if (!show_shader_params_popup) return;
@@ -167,13 +180,39 @@ static void render_shader_parameters_popup()
 	ImGui::SetNextWindowSize(ImVec2(BUTTON_WIDTH * 5, BUTTON_HEIGHT * 10), ImGuiCond_FirstUseEver);
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 2.0f);
 	ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.6f, 0.6f, 0.6f, 1.0f));
-	if (ImGui::Begin("Shader Parameters", &show_shader_params_popup)) {
+	const char* popup_title = shader_params_popup_rtg ? "RTG Shader Parameters" : "Native Shader Parameters";
+	if (ImGui::Begin(popup_title, &show_shader_params_popup)) {
 		auto* gl_renderer = get_opengl_renderer();
-		auto* params = gl_renderer ? gl_renderer->shader_parameters() : nullptr;
+		auto* params = gl_renderer
+			? gl_renderer->shader_parameters(shader_params_popup_name.c_str(), shader_params_popup_rtg)
+			: nullptr;
 
 		if (params && !params->empty()) {
-			ImGui::Text("Adjust shader parameters:");
+			ImGui::Text("Shader: %s", shader_params_popup_name.c_str());
+			ImGui::Spacing();
+
+			if (AmigaButton(ICON_FA_ARROW_ROTATE_LEFT " Reset to Shader Defaults",
+				ImVec2(BUTTON_WIDTH * 2.25f, BUTTON_HEIGHT))) {
+				for (auto& param : *params) {
+					param.current_value = param.default_value;
+					gl_renderer->set_shader_parameter(shader_params_popup_name.c_str(),
+						shader_params_popup_rtg, param.name, param.default_value);
+				}
+			}
+			ShowHelpMarker("Restore the values declared by this shader.");
+			ImGui::SameLine();
+			if (AmigaButton(ICON_FA_FLOPPY_DISK " Save Parameters",
+				ImVec2(BUTTON_WIDTH * 1.75f, BUTTON_HEIGHT))) {
+				gl_renderer->save_shader_parameters(shader_params_popup_name.c_str(), shader_params_popup_rtg);
+				save_amiberry_settings();
+			}
+			ShowHelpMarker(shader_params_popup_rtg
+				? "Save these values as the defaults for the RTG shader."
+				: "Save these values as the defaults for the native shader.");
+
+			ImGui::Spacing();
 			ImGui::Separator();
+			ImGui::Text("Adjust shader parameters:");
 			ImGui::Spacing();
 
 			for (auto& param : *params) {
@@ -185,22 +224,17 @@ static void render_shader_parameters_popup()
 				ImGui::SetNextItemWidth(-1);
 				if (ImGui::SliderFloat("##val", &param.current_value,
 					param.min_value, param.max_value, "%.3f")) {
-					gl_renderer->set_shader_parameter(param.name, param.current_value);
+					gl_renderer->set_shader_parameter(shader_params_popup_name.c_str(),
+						shader_params_popup_rtg, param.name, param.current_value);
 				}
 				AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
 				ImGui::PopID();
 			}
-
-			ImGui::Spacing();
-			ImGui::Separator();
-			if (AmigaButton(ICON_FA_ARROW_ROTATE_LEFT " Reset to Defaults")) {
-				for (auto& param : *params) {
-					param.current_value = param.default_value;
-					gl_renderer->set_shader_parameter(param.name, param.default_value);
-				}
-			}
 		} else {
-			ImGui::Text("No adjustable parameters for the current shader.");
+			ImGui::Text("Shader: %s", shader_params_popup_name.c_str());
+			ImGui::Spacing();
+			ImGui::TextWrapped("No adjustable parameters are currently available for this %s shader.",
+				shader_params_popup_rtg ? "RTG" : "native");
 		}
 	}
 	ImGui::End();
@@ -305,6 +339,14 @@ void render_panel_filter()
 		ShowHelpMarker("CRT shader applied to native Amiga chipset display modes.");
 		ImGui::SameLine();
 		ImGui::Text("Shader for native Amiga modes");
+		ImGui::Spacing();
+#ifdef USE_OPENGL
+		if (AmigaButton(ICON_FA_SLIDERS " Shader Parameters...##NativeShaderParameters",
+			ImVec2(BUTTON_WIDTH * 1.75f, BUTTON_HEIGHT))) {
+			open_shader_parameters_popup(changed_prefs.shader, false);
+		}
+		ShowHelpMarker("Edit parameters for the native display shader.");
+#endif
 	}
 	EndGroupBox("Native Display Shader");
 
@@ -332,6 +374,14 @@ void render_panel_filter()
 		ShowHelpMarker("CRT shader applied to RTG/Picasso96 graphics card display modes.");
 		ImGui::SameLine();
 		ImGui::Text("Shader for RTG/Picasso modes");
+		ImGui::Spacing();
+#ifdef USE_OPENGL
+		if (AmigaButton(ICON_FA_SLIDERS " Shader Parameters...##RTGShaderParameters",
+			ImVec2(BUTTON_WIDTH * 1.75f, BUTTON_HEIGHT))) {
+			open_shader_parameters_popup(changed_prefs.shader_rtg, true);
+		}
+		ShowHelpMarker("Edit parameters for the RTG display shader.");
+#endif
 	}
 	EndGroupBox("RTG Display Shader");
 
@@ -400,18 +450,11 @@ void render_panel_filter()
 	}
 	ImGui::SameLine();
 
-	// Shader Parameters button (only shown when active shader has parameters)
-	if (g_renderer && g_renderer->has_shader_parameters()) {
-		if (AmigaButton(ICON_FA_SLIDERS " Shader Parameters...", ImVec2(BUTTON_WIDTH * 1.5f, BUTTON_HEIGHT))) {
-			show_shader_params_popup = true;
-		}
-		ImGui::SameLine();
-	}
-
 	// Save button
-	if (AmigaButton(ICON_FA_FLOPPY_DISK " Save Defaults", ImVec2(BUTTON_WIDTH * 1.5f, BUTTON_HEIGHT))) {
+	if (AmigaButton(ICON_FA_FLOPPY_DISK " Save Defaults", ImVec2(BUTTON_WIDTH * 1.75f, BUTTON_HEIGHT))) {
 		save_filter_defaults();
 	}
+	ShowHelpMarker("Save the shader selections and bezel settings as application defaults.");
 
 	// Render the shader parameters popup if open
 	render_shader_parameters_popup();

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -35,6 +35,7 @@
 #include "imgui_osk.h"
 #include "on_screen_joystick.h"
 #include "gui/gui_handling.h"
+#include <algorithm>
 #include <cmath>
 #include <SDL3_image/SDL_image.h>
 

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -247,17 +247,21 @@ bool OpenGLRenderer::alloc_texture(int monid, int w, int h)
 
 	auto mon = &AMonitors[monid];
 	const char* shader_name = get_selected_shader_name(mon);
+	const bool shader_for_rtg = mon->screen_is_picasso;
 
-	// Skip shader recreation if already loaded with the same name.
-	// This preserves runtime parameter changes made by the user.
+	// Parameterized shaders may have different Native and RTG values, so they
+	// must be recreated when the display target changes even if the name matches.
 	bool shader_exists = (m_shader.crtemu != nullptr || m_shader.external != nullptr || m_shader.preset != nullptr);
-	if (shader_exists && m_shader.loaded_name == shader_name) {
+	const bool parameterized_shader = m_shader.external != nullptr || m_shader.preset != nullptr;
+	if (shader_exists && m_shader.loaded_name == shader_name
+		&& (!parameterized_shader || m_shader.loaded_for_rtg == shader_for_rtg)) {
 		return true;
 	}
 
 	// Clean up existing shaders (name changed or no shader loaded yet)
 	destroy_shaders();
 	m_shader.loaded_name = shader_name;
+	m_shader.loaded_for_rtg = shader_for_rtg;
 
 	// Force full render on next frame after shader switch
 	mon->full_render_needed = true;
@@ -277,7 +281,8 @@ bool OpenGLRenderer::alloc_texture(int monid, int w, int h)
 			shader_name = "none";
 		} else {
 			write_log("Shader preset loaded successfully (%d passes)\n", m_shader.preset->get_pass_count());
-			restore_shader_parameters(shader_name);
+			cache_shader_parameter_template();
+			restore_shader_parameters(shader_name, shader_for_rtg);
 			return true;
 		}
 	}
@@ -291,7 +296,8 @@ bool OpenGLRenderer::alloc_texture(int monid, int w, int h)
 			shader_name = "none";
 		} else {
 			write_log("External shader loaded successfully\n");
-			restore_shader_parameters(shader_name);
+			cache_shader_parameter_template();
+			restore_shader_parameters(shader_name, shader_for_rtg);
 			return true;
 		}
 	}
@@ -999,8 +1005,23 @@ bool OpenGLRenderer::has_valid_shader() const
 
 bool OpenGLRenderer::has_shader_parameters() const
 {
-	const auto* params = shader_parameters();
-	return params && !params->empty();
+	const bool rtg = AMonitors[0].screen_is_picasso;
+	return has_shader_parameters(get_selected_shader_name(&AMonitors[0]), rtg);
+}
+
+void OpenGLRenderer::cache_shader_parameter_template()
+{
+	const std::vector<ShaderParameter>* params = nullptr;
+	if (m_shader.preset && m_shader.preset->is_valid()) {
+		params = &m_shader.preset->get_all_parameters();
+	} else if (m_shader.external && m_shader.external->is_valid()) {
+		params = &m_shader.external->get_parameters();
+	}
+
+	if (params) {
+		m_shader.parameter_template.shader_name = m_shader.loaded_name;
+		m_shader.parameter_template.parameters = *params;
+	}
 }
 
 void OpenGLRenderer::cache_shader_parameters()
@@ -1013,22 +1034,36 @@ void OpenGLRenderer::cache_shader_parameters()
 	}
 
 	if (params) {
-		m_shader.parameter_cache_name = m_shader.loaded_name;
-		m_shader.parameter_cache = *params;
+		auto& cache = m_shader.loaded_for_rtg
+			? m_shader.rtg_parameter_cache
+			: m_shader.native_parameter_cache;
+		cache.shader_name = m_shader.loaded_name;
+		cache.parameters = *params;
 	}
 }
 
-void OpenGLRenderer::restore_shader_parameters(const char* shader_name)
+void OpenGLRenderer::restore_shader_parameters(const char* shader_name, const bool rtg)
 {
-	if (!shader_name || m_shader.parameter_cache_name != shader_name)
+	if (!shader_name)
 		return;
 
-	for (const auto& param : m_shader.parameter_cache) {
+	auto apply_parameter = [&](const std::string& name, const float value) {
 		if (m_shader.preset) {
-			m_shader.preset->set_parameter(param.name, param.current_value);
+			m_shader.preset->set_parameter(name, value);
 		} else if (m_shader.external) {
-			m_shader.external->set_parameter(param.name, param.current_value);
+			m_shader.external->set_parameter(name, value);
 		}
+	};
+
+	for (const auto& parameter : amiberry_options.shader_parameters) {
+		if (parameter.rtg == rtg && parameter.shader == shader_name)
+			apply_parameter(parameter.name, parameter.value);
+	}
+
+	const auto& cache = rtg ? m_shader.rtg_parameter_cache : m_shader.native_parameter_cache;
+	if (cache.shader_name == shader_name) {
+		for (const auto& parameter : cache.parameters)
+			apply_parameter(parameter.name, parameter.current_value);
 	}
 }
 
@@ -1701,41 +1736,82 @@ const ShaderState& OpenGLRenderer::shader_state() const
 	return m_shader;
 }
 
-std::vector<ShaderParameter>* OpenGLRenderer::shader_parameters()
+std::vector<ShaderParameter>* OpenGLRenderer::shader_parameters(const char* shader_name, const bool rtg)
 {
-	return const_cast<std::vector<ShaderParameter>*>(
-		static_cast<const OpenGLRenderer*>(this)->shader_parameters());
+	auto* params = const_cast<std::vector<ShaderParameter>*>(
+		static_cast<const OpenGLRenderer*>(this)->shader_parameters(shader_name, rtg));
+	if (params || !shader_name)
+		return params;
+
+	// The same shader can be configured independently for Native and RTG modes.
+	// Start with the values supplied by the shader/preset before target overrides.
+	const std::vector<ShaderParameter>* source = nullptr;
+	bool use_template_values = false;
+	if (m_shader.parameter_template.shader_name == shader_name) {
+		source = &m_shader.parameter_template.parameters;
+		use_template_values = true;
+	} else {
+		source = static_cast<const OpenGLRenderer*>(this)->shader_parameters(shader_name, !rtg);
+	}
+	if (!source)
+		return nullptr;
+
+	auto& cache = rtg ? m_shader.rtg_parameter_cache : m_shader.native_parameter_cache;
+	cache.shader_name = shader_name;
+	cache.parameters = *source;
+	for (auto& parameter : cache.parameters) {
+		if (!use_template_values)
+			parameter.current_value = parameter.default_value;
+		for (const auto& saved : amiberry_options.shader_parameters) {
+			if (saved.rtg == rtg && saved.shader == shader_name && saved.name == parameter.name) {
+				parameter.current_value = std::max(parameter.min_value,
+					std::min(parameter.max_value, saved.value));
+				break;
+			}
+		}
+	}
+	return &cache.parameters;
 }
 
-const std::vector<ShaderParameter>* OpenGLRenderer::shader_parameters() const
+const std::vector<ShaderParameter>* OpenGLRenderer::shader_parameters(const char* shader_name, const bool rtg) const
 {
-	const char* selected_name = get_selected_shader_name(&AMonitors[0]);
-	if (m_shader.loaded_name == selected_name) {
+	if (!shader_name)
+		return nullptr;
+
+	if (m_shader.loaded_name == shader_name && m_shader.loaded_for_rtg == rtg) {
 		if (m_shader.preset && m_shader.preset->is_valid())
 			return &m_shader.preset->get_all_parameters();
 		if (m_shader.external && m_shader.external->is_valid())
 			return &m_shader.external->get_parameters();
 	}
 
-	if (m_shader.parameter_cache_name == selected_name)
-		return &m_shader.parameter_cache;
+	const auto& cache = rtg ? m_shader.rtg_parameter_cache : m_shader.native_parameter_cache;
+	if (cache.shader_name == shader_name)
+		return &cache.parameters;
 
 	return nullptr;
 }
 
-bool OpenGLRenderer::set_shader_parameter(const std::string& name, float value)
+bool OpenGLRenderer::has_shader_parameters(const char* shader_name, const bool rtg) const
+{
+	const auto* params = shader_parameters(shader_name, rtg);
+	return params && !params->empty();
+}
+
+bool OpenGLRenderer::set_shader_parameter(const char* shader_name, const bool rtg,
+	const std::string& name, const float value)
 {
 	bool updated = false;
-	const char* selected_name = get_selected_shader_name(&AMonitors[0]);
-	if (m_shader.loaded_name == selected_name) {
+	if (shader_name && m_shader.loaded_name == shader_name && m_shader.loaded_for_rtg == rtg) {
 		if (m_shader.preset && m_shader.preset->is_valid())
 			updated = m_shader.preset->set_parameter(name, value) || updated;
 		else if (m_shader.external && m_shader.external->is_valid())
 			updated = m_shader.external->set_parameter(name, value) || updated;
 	}
 
-	if (m_shader.parameter_cache_name == selected_name) {
-		for (auto& param : m_shader.parameter_cache) {
+	auto& cache = rtg ? m_shader.rtg_parameter_cache : m_shader.native_parameter_cache;
+	if (shader_name && cache.shader_name == shader_name) {
+		for (auto& param : cache.parameters) {
 			if (param.name == name) {
 				param.current_value = std::max(param.min_value, std::min(param.max_value, value));
 				updated = true;
@@ -1745,6 +1821,24 @@ bool OpenGLRenderer::set_shader_parameter(const std::string& name, float value)
 	}
 
 	return updated;
+}
+
+void OpenGLRenderer::save_shader_parameters(const char* shader_name, const bool rtg)
+{
+	const auto* params = shader_parameters(shader_name, rtg);
+	if (!params || !shader_name)
+		return;
+
+	auto& saved = amiberry_options.shader_parameters;
+	saved.erase(std::remove_if(saved.begin(), saved.end(),
+		[&](const amiberry_shader_parameter& parameter) {
+			return parameter.rtg == rtg && parameter.shader == shader_name;
+		}), saved.end());
+
+	for (const auto& parameter : *params) {
+		if (parameter.current_value != parameter.default_value)
+			saved.push_back({rtg, shader_name, parameter.name, parameter.current_value});
+	}
 }
 
 GLOverlayState& OpenGLRenderer::overlay_state()

--- a/src/osdep/opengl_renderer.h
+++ b/src/osdep/opengl_renderer.h
@@ -23,6 +23,11 @@
 struct crtemu_t;
 class ShaderPreset;
 
+struct ShaderParameterCache {
+	std::string shader_name;
+	std::vector<ShaderParameter> parameters;
+};
+
 // Shader lifecycle and caching state (owned by OpenGLRenderer)
 struct ShaderState {
 	crtemu_t* crtemu = nullptr;
@@ -30,8 +35,10 @@ struct ShaderState {
 	ShaderPreset* preset = nullptr;
 	std::string external_name;
 	std::string loaded_name;      // cache key to avoid recreation
-	std::string parameter_cache_name;
-	std::vector<ShaderParameter> parameter_cache;
+	bool loaded_for_rtg = false;
+	ShaderParameterCache parameter_template;
+	ShaderParameterCache native_parameter_cache;
+	ShaderParameterCache rtg_parameter_cache;
 	GLenum texture_filter_mode = GL_LINEAR;
 	bool bezel_enabled = false;
 };
@@ -131,9 +138,11 @@ public:
 	// Access shader state for filter.cpp parameter editing
 	ShaderState& shader_state();
 	const ShaderState& shader_state() const;
-	std::vector<ShaderParameter>* shader_parameters();
-	const std::vector<ShaderParameter>* shader_parameters() const;
-	bool set_shader_parameter(const std::string& name, float value);
+	std::vector<ShaderParameter>* shader_parameters(const char* shader_name, bool rtg);
+	const std::vector<ShaderParameter>* shader_parameters(const char* shader_name, bool rtg) const;
+	bool has_shader_parameters(const char* shader_name, bool rtg) const;
+	bool set_shader_parameter(const char* shader_name, bool rtg, const std::string& name, float value);
+	void save_shader_parameters(const char* shader_name, bool rtg);
 
 	// Access overlay state for overlay rendering functions
 	GLOverlayState& overlay_state();
@@ -155,8 +164,9 @@ private:
 	// Private helpers for overlay rendering
 	bool init_osd_shader();
 	bool load_bezel_texture(const char* bezel_name);
+	void cache_shader_parameter_template();
 	void cache_shader_parameters();
-	void restore_shader_parameters(const char* shader_name);
+	void restore_shader_parameters(const char* shader_name, bool rtg);
 
 	// Private helper for external shader rendering
 	void render_external_shader(ExternalShader* shader, int monid,


### PR DESCRIPTION
## Summary

- add separate Shader Parameters actions beneath the Native and RTG shader selectors
- move Reset to Shader Defaults to the top of each targeted popup and add a Save Parameters action beside it
- persist parameter overrides independently for Native and RTG modes, including when both modes use the same shader
- keep Save Defaults for the remaining Filter defaults: shader selections and bezel settings
- widen the shader-related buttons so their labels remain visible

## Root cause

Shader parameter edits only lived in renderer state. The Filter panel's Save Defaults action stored the selected shader names and bezel settings, but it had no serialized parameter state to restore after restarting Amiberry. A single untargeted popup also could not distinguish Native values from RTG values.

## User impact

Native and RTG shader parameters can now be edited, reset, saved, and restored independently from their respective controls. Reset followed by Save removes that target's overrides and returns it to the values declared by the shader.

## Validation

- built the macOS Debug target successfully after rebasing onto the latest `master`
- manually verified the revised Filter layout and unclipped button labels
- saved different values for Native and RTG while both selected the same shader, restarted, and confirmed each popup restored its own value
- reset and saved each target independently, confirming only that target's serialized override was removed
- `git diff --check`
