### PR TITLE
fix(p96): prevent host cursor jump

### DIFF
--- a/src/include/amiberry_cursor.h
+++ b/src/include/amiberry_cursor.h
@@ -25,12 +25,19 @@ static inline std::uint32_t amiberry_cursor_rgba32_from_rgb24(std::uint32_t rgb)
 #endif
 }
 
-static inline int amiberry_cursor_hotspot_from_offset(int hotspot_offset, int extent)
+static inline int amiberry_cursor_hotspot_from_p96_offset(std::uint8_t raw_pointer_offset, int extent)
 {
 	if (extent <= 0) {
 		return 0;
 	}
 
+	// P96 stores this displacement in an unsigned BoardInfo byte, but applies
+	// it as a signed BYTE when positioning the sprite. SDL instead expects the
+	// hotspot's positive offset from the cursor bitmap's top-left corner.
+	const int pointer_offset = raw_pointer_offset & 0x80
+		? static_cast<int>(raw_pointer_offset) - 0x100
+		: static_cast<int>(raw_pointer_offset);
+	const int hotspot_offset = -pointer_offset;
 	if (hotspot_offset < 0) {
 		return 0;
 	}

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -2376,8 +2376,8 @@ static int createwindowscursor(int monid, int set, int chipset)
 		}
 	} else {
 		reset_native_cursor_hotspot_tracker();
-		hotspot_x = amiberry_cursor_hotspot_from_offset(cursorxoffset, w);
-		hotspot_y = amiberry_cursor_hotspot_from_offset(cursoryoffset, h);
+		hotspot_x = amiberry_cursor_hotspot_from_p96_offset(cursorxoffset, w);
+		hotspot_y = amiberry_cursor_hotspot_from_p96_offset(cursoryoffset, h);
 
 		// Track pending shapes independently from the SDL cursor that is still
 		// displayed. Bitmap, colors, and declared offsets all identify a P96 cursor.
@@ -2706,8 +2706,9 @@ static uae_u32 setspriteimage(TrapContext *ctx, uaecptr bi)
 	bpp = 4;
 	w = trap_get_byte(ctx, bi + PSSO_BoardInfo_MouseWidth);
 	h = trap_get_byte(ctx, bi + PSSO_BoardInfo_MouseHeight);
-	// P96 declares these BoardInfo fields as UBYTE. Some versions leave them
-	// zero, in which case the live pointer-to-sprite tracker supplies the hotspot.
+	// P96 stores these fields as UBYTE but interprets them as signed BYTE
+	// displacements. Keep the raw byte here; hotspot conversion sign-extends it.
+	// Some versions leave them zero, in which case the live tracker can refine it.
 	cursorxoffset = trap_get_byte(ctx, bi + PSSO_BoardInfo_MouseXOffset);
 	cursoryoffset = trap_get_byte(ctx, bi + PSSO_BoardInfo_MouseYOffset);
 	flags = trap_get_long(ctx, bi + PSSO_BoardInfo_Flags);

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -75,14 +75,31 @@ static void test_rgba32_cursor_pixels_use_raw_rgb_order()
 
 static void test_rtg_cursor_hotspot_uses_pointer_offset()
 {
-	expect_int_eq(amiberry_cursor_hotspot_from_offset(25, 51), 25,
-		"centered P96 cursor x offset must become the SDL hotspot");
-	expect_int_eq(amiberry_cursor_hotspot_from_offset(30, 61), 30,
-		"centered P96 cursor y offset must become the SDL hotspot");
-	expect_int_eq(amiberry_cursor_hotspot_from_offset(-4, 16), 0,
-		"negative P96 cursor offset must clamp to the first pixel");
-	expect_int_eq(amiberry_cursor_hotspot_from_offset(80, 16), 15,
-		"oversized P96 cursor offset must clamp to the last pixel");
+	expect_int_eq(amiberry_cursor_hotspot_from_p96_offset(0xe7, 51), 25,
+		"signed -25 P96 x displacement must become hotspot 25");
+	expect_int_eq(amiberry_cursor_hotspot_from_p96_offset(0xe2, 61), 30,
+		"signed -30 P96 y displacement must become hotspot 30");
+	expect_int_eq(amiberry_cursor_hotspot_from_p96_offset(0xff, 32), 1,
+		"signed -1 P96 displacement must not clamp to the far cursor edge");
+	expect_int_eq(amiberry_cursor_hotspot_from_p96_offset(0, 16), 0,
+		"zero P96 displacement must keep a top-left hotspot");
+	expect_int_eq(amiberry_cursor_hotspot_from_p96_offset(4, 16), 0,
+		"positive P96 displacement must clamp to the first pixel");
+	expect_int_eq(amiberry_cursor_hotspot_from_p96_offset(0x80, 16), 15,
+		"oversized negative P96 displacement must clamp to the last pixel");
+
+	int hotspot_x = amiberry_cursor_hotspot_from_p96_offset(0xe7, 51);
+	int hotspot_y = amiberry_cursor_hotspot_from_p96_offset(0xe2, 61);
+	amiberry_input_cursor_hotspot_tracker tracker;
+	for (int i = 0; i < 3; i++) {
+		amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+			300 + i * 4, 220 + i * 4, 275 + i * 4, 190 + i * 4,
+			51, 61, 3, &hotspot_x, &hotspot_y);
+	}
+	expect_int_eq(hotspot_x, 25,
+		"learned P96 x hotspot must not correct an already decoded offset later");
+	expect_int_eq(hotspot_y, 30,
+		"learned P96 y hotspot must not correct an already decoded offset later");
 }
 
 static void test_host_only_forces_separate_rtg_sprite()


### PR DESCRIPTION
## Summary

- decode P96 cursor offsets as signed byte displacements
- derive the correct SDL hotspot before the delayed tracker completes
- cover signed offsets and tracker consistency with regression tests

## Root cause

P96 stores `MouseXOffset` and `MouseYOffset` in unsigned `BoardInfo` bytes but applies them as signed displacements. A raw value such as `0xff` was initially clamped to the far edge of a 32-pixel cursor. After three stable samples, the live tracker corrected the hotspot to pixel 1 and replaced the cursor while it was moving, producing the visible jump from issue #2135.

Converting the signed displacement to the SDL hotspot immediately keeps the declared and learned hotspots consistent, so the later tracker update no longer repositions the cursor.

## Testing

- `sh tests/test_cursor_pixel_format.sh`
- `tests/test_gfx_geometry.sh`
- `cmake --build build --parallel`
- `git diff --check`

Refs #2135