### PR TITLE
Fix theme, RP9, and shader settings

### DIFF
--- a/cmake/SourceFiles.cmake
+++ b/cmake/SourceFiles.cmake
@@ -368,6 +368,7 @@ set(IMGUI_GUI_FILES
 		src/osdep/imgui/rom.cpp
 		src/osdep/imgui/rtg.cpp
 		src/osdep/imgui/savestates.cpp
+		src/osdep/imgui/shader_catalog.cpp
 		src/osdep/imgui/sound.cpp
 		src/osdep/imgui/themes.cpp
 		src/osdep/imgui/virtualkeyboard.cpp

--- a/libretro/libretro_stubs.cpp
+++ b/libretro/libretro_stubs.cpp
@@ -430,9 +430,10 @@ void load_default_dark_theme()
 {
 }
 
-void save_theme(const std::string& theme_filename)
+bool save_theme(const std::string& theme_filename)
 {
 	(void)theme_filename;
+	return false;
 }
 
 struct libretro_rom_scan_candidate

--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -1941,7 +1941,7 @@ std::string get_system_fonts_path()
 	return path;
 }
 
-void save_theme(const std::string& theme_filename)
+bool save_theme(const std::string& theme_filename)
 {
 	std::string filename = get_themes_path();
 	filename.append(theme_filename);
@@ -1970,7 +1970,9 @@ void save_theme(const std::string& theme_filename)
 		write_color("background_color", gui_theme.background_color);
 		write_color("foreground_color", gui_theme.foreground_color);
 		file_output.close();
+		return !file_output.fail();
 	}
+	return false;
 }
 
 void load_theme(const std::string& theme_filename)

--- a/src/osdep/gui/gui_handling.h
+++ b/src/osdep/gui/gui_handling.h
@@ -528,7 +528,7 @@ extern void clear_whdload_prefs();
 extern void create_startup_sequence();
 
 extern std::vector<int> parse_color_string(const std::string& input);
-extern void save_theme(const std::string& theme_filename);
+extern bool save_theme(const std::string& theme_filename);
 extern void load_theme(const std::string& theme_filename);
 extern void load_default_theme();
 extern void load_default_dark_theme();

--- a/src/osdep/imgui/filter.cpp
+++ b/src/osdep/imgui/filter.cpp
@@ -5,6 +5,7 @@
 #include "gui/gui_handling.h"
 #include "amiberry_gfx.h"
 #include "target.h"
+#include "shader_catalog.h"
 #include <algorithm>
 #include <filesystem>
 #include <vector>
@@ -16,9 +17,6 @@
 #include "shader_preset.h"
 #include "opengl_renderer.h"
 #endif
-
-// Built-in shader names
-static const char* builtin_shaders[] = { "none", "tv", "pc", "lite", "1084" };
 
 // Bezel list storage
 static std::vector<std::string> bezel_names;
@@ -70,77 +68,14 @@ static int find_bezel_index(const char* bezel_name)
 	return 0; // Default to "none"
 }
 
-// Shader list storage
-static std::vector<std::string> shader_names;
-static std::vector<const char*> shader_items;
-static bool shaders_initialized = false;
-
-// Scan for available shaders (built-in + .glsl + .glslp files)
-static void scan_shaders()
-{
-	shader_names.clear();
-	shader_items.clear();
-
-	// Add built-in shaders first
-	for (auto & builtin_shader : builtin_shaders) {
-		shader_names.emplace_back(builtin_shader);
-	}
-
-	// Scan shaders directory for shader files:
-	// - .glsl files: top-level only (user's custom single-pass shaders)
-	// - .glslp presets: recursively (e.g. crt/crt-aperture.glslp)
-	std::string shaders_dir = get_shaders_path();
-	if (!shaders_dir.empty()) {
-		namespace fs = std::filesystem;
-		fs::path base_path(shaders_dir);
-		try {
-			for (const auto& entry : fs::recursive_directory_iterator(base_path,
-				fs::directory_options::skip_permission_denied)) {
-				if (!entry.is_regular_file()) continue;
-
-				std::string filename = entry.path().filename().string();
-				bool is_glslp = filename.size() > 6 &&
-					filename.substr(filename.size() - 6) == ".glslp";
-				bool is_glsl = !is_glslp && filename.size() > 5 &&
-					filename.substr(filename.size() - 5) == ".glsl";
-
-				if (!is_glsl && !is_glslp) continue;
-
-				fs::path rel = fs::relative(entry.path(), base_path);
-
-				// For .glsl files, only include those at the top level
-				// (subdirectory .glsl files are shader components, not standalone)
-				if (is_glsl && !rel.parent_path().empty()) continue;
-
-				// Store path relative to shaders base dir
-				std::string rel_str = rel.generic_string(); // use forward slashes
-				shader_names.push_back(rel_str);
-			}
-		} catch (...) {
-			// Directory doesn't exist or can't be read - ignore
-		}
-	}
-
-	// Sort external shaders alphabetically (after built-in shaders)
-	std::sort(shader_names.begin() + 5, shader_names.end());
-
-	// Build const char* array for ImGui
-	for (const auto& name : shader_names) {
-		shader_items.push_back(name.c_str());
-	}
-
-	shaders_initialized = true;
-}
-
-// Find index of shader name in list
-static int find_shader_index(const char* shader_name)
+static int find_shader_index(const std::vector<std::string>& shader_names, const char* shader_name)
 {
 	for (size_t i = 0; i < shader_names.size(); i++) {
 		if (shader_names[i] == shader_name) {
 			return static_cast<int>(i);
 		}
 	}
-	return 0;  // Default to "none"
+	return -1;
 }
 
 static bool show_shader_params_popup = false;
@@ -248,10 +183,7 @@ void render_panel_filter()
 	ImGui::Indent(4.0f);
 	const float spacing = ImGui::GetStyle().ItemSpacing.x;
 
-	// Initialize shader list on first call
-	if (!shaders_initialized) {
-		scan_shaders();
-	}
+	const auto& shader_names = get_available_shader_names();
 
 	BeginGroupBox("Crop and Offset");
 	if (changed_prefs.gfx_manual_crop) ImGui::BeginDisabled();
@@ -320,13 +252,15 @@ void render_panel_filter()
 	// Native Shader Selection
 	BeginGroupBox("Native Display Shader");
 	{
-		int native_idx = find_shader_index(changed_prefs.shader);
+		const int native_idx = find_shader_index(shader_names, changed_prefs.shader);
+		const char* native_preview = native_idx >= 0
+			? shader_names[native_idx].c_str() : changed_prefs.shader;
 		const float native_label_w = ImGui::CalcTextSize("Shader for native Amiga modes").x;
 		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - native_label_w - spacing * 3);
-		if (ImGui::BeginCombo("##NativeShader", shader_items[native_idx])) {
-			for (int i = 0; i < static_cast<int>(shader_items.size()); i++) {
+		if (ImGui::BeginCombo("##NativeShader", native_preview)) {
+			for (int i = 0; i < static_cast<int>(shader_names.size()); i++) {
 				bool is_selected = (i == native_idx);
-				if (ImGui::Selectable(shader_items[i], is_selected)) {
+				if (ImGui::Selectable(shader_names[i].c_str(), is_selected)) {
 					strncpy(changed_prefs.shader, shader_names[i].c_str(),
 							sizeof(changed_prefs.shader) - 1);
 					changed_prefs.shader[sizeof(changed_prefs.shader) - 1] = '\0';
@@ -355,13 +289,15 @@ void render_panel_filter()
 	// RTG Shader Selection
 	BeginGroupBox("RTG Display Shader");
 	{
-		int rtg_idx = find_shader_index(changed_prefs.shader_rtg);
+		const int rtg_idx = find_shader_index(shader_names, changed_prefs.shader_rtg);
+		const char* rtg_preview = rtg_idx >= 0
+			? shader_names[rtg_idx].c_str() : changed_prefs.shader_rtg;
 		const float rtg_label_w = ImGui::CalcTextSize("Shader for RTG/Picasso modes").x;
 		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - rtg_label_w - spacing * 3);
-		if (ImGui::BeginCombo("##RTGShader", shader_items[rtg_idx])) {
-			for (int i = 0; i < static_cast<int>(shader_items.size()); i++) {
+		if (ImGui::BeginCombo("##RTGShader", rtg_preview)) {
+			for (int i = 0; i < static_cast<int>(shader_names.size()); i++) {
 				bool is_selected = (i == rtg_idx);
-				if (ImGui::Selectable(shader_items[i], is_selected)) {
+				if (ImGui::Selectable(shader_names[i].c_str(), is_selected)) {
 					strncpy(changed_prefs.shader_rtg, shader_names[i].c_str(),
 							sizeof(changed_prefs.shader_rtg) - 1);
 					changed_prefs.shader_rtg[sizeof(changed_prefs.shader_rtg) - 1] = '\0';
@@ -445,7 +381,7 @@ void render_panel_filter()
 
 	// Rescan button
 	if (AmigaButton(ICON_FA_ARROWS_ROTATE " Rescan Shaders & Bezels", ImVec2(BUTTON_WIDTH * 2.0f, BUTTON_HEIGHT))) {
-		shaders_initialized = false;  // Force rescan on next frame
+		invalidate_shader_catalog();
 		bezels_initialized = false;
 	}
 	ImGui::SameLine();

--- a/src/osdep/imgui/global_settings.cpp
+++ b/src/osdep/imgui/global_settings.cpp
@@ -12,6 +12,7 @@
 #include "registry.h"
 #include "target.h"
 #include "gui/gui_handling.h"
+#include "shader_catalog.h"
 
 namespace {
 
@@ -105,6 +106,33 @@ static bool render_string_combo_row(const char* label, char* value, const size_t
 				strncpy(value, options[i].value, value_size - 1);
 				value[value_size - 1] = '\0';
 				current_index = i;
+				changed = true;
+			}
+			if (selected)
+				ImGui::SetItemDefaultFocus();
+		}
+		ImGui::EndCombo();
+	}
+	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActive());
+	finish_setting_row(help);
+	return changed;
+}
+
+static bool render_shader_combo_row(const char* label, char* value, const size_t value_size,
+	const char* help)
+{
+	next_setting_row(label);
+	const auto& shader_names = get_available_shader_names();
+	const char* preview = value[0] ? value : "none";
+
+	bool changed = false;
+	ImGui::SetNextItemWidth(-1.0f);
+	if (ImGui::BeginCombo("##value", preview)) {
+		for (const auto& shader_name : shader_names) {
+			const bool selected = strcmp(shader_name.c_str(), value) == 0;
+			if (ImGui::Selectable(shader_name.c_str(), selected)) {
+				strncpy(value, shader_name.c_str(), value_size - 1);
+				value[value_size - 1] = '\0';
 				changed = true;
 			}
 			if (selected)
@@ -424,10 +452,10 @@ void render_panel_global_settings()
 		render_string_row("GUI theme", amiberry_options.gui_theme,
 			sizeof amiberry_options.gui_theme,
 			"Theme file loaded by the ImGui interface.");
-		render_string_row("Native shader", amiberry_options.shader,
+		render_shader_combo_row("Native shader", amiberry_options.shader,
 			sizeof amiberry_options.shader,
 			"Default shader preset for native chipset modes. Use none to disable.");
-		render_string_row("RTG shader", amiberry_options.shader_rtg,
+		render_shader_combo_row("RTG shader", amiberry_options.shader_rtg,
 			sizeof amiberry_options.shader_rtg,
 			"Default shader preset for RTG modes. Use none to disable.");
 		render_bool_row("Use bezel", &amiberry_options.use_bezel,

--- a/src/osdep/imgui/paths.cpp
+++ b/src/osdep/imgui/paths.cpp
@@ -556,6 +556,7 @@ void render_panel_paths()
 		RenderPathRow("Floppies:", "FloppiesPath", get_floppy_path(), [](const std::string& p) { set_floppy_path(p); });
 		RenderPathRow("CD-ROMs:", "CDROMPath", get_cdrom_path(), [](const std::string& p) { set_cdrom_path(p); });
 		RenderPathRow("Hard drives:", "HDDPath", get_harddrive_path(), [](const std::string& p) { set_harddrive_path(p); });
+		RenderPathRow("RP9 packages:", "RP9Path", get_rp9_path(), [](const std::string& p) { set_rp9_path(p); });
 		RenderPathRow("Screenshots:", "ScreenshotsPath", get_screenshot_path(), [](const std::string& p) { set_screenshot_path(p); });
 
 		get_savestate_path(tmp, MAX_DPATH);

--- a/src/osdep/imgui/play.cpp
+++ b/src/osdep/imgui/play.cpp
@@ -794,6 +794,8 @@ void render_display_defaults()
 		display_defaults.shader = static_cast<PlayShaderChoice>(shader);
 		apply_display_defaults_to_changed_prefs();
 	}
+	ShowHelpMarker("This Play choice is applied after content auto-configuration, including WHDLoad. "
+		"Custom preserves the native and RTG shader names selected in Display or Global Settings.");
 
 	ImGui::Spacing();
 	if (AmigaButton("Apply now", ImVec2(BUTTON_WIDTH * 1.2f, BUTTON_HEIGHT)))

--- a/src/osdep/imgui/shader_catalog.cpp
+++ b/src/osdep/imgui/shader_catalog.cpp
@@ -1,0 +1,70 @@
+#include "shader_catalog.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <iterator>
+
+std::string get_shaders_path();
+
+namespace {
+
+constexpr const char* builtin_shaders[] = { "none", "tv", "pc", "lite", "1084" };
+
+std::vector<std::string> shader_names;
+std::string scanned_shaders_path;
+bool shader_catalog_initialized = false;
+
+void scan_shaders()
+{
+	shader_names.clear();
+	for (const auto* builtin_shader : builtin_shaders)
+		shader_names.emplace_back(builtin_shader);
+
+	scanned_shaders_path = get_shaders_path();
+	if (!scanned_shaders_path.empty()) {
+		namespace fs = std::filesystem;
+		const fs::path base_path(scanned_shaders_path);
+		try {
+			for (const auto& entry : fs::recursive_directory_iterator(base_path,
+				fs::directory_options::skip_permission_denied)) {
+				if (!entry.is_regular_file())
+					continue;
+
+				const std::string filename = entry.path().filename().string();
+				const bool is_glslp = filename.size() > 6
+					&& filename.substr(filename.size() - 6) == ".glslp";
+				const bool is_glsl = !is_glslp && filename.size() > 5
+					&& filename.substr(filename.size() - 5) == ".glsl";
+				if (!is_glsl && !is_glslp)
+					continue;
+
+				const fs::path relative_path = fs::relative(entry.path(), base_path);
+				if (is_glsl && !relative_path.parent_path().empty())
+					continue;
+
+				shader_names.push_back(relative_path.generic_string());
+			}
+		}
+		catch (...) {
+			// A missing or unreadable shader directory simply contributes no presets.
+		}
+	}
+
+	std::sort(shader_names.begin() + std::size(builtin_shaders), shader_names.end());
+	shader_names.erase(std::unique(shader_names.begin(), shader_names.end()), shader_names.end());
+	shader_catalog_initialized = true;
+}
+
+} // namespace
+
+const std::vector<std::string>& get_available_shader_names()
+{
+	if (!shader_catalog_initialized || scanned_shaders_path != get_shaders_path())
+		scan_shaders();
+	return shader_names;
+}
+
+void invalidate_shader_catalog()
+{
+	shader_catalog_initialized = false;
+}

--- a/src/osdep/imgui/shader_catalog.h
+++ b/src/osdep/imgui/shader_catalog.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+const std::vector<std::string>& get_available_shader_names();
+void invalidate_shader_catalog();

--- a/src/osdep/imgui/themes.cpp
+++ b/src/osdep/imgui/themes.cpp
@@ -24,6 +24,7 @@ static bool s_themes_initialized = false;
 static char s_save_as_name[128] = "";
 static bool s_open_save_as_popup = false;
 static bool s_font_changed = false;
+static bool s_theme_modified = false;
 
 // Font input buffer (sized for absolute paths)
 static char s_font_name_buf[512] = "";
@@ -121,6 +122,7 @@ static void load_selected_theme()
 	strncpy(s_font_name_buf, gui_theme.font_name.c_str(), sizeof(s_font_name_buf) - 1);
 	s_font_name_buf[sizeof(s_font_name_buf) - 1] = '\0';
 	s_font_changed = false;
+	s_theme_modified = false;
 }
 
 struct FontEntry {
@@ -243,6 +245,7 @@ void render_panel_themes()
 		strncpy(s_font_name_buf, gui_theme.font_name.c_str(), sizeof(s_font_name_buf) - 1);
 		s_font_name_buf[sizeof(s_font_name_buf) - 1] = '\0';
 		s_font_changed = false;
+		s_theme_modified = false;
 		strncpy(s_synced_theme, amiberry_options.gui_theme, sizeof(s_synced_theme) - 1); s_synced_theme[sizeof(s_synced_theme) - 1] = '\0';
 		s_themes_initialized = true;
 	}
@@ -264,6 +267,7 @@ void render_panel_themes()
 		strncpy(s_font_name_buf, gui_theme.font_name.c_str(), sizeof(s_font_name_buf) - 1);
 		s_font_name_buf[sizeof(s_font_name_buf) - 1] = '\0';
 		s_font_changed = false;
+		s_theme_modified = false;
 	}
 
 	ImGui::Indent(4.0f);
@@ -316,6 +320,7 @@ void render_panel_themes()
 	{
 		gui_theme.font_name = s_font_name_buf;
 		s_font_changed = true;
+		s_theme_modified = true;
 	}
 	ImGui::SameLine();
 	if (AmigaButton("...##FontBrowse", ImVec2(browse_btn_w, 0)))
@@ -336,6 +341,7 @@ void render_panel_themes()
 				s_font_name_buf[sizeof(s_font_name_buf) - 1] = '\0';
 				gui_theme.font_name = font_result;
 				s_font_changed = true;
+				s_theme_modified = true;
 			}
 		}
 	}
@@ -353,7 +359,10 @@ void render_panel_themes()
 		if (AmigaButton("+##FontInc") && gui_theme.font_size < 32)
 			gui_theme.font_size++;
 		if (gui_theme.font_size != old_size)
+		{
 			rebuild_gui_fonts();
+			s_theme_modified = true;
+		}
 	}
 
 	if (s_font_changed)
@@ -439,6 +448,7 @@ void render_panel_themes()
 					s_font_name_buf[sizeof(s_font_name_buf) - 1] = '\0';
 					gui_theme.font_name = fe.full_path;
 					s_font_changed = true;
+					s_theme_modified = true;
 				}
 				if (ImGui::IsItemHovered())
 					ImGui::SetTooltip("%s", fe.full_path.c_str());
@@ -522,7 +532,10 @@ void render_panel_themes()
 	}
 
 	if (color_changed)
+	{
 		apply_imgui_theme();
+		s_theme_modified = true;
+	}
 
 	EndGroupBox("Colors");
 
@@ -535,19 +548,36 @@ void render_panel_themes()
 
 	if (AmigaButton(ICON_FA_CHECK " Use", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT)))
 	{
-		strncpy(amiberry_options.gui_theme, current_theme.c_str(),
-			sizeof(amiberry_options.gui_theme) - 1);
-		amiberry_options.gui_theme[sizeof(amiberry_options.gui_theme) - 1] = '\0';
-		strncpy(s_synced_theme, amiberry_options.gui_theme, sizeof(s_synced_theme) - 1); s_synced_theme[sizeof(s_synced_theme) - 1] = '\0';
-		save_amiberry_settings();
+		if (s_theme_modified && is_protected)
+		{
+			ShowMessageBox("Save Theme",
+				"Default.theme and Dark.theme are built-in presets and cannot be overwritten.\n\nUse Save as... to keep these changes.");
+		}
+		else if (!s_theme_modified || save_theme(current_theme))
+		{
+			s_theme_modified = false;
+			strncpy(amiberry_options.gui_theme, current_theme.c_str(),
+				sizeof(amiberry_options.gui_theme) - 1);
+			amiberry_options.gui_theme[sizeof(amiberry_options.gui_theme) - 1] = '\0';
+			strncpy(s_synced_theme, amiberry_options.gui_theme, sizeof(s_synced_theme) - 1); s_synced_theme[sizeof(s_synced_theme) - 1] = '\0';
+			if (!save_amiberry_settings_with_result())
+				ShowMessageBox("Save Theme", "Failed to save the active theme setting.\n\nCheck file permissions in the settings directory.");
+		}
+		else
+		{
+			ShowMessageBox("Save Theme", "Failed to save the theme file.\n\nCheck file permissions in the Themes directory.");
+		}
 	}
-	ShowHelpMarker("Apply the current theme as the active theme");
+	ShowHelpMarker("Make this the active theme and persist edited custom-theme colors and font settings.");
 
 	ImGui::SameLine();
 	if (is_protected) ImGui::BeginDisabled();
 	if (AmigaButton(ICON_FA_FLOPPY_DISK " Save", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT)))
 	{
-		save_theme(current_theme);
+		if (save_theme(current_theme))
+			s_theme_modified = false;
+		else
+			ShowMessageBox("Save Theme", "Failed to save the theme file.\n\nCheck file permissions in the Themes directory.");
 	}
 	if (is_protected) ImGui::EndDisabled();
 	ShowHelpMarker("Overwrite the current custom theme file");
@@ -597,20 +627,22 @@ void render_panel_themes()
 		if (name_invalid) ImGui::BeginDisabled();
 		if (AmigaButton(ICON_FA_FLOPPY_DISK " Save", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT)))
 		{
-			save_theme(save_filename);
-
-			// Only persist if the file was actually written
-			const std::string saved_path = get_themes_path() + save_filename;
-			if (std::filesystem::exists(saved_path))
+			if (save_theme(save_filename))
 			{
+				s_theme_modified = false;
 				strncpy(amiberry_options.gui_theme, save_filename.c_str(),
 					sizeof(amiberry_options.gui_theme) - 1);
 				amiberry_options.gui_theme[sizeof(amiberry_options.gui_theme) - 1] = '\0';
 				strncpy(s_synced_theme, amiberry_options.gui_theme, sizeof(s_synced_theme) - 1); s_synced_theme[sizeof(s_synced_theme) - 1] = '\0';
-				save_amiberry_settings();
+				if (!save_amiberry_settings_with_result())
+					ShowMessageBox("Save Theme", "The theme file was saved, but the active theme setting was not.\n\nCheck file permissions in the settings directory.");
 
 				scan_theme_files();
 				select_theme_by_name(save_filename);
+			}
+			else
+			{
+				ShowMessageBox("Save Theme", "Failed to save the theme file.\n\nCheck file permissions in the Themes directory.");
 			}
 
 			ImGui::CloseCurrentPopup();

--- a/tests/shader_catalog_test.cpp
+++ b/tests/shader_catalog_test.cpp
@@ -1,0 +1,87 @@
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include "imgui/shader_catalog.h"
+
+namespace {
+
+std::string shaders_path;
+int failures;
+
+void expect(const bool condition, const char* message)
+{
+	if (!condition) {
+		std::cerr << message << '\n';
+		failures++;
+	}
+}
+
+bool contains(const std::vector<std::string>& names, const std::string& name)
+{
+	return std::find(names.begin(), names.end(), name) != names.end();
+}
+
+void create_file(const std::filesystem::path& path)
+{
+	std::filesystem::create_directories(path.parent_path());
+	std::ofstream(path).put('\n');
+}
+
+} // namespace
+
+std::string get_shaders_path()
+{
+	return shaders_path;
+}
+
+int main()
+{
+	const auto suffix = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+	const auto root = std::filesystem::temp_directory_path()
+		/ ("amiberry-shader-catalog-" + std::to_string(suffix));
+	const auto alternate_root = root.string() + "-alternate";
+
+	try {
+		create_file(root / "custom.glsl");
+		create_file(root / "crt" / "preset.glslp");
+		create_file(root / "crt" / "component.glsl");
+		create_file(root / "ignored.txt");
+		shaders_path = root.string();
+
+		const auto& names = get_available_shader_names();
+		expect(names.size() >= 7, "Catalog must include built-in and external shaders");
+		expect(names[0] == "none" && names[1] == "tv" && names[2] == "pc"
+			&& names[3] == "lite" && names[4] == "1084",
+			"Built-in shaders must retain their UI order");
+		expect(contains(names, "custom.glsl"), "Top-level GLSL shaders must be listed");
+		expect(contains(names, "crt/preset.glslp"), "Nested GLSLP presets must be listed");
+		expect(!contains(names, "crt/component.glsl"), "Nested GLSL components must not be listed");
+		expect(!contains(names, "ignored.txt"), "Non-shader files must not be listed");
+
+		create_file(root / "new.glslp");
+		expect(!contains(get_available_shader_names(), "new.glslp"),
+			"Catalog must stay cached until invalidated");
+		invalidate_shader_catalog();
+		expect(contains(get_available_shader_names(), "new.glslp"),
+			"Invalidating the catalog must discover new presets");
+
+		create_file(std::filesystem::path(alternate_root) / "alternate.glslp");
+		shaders_path = alternate_root;
+		expect(contains(get_available_shader_names(), "alternate.glslp"),
+			"Changing the shader path must rescan automatically");
+		expect(!contains(get_available_shader_names(), "custom.glsl"),
+			"Changing the shader path must discard the previous catalog");
+	}
+	catch (const std::exception& error) {
+		std::cerr << error.what() << '\n';
+		failures++;
+	}
+
+	std::filesystem::remove_all(root);
+	std::filesystem::remove_all(alternate_root);
+	return failures == 0 ? 0 : 1;
+}

--- a/tests/test_shader_catalog.sh
+++ b/tests/test_shader_catalog.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cxx="${CXX:-c++}"
+out="${TMPDIR:-/tmp}/shader_catalog_test.$$"
+trap 'rm -f "$out"' EXIT
+
+"$cxx" -std=c++17 -Wall -Wextra -Werror \
+	-Isrc -Isrc/osdep \
+	-o "$out" \
+	tests/shader_catalog_test.cpp \
+	src/osdep/imgui/shader_catalog.cpp
+"$out"


### PR DESCRIPTION
## Summary

- Persist edited custom-theme colors and font settings when making a theme active, with clear save-error reporting.
- Expose the RP9 package directory in the Paths panel so non-portable installations can redirect it.
- Share shader discovery between Display and Global Settings, giving Global Settings the same preset dropdown.
- Clarify that Play display choices intentionally apply after WHDLoad/LHA auto-configuration and that Custom preserves configured shader names.

## Root cause

Theme activation saved only the selected filename, while unsaved edits remained in memory. The RP9 backend path already supported persistence but had no row in the Paths UI. Global Settings used free-text shader fields instead of the shader discovery code from Display.

The Play shader precedence is intentional: display defaults are applied after content auto-configuration. The added help text makes that ordering visible without changing behavior.

## User impact

Custom theme edits now survive restart when the theme is activated. RP9 packages no longer have to use the default directory. Shader selection is consistent across settings panels, including discovered GLSL/GLSLP presets.

## Validation

- `cmake --build build --parallel`
- `bash tests/test_shader_catalog.sh`
- `bash tests/test_play_setup.sh`
- `bash tests/test_play_start_logic.sh`
- `bash tests/test_play_use_content_logic.sh`
- `build/Amiberry.app/Contents/MacOS/Amiberry --path-migration-selftest`
- `build/Amiberry.app/Contents/MacOS/Amiberry --dump-paths`
- `git diff --check`
