### PR TITLE
fix(p96): keep declared cursor hotspot stable

### DIFF
--- a/src/include/amiberry_cursor.h
+++ b/src/include/amiberry_cursor.h
@@ -47,6 +47,14 @@ static inline int amiberry_cursor_hotspot_from_p96_offset(std::uint8_t raw_point
 	return hotspot_offset;
 }
 
+static inline bool amiberry_cursor_p96_hotspot_needs_tracking(
+	std::uint8_t raw_x_offset, std::uint8_t raw_y_offset)
+{
+	// A non-zero BoardInfo displacement is authoritative. Live position
+	// sampling is only a fallback for P96 versions that omit both offsets.
+	return raw_x_offset == 0 && raw_y_offset == 0;
+}
+
 static inline bool amiberry_cursor_host_only_enabled(int input_tablet,
 	int input_magic_mouse_cursor, int host_only_cursor_value, bool host_cursor_available)
 {

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -2380,30 +2380,32 @@ static int createwindowscursor(int monid, int set, int chipset)
 		hotspot_x = amiberry_cursor_hotspot_from_p96_offset(cursorxoffset, w);
 		hotspot_y = amiberry_cursor_hotspot_from_p96_offset(cursoryoffset, h);
 
-		// Track pending shapes independently from the SDL cursor that is still
-		// displayed. Bitmap, colors, and declared offsets all identify a P96 cursor.
-		const uae_u64 hotspot_signature = amiberry_input_cursor_hotspot_signature(
-			cursor_signature, cursorxoffset, cursoryoffset);
-		auto* hotspot_tracker = amiberry_input_cursor_hotspot_tracker_cache_acquire(
-			&p96_cursor_hotspot_tracker_cache, w, h, hotspot_signature);
+		if (amiberry_cursor_p96_hotspot_needs_tracking(cursorxoffset, cursoryoffset)) {
+			// Track pending shapes independently from the SDL cursor that is still
+			// displayed when P96 does not provide a usable hotspot.
+			const uae_u64 hotspot_signature = amiberry_input_cursor_hotspot_signature(
+				cursor_signature, cursorxoffset, cursoryoffset);
+			auto* hotspot_tracker = amiberry_input_cursor_hotspot_tracker_cache_acquire(
+				&p96_cursor_hotspot_tracker_cache, w, h, hotspot_signature);
 
-		if (amiberry_input_cursor_hotspot_tracker_sample(hotspot_tracker,
-			pointer_valid, pointer_x, pointer_y,
-			newcursor_x, newcursor_y, w, h, 3, &hotspot_x, &hotspot_y)) {
-			residual_x = 0;
-			residual_y = 0;
-		}
+			if (amiberry_input_cursor_hotspot_tracker_sample(hotspot_tracker,
+				pointer_valid, pointer_x, pointer_y,
+				newcursor_x, newcursor_y, w, h, 3, &hotspot_x, &hotspot_y)) {
+				residual_x = 0;
+				residual_y = 0;
+			}
 
-		const bool cursor_update_needed = !cursor_cache_matches
-			|| hotspot_x != tmp_sprite_hotspot_x || hotspot_y != tmp_sprite_hotspot_y;
-		if (amiberry_input_cursor_hotspot_should_defer_swap(cursor_update_needed,
-			old_cursor && tmp_sprite_chipset == 0, hotspot_tracker)) {
-			SDL_SetCursor(old_cursor);
-			SDL_ShowCursor();
-			input_mousehack_set_host_cursor_uses_hotspot(true,
-				tmp_sprite_residual_x, tmp_sprite_residual_y);
-			wincursor_shown = 1;
-			return 1;
+			const bool cursor_update_needed = !cursor_cache_matches
+				|| hotspot_x != tmp_sprite_hotspot_x || hotspot_y != tmp_sprite_hotspot_y;
+			if (amiberry_input_cursor_hotspot_should_defer_swap(cursor_update_needed,
+				old_cursor && tmp_sprite_chipset == 0, hotspot_tracker)) {
+				SDL_SetCursor(old_cursor);
+				SDL_ShowCursor();
+				input_mousehack_set_host_cursor_uses_hotspot(true,
+					tmp_sprite_residual_x, tmp_sprite_residual_y);
+				wincursor_shown = 1;
+				return 1;
+			}
 		}
 	}
 

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -102,6 +102,18 @@ static void test_rtg_cursor_hotspot_uses_pointer_offset()
 		"learned P96 y hotspot must not correct an already decoded offset later");
 }
 
+static void test_rtg_declared_hotspot_disables_live_tracking()
+{
+	expect_true(!amiberry_cursor_p96_hotspot_needs_tracking(0xff, 0xfe),
+		"declared arrow hotspot must not be revised after the cursor is rendered");
+	expect_true(!amiberry_cursor_p96_hotspot_needs_tracking(0xe7, 0xe2),
+		"declared centered hotspot must not be revised after the cursor is rendered");
+	expect_true(!amiberry_cursor_p96_hotspot_needs_tracking(0, 0xfe),
+		"a declared hotspot on either axis must make the BoardInfo pair authoritative");
+	expect_true(amiberry_cursor_p96_hotspot_needs_tracking(0, 0),
+		"missing P96 offsets must retain live hotspot tracking as a fallback");
+}
+
 static void test_host_only_forces_separate_rtg_sprite()
 {
 	const int host_only = 2;
@@ -435,6 +447,7 @@ int main()
 	test_rgba32_cursor_pixels_are_opaque();
 	test_rgba32_cursor_pixels_use_raw_rgb_order();
 	test_rtg_cursor_hotspot_uses_pointer_offset();
+	test_rtg_declared_hotspot_disables_live_tracking();
 	test_host_only_forces_separate_rtg_sprite();
 	test_rtg_cursor_keeps_softsprite_fallback_disabled();
 	test_native_axis_clamp_uses_native_extent();


### PR DESCRIPTION
## Summary

- keep declared P96 cursor hotspots stable across shape changes
- retain live hotspot learning only when both P96 offsets are missing
- add regression coverage for declared, partial, and missing offsets

## Why

The live pointer-to-sprite tracker could sample a transient sprite position
during a cursor shape change, then overwrite P96's declared hotspot several
frames after the new cursor was rendered. This made a stationary host cursor
jump by roughly one cursor width after the guest redraw.

Treating non-zero BoardInfo offsets as authoritative keeps the hotspot change
synchronized with the cursor image. Older P96 variants that leave both offsets
at zero still use live tracking as a fallback.

Refs #2135

## Testing

- `sh tests/test_cursor_pixel_format.sh`
- `sh tests/test_gfx_geometry.sh`
- `git diff --check`
- `cmake --build build -j8`
