### PR TITLE
Fix native cursor jumps at screen edges

### DIFF
--- a/src/osdep/amiberry_input_helpers.h
+++ b/src/osdep/amiberry_input_helpers.h
@@ -240,6 +240,17 @@ static inline bool amiberry_input_cursor_hotspot_tracker_sample(
 	if (!tracker) {
 		return false;
 	}
+	if (tracker->learned) {
+		// The hotspot belongs to the cursor bitmap, not its current screen
+		// position. Edge-clamped sprite coordinates must not relearn it.
+		if (hotspot_x) {
+			*hotspot_x = tracker->hotspot_x;
+		}
+		if (hotspot_y) {
+			*hotspot_y = tracker->hotspot_y;
+		}
+		return true;
+	}
 
 	const int candidate_x = pointer_x - sprite_x;
 	const int candidate_y = pointer_y - sprite_y;

--- a/src/osdep/amiberry_input_helpers.h
+++ b/src/osdep/amiberry_input_helpers.h
@@ -120,6 +120,14 @@ struct amiberry_input_cursor_hotspot_tracker
 {
 	bool have_sample = false;
 	bool learned = false;
+	bool confirmed_x = false;
+	bool confirmed_y = false;
+	bool candidate_x_moved = false;
+	bool candidate_y_moved = false;
+	int last_pointer_x = 0;
+	int last_pointer_y = 0;
+	int last_sprite_x = 0;
+	int last_sprite_y = 0;
 	int candidate_x = 0;
 	int candidate_y = 0;
 	int stable_samples = 0;
@@ -240,7 +248,7 @@ static inline bool amiberry_input_cursor_hotspot_tracker_sample(
 	if (!tracker) {
 		return false;
 	}
-	if (tracker->learned) {
+	if (tracker->confirmed_x && tracker->confirmed_y) {
 		// The hotspot belongs to the cursor bitmap, not its current screen
 		// position. Edge-clamped sprite coordinates must not relearn it.
 		if (hotspot_x) {
@@ -261,20 +269,47 @@ static inline bool amiberry_input_cursor_hotspot_tracker_sample(
 	if (candidate_valid) {
 		const bool stable = tracker->have_sample
 			&& candidate_x == tracker->candidate_x && candidate_y == tracker->candidate_y;
+		const bool moved_x = stable
+			&& pointer_x != tracker->last_pointer_x && sprite_x != tracker->last_sprite_x;
+		const bool moved_y = stable
+			&& pointer_y != tracker->last_pointer_y && sprite_y != tracker->last_sprite_y;
 
 		tracker->stable_samples = stable ? tracker->stable_samples + 1 : 1;
+		tracker->candidate_x_moved = stable
+			? tracker->candidate_x_moved || moved_x : false;
+		tracker->candidate_y_moved = stable
+			? tracker->candidate_y_moved || moved_y : false;
 		tracker->have_sample = true;
+		tracker->last_pointer_x = pointer_x;
+		tracker->last_pointer_y = pointer_y;
+		tracker->last_sprite_x = sprite_x;
+		tracker->last_sprite_y = sprite_y;
 		tracker->candidate_x = candidate_x;
 		tracker->candidate_y = candidate_y;
 
 		if (tracker->stable_samples >= required_stable_samples) {
-			tracker->learned = true;
-			tracker->hotspot_x = candidate_x;
-			tracker->hotspot_y = candidate_y;
+			if (!tracker->learned) {
+				tracker->learned = true;
+				tracker->hotspot_x = candidate_x;
+				tracker->hotspot_y = candidate_y;
+			}
+			// Stationary samples provide a provisional hotspot, but only
+			// coordinated movement can replace and confirm an axis. A clamped
+			// sprite cannot follow pointer movement along that axis.
+			if (!tracker->confirmed_x && tracker->candidate_x_moved) {
+				tracker->hotspot_x = candidate_x;
+				tracker->confirmed_x = true;
+			}
+			if (!tracker->confirmed_y && tracker->candidate_y_moved) {
+				tracker->hotspot_y = candidate_y;
+				tracker->confirmed_y = true;
+			}
 		}
 	} else {
 		tracker->have_sample = false;
 		tracker->stable_samples = 0;
+		tracker->candidate_x_moved = false;
+		tracker->candidate_y_moved = false;
 	}
 
 	if (tracker->learned) {

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -400,10 +400,13 @@ static void test_native_cursor_hotspot_learning_stays_stable_at_edges()
 
 	for (int i = 0; i < 3; i++) {
 		amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
-			300, 220, 275, 190, 51, 61, 3, &hotspot_x, &hotspot_y);
+			300 + i * 2, 220 + i * 2, 275 + i * 2, 190 + i * 2,
+			51, 61, 3, &hotspot_x, &hotspot_y);
 	}
 	expect_int_eq(hotspot_x, 25, "tracker must learn the centered x hotspot");
 	expect_int_eq(hotspot_y, 30, "tracker must learn the centered y hotspot");
+	expect_true(tracker.confirmed_x && tracker.confirmed_y,
+		"coordinated interior movement must confirm both hotspot axes");
 
 	// A slowly crossed screen edge can leave the guest sprite clamped for
 	// several samples while the host pointer continues moving. This is not a
@@ -416,6 +419,36 @@ static void test_native_cursor_hotspot_learning_stays_stable_at_edges()
 		"edge-clamped samples must not replace a learned x hotspot");
 	expect_int_eq(hotspot_y, 30,
 		"edge-clamped samples must not replace a learned y hotspot");
+}
+
+static void test_native_cursor_hotspot_learning_recovers_from_initial_edge()
+{
+	amiberry_input_cursor_hotspot_tracker tracker;
+	int hotspot_x = -1;
+	int hotspot_y = -1;
+
+	// The cursor first appears at the top edge and only moves horizontally.
+	// Its x displacement is reliable, but its clamped y displacement is not.
+	for (int i = 0; i < 3; i++) {
+		amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+			300 + i * 2, 220, 275 + i * 2, 220,
+			51, 61, 3, &hotspot_x, &hotspot_y);
+	}
+	expect_int_eq(hotspot_x, 25, "edge-learned x hotspot must be available provisionally");
+	expect_int_eq(hotspot_y, 0, "edge-learned y hotspot must be available provisionally");
+	expect_true(tracker.confirmed_x, "horizontal edge movement must confirm the x hotspot");
+	expect_true(!tracker.confirmed_y, "horizontal edge movement must not confirm the clamped y hotspot");
+
+	// Coordinated vertical movement in the interior supplies reliable samples
+	// for the axis that was previously clamped.
+	for (int i = 0; i < 3; i++) {
+		amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+			304, 224 + i * 2, 279, 194 + i * 2,
+			51, 61, 3, &hotspot_x, &hotspot_y);
+	}
+	expect_int_eq(hotspot_x, 25, "interior movement must retain the learned x hotspot");
+	expect_int_eq(hotspot_y, 30, "interior movement must recover an edge-learned y hotspot");
+	expect_true(tracker.confirmed_y, "vertical interior movement must confirm the recovered y hotspot");
 }
 
 static void test_p96_cursor_swap_waits_for_stable_hotspot()
@@ -489,6 +522,7 @@ int main()
 	test_native_cursor_bitmap_signature_includes_pixels_and_colors();
 	test_native_cursor_hotspot_learning_keeps_last_valid_result();
 	test_native_cursor_hotspot_learning_stays_stable_at_edges();
+	test_native_cursor_hotspot_learning_recovers_from_initial_edge();
 	test_p96_cursor_swap_waits_for_stable_hotspot();
 	test_native_crosshair_hotspot_snaps_to_bitmap_intersection();
 	return failures == 0 ? 0 : 1;

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -392,6 +392,32 @@ static void test_native_cursor_hotspot_learning_keeps_last_valid_result()
 	expect_true(!tracker.learned, "reset must discard a hotspot learned for old cursor dimensions");
 }
 
+static void test_native_cursor_hotspot_learning_stays_stable_at_edges()
+{
+	amiberry_input_cursor_hotspot_tracker tracker;
+	int hotspot_x = -1;
+	int hotspot_y = -1;
+
+	for (int i = 0; i < 3; i++) {
+		amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+			300, 220, 275, 190, 51, 61, 3, &hotspot_x, &hotspot_y);
+	}
+	expect_int_eq(hotspot_x, 25, "tracker must learn the centered x hotspot");
+	expect_int_eq(hotspot_y, 30, "tracker must learn the centered y hotspot");
+
+	// A slowly crossed screen edge can leave the guest sprite clamped for
+	// several samples while the host pointer continues moving. This is not a
+	// new hotspot for the same cursor bitmap.
+	for (int i = 0; i < 3; i++) {
+		amiberry_input_cursor_hotspot_tracker_sample(&tracker, true,
+			300, 220, 275, 220, 51, 61, 3, &hotspot_x, &hotspot_y);
+	}
+	expect_int_eq(hotspot_x, 25,
+		"edge-clamped samples must not replace a learned x hotspot");
+	expect_int_eq(hotspot_y, 30,
+		"edge-clamped samples must not replace a learned y hotspot");
+}
+
 static void test_p96_cursor_swap_waits_for_stable_hotspot()
 {
 	amiberry_input_cursor_hotspot_tracker tracker;
@@ -462,6 +488,7 @@ int main()
 	test_native_cursor_hotspot_cache_separates_same_size_bitmaps();
 	test_native_cursor_bitmap_signature_includes_pixels_and_colors();
 	test_native_cursor_hotspot_learning_keeps_last_valid_result();
+	test_native_cursor_hotspot_learning_stays_stable_at_edges();
 	test_p96_cursor_swap_waits_for_stable_hotspot();
 	test_native_crosshair_hotspot_snaps_to_bitmap_intersection();
 	return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

- keep motion-confirmed cursor hotspot axes stable for each cached bitmap
- let a cursor first seen at an edge recover a provisional clamped axis after reliable interior movement
- add regressions for both edge stability and edge-first recovery

## Root cause

The hotspot tracker treated every repeated pointer-to-sprite delta as equally reliable. Near a native screen edge, the guest sprite can remain clamped while the host pointer continues moving, so slow movement could replace the correct hotspot with a distorted delta and make SDL recreate the cursor at a shifted position.

Stationary samples now provide only a provisional value. Coordinated pointer and sprite movement confirms each axis independently; confirmed axes remain immutable, while an unconfirmed edge-clamped axis can recover later.

## Testing

- `sh tests/test_cursor_pixel_format.sh`
- `sh tests/test_gfx_geometry.sh`
- `git diff --check`
- `cmake --build build -j8`

Refs #2135
