### PR TITLE
fix(zz9000): translate VRAM for ARM64 JIT

### DIFF
--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -3679,6 +3679,13 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
                 uae_u32 opcode = DO_GET_OPCODE(pc_hist[i].location);
                 needed_flags = (liveflags[i + 1] & prop[opcode].set_flags);
                 special_mem = pc_hist[i].specmem;
+#if defined(CPU_AARCH64)
+                /* Runtime data addresses can enter an indirect bank even when
+                 * instruction history has no special-memory marker. Keep native
+                 * multi-access operations on bounded per-access helpers. */
+                if (unsafe_compile_fallbacks)
+                    special_mem |= S_READ | S_WRITE | S_N_ADDR;
+#endif
                 if (!needed_flags && currprefs.compnf) {
 #ifdef NOFLAGS_SUPPORT_GENCOMP
                     cputbl = nfcpufunctbl;

--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -195,6 +195,18 @@ static inline bool jit_use_compile_fallbacks(void)
 {
     return jit_n_addr_bank_unsafe;
 }
+
+static inline bool jit_opcode_needs_compile_fallback(uae_u32 opcode)
+{
+    switch (table68k[opcode].mnemo) {
+        case i_MVMEL:
+        case i_MVMLE:
+        case i_MOVE16:
+            return true;
+        default:
+            return false;
+    }
+}
 #endif
 
 //#if DEBUG
@@ -3682,8 +3694,9 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
 #if defined(CPU_AARCH64)
                 /* Runtime data addresses can enter an indirect bank even when
                  * instruction history has no special-memory marker. Keep native
-                 * multi-access operations on bounded per-access helpers. */
-                if (unsafe_compile_fallbacks)
+                 * multi-access operations on bounded per-access helpers without
+                 * disabling unrelated opcode compilers such as the FPU JIT. */
+                if (unsafe_compile_fallbacks && jit_opcode_needs_compile_fallback(opcode))
                     special_mem |= S_READ | S_WRITE | S_N_ADDR;
 #endif
                 if (!needed_flags && currprefs.compnf) {

--- a/src/zz9000.cpp
+++ b/src/zz9000.cpp
@@ -426,10 +426,10 @@ static uae_u8 *REGPARAM2 zz9000_xlate(uaecptr addr)
 {
 	zz9000_state *data = zz_find_board(addr);
 	if (!data)
-		return nullptr;
+		return default_xlate(addr);
 	const uae_u32 offset = addr - data->configured;
 	if (offset < ZZ9000_MEMORY_BASE || offset >= data->card_size)
-		return nullptr;
+		return default_xlate(addr);
 	/* Callers using a translated pointer bypass the byte/word/long bank
 	 * handlers, so conservatively flag VRAM as changed for display refresh. */
 	data->modified = true;

--- a/src/zz9000.cpp
+++ b/src/zz9000.cpp
@@ -236,13 +236,18 @@ static uae_u32 REGPARAM2 zz9000_bget(uaecptr addr);
 static void REGPARAM2 zz9000_lput(uaecptr addr, uae_u32 value);
 static void REGPARAM2 zz9000_wput(uaecptr addr, uae_u32 value);
 static void REGPARAM2 zz9000_bput(uaecptr addr, uae_u32 value);
+static int REGPARAM2 zz9000_check(uaecptr addr, uae_u32 size);
+static uae_u8 *REGPARAM2 zz9000_xlate(uaecptr addr);
 
 static addrbank zz9000_bank = {
 	zz9000_lget, zz9000_wget, zz9000_bget,
 	zz9000_lput, zz9000_wput, zz9000_bput,
-	default_xlate, default_check, nullptr, nullptr, _T("ZZ9000"),
+	zz9000_xlate, zz9000_check, nullptr, nullptr, _T("ZZ9000"),
 	zz9000_lget, zz9000_wget,
-	ABFLAG_IO, S_READ, S_WRITE
+	/* ZZ9000 VRAM lives in the board's private allocation, not at its
+	 * natmem address. Force JIT accesses through the bank translation and
+	 * helpers instead of replaying faulting direct accesses. */
+	ABFLAG_IO, S_READ | S_N_ADDR, S_WRITE | S_N_ADDR
 };
 
 static inline uae_u16 zz_bswap16(uae_u16 value)
@@ -405,6 +410,30 @@ static zz9000_state *zz_find_board(uaecptr addr)
 			return data;
 	}
 	return nullptr;
+}
+
+static int REGPARAM2 zz9000_check(uaecptr addr, uae_u32 size)
+{
+	zz9000_state *data = zz_find_board(addr);
+	if (!data)
+		return 0;
+	const uae_u32 offset = addr - data->configured;
+	return offset >= ZZ9000_MEMORY_BASE && offset < data->card_size &&
+		size <= data->card_size - offset;
+}
+
+static uae_u8 *REGPARAM2 zz9000_xlate(uaecptr addr)
+{
+	zz9000_state *data = zz_find_board(addr);
+	if (!data)
+		return nullptr;
+	const uae_u32 offset = addr - data->configured;
+	if (offset < ZZ9000_MEMORY_BASE || offset >= data->card_size)
+		return nullptr;
+	/* Callers using a translated pointer bypass the byte/word/long bank
+	 * handlers, so conservatively flag VRAM as changed for display refresh. */
+	data->modified = true;
+	return data->memory + offset;
 }
 
 static uae_u32 zz_apply_minterm(uae_u32 source, uae_u32 destination, int minterm)


### PR DESCRIPTION
## Summary

- add bounded address translation for the ZZ9000 private VRAM allocation
- route JIT native-address accesses through the address bank helpers
- preserve RTG refresh tracking for translated VRAM accesses

## Root cause

ZZ9000 VRAM is allocated privately and is not backed by its natmem address. ARM64 JIT bulk-copy code could access the natmem address directly and rely on signal-handler replay. The affected p96cts copy paths consequently produced an all-zero backdrop with JIT enabled, while disabling JIT passed.

## Impact

ZZ9000 RTG workloads using native-address operations, including the p96cts backdrop upload and readback paths, now use the board VRAM allocation directly and safely.

No ZZ9000 driver or firmware changes are required.

## Validation

- macOS ARM64 build: cmake --build build --parallel 8
- booted the A4000 configuration into 1280x1024 RTG Workbench with JIT enabled
- all p96cts drawline, fillrect, and copyrect tests pass with the current ZZ9000 driver

Fixes #2196

Related to BlitterStudio/zz9000-drivers#52