### PR TITLE
Improve Global Settings UI controls

### DIFF
--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -2749,14 +2749,26 @@ void run_gui()
 		}
 
 		if (show_message_box) {
-            // Center the dialog on appearing; use viewport-relative sizes for proper scaling on all platforms
-            const float vw = vp->Size.x;
-            const float vh = vp->Size.y;
-            const float desired_w = vw * 0.56f;
-            ImGui::SetNextWindowPos(vp->GetCenter(), ImGuiCond_FirstUseEver, ImVec2(0.5f, 0.5f));
-            ImGui::SetNextWindowSize(ImVec2(desired_w, 0.0f), ImGuiCond_Appearing);
-            // Lock width to desired_w; allow height to grow up to 85% viewport
-            ImGui::SetNextWindowSizeConstraints(ImVec2(desired_w, 0.0f), ImVec2(desired_w, vh * 0.85f));
+			// Size short notices to their content while keeping long help and error text scrollable.
+			const float vw = vp->Size.x;
+			const float vh = vp->Size.y;
+			const auto& style = ImGui::GetStyle();
+			const float max_dialog_w = vw * 0.56f;
+			const float min_dialog_w = std::min(BUTTON_WIDTH * 2.75f, max_dialog_w);
+			const float title_w = ImGui::CalcTextSize(message_box_title).x
+				+ ImGui::GetFrameHeight() * 2.0f + style.WindowPadding.x * 2.0f;
+			const float message_w = ImGui::CalcTextSize(message_box_message.c_str()).x
+				+ style.WindowPadding.x * 2.0f + style.ScrollbarSize;
+			const float desired_w = std::clamp(std::max(title_w, message_w), min_dialog_w, max_dialog_w);
+			const float wrap_w = std::max(1.0f, desired_w - style.WindowPadding.x * 2.0f
+				- style.ScrollbarSize);
+			const float message_h = ImGui::CalcTextSize(message_box_message.c_str(), nullptr, false, wrap_w).y;
+			const float max_child_h = vh * 0.65f;
+			const float child_h = std::min(std::max(message_h + style.FramePadding.y * 2.0f,
+				ImGui::GetTextLineHeightWithSpacing()), max_child_h);
+			ImGui::SetNextWindowPos(vp->GetCenter(), ImGuiCond_FirstUseEver, ImVec2(0.5f, 0.5f));
+			ImGui::SetNextWindowSize(ImVec2(desired_w, 0.0f), ImGuiCond_Appearing);
+			ImGui::SetNextWindowSizeConstraints(ImVec2(desired_w, 0.0f), ImVec2(desired_w, vh * 0.85f));
 
             // Open the popup once on the rising edge. Calling OpenPopup() every frame
             // made the dialog impossible to dismiss whenever a caller kept re-requesting
@@ -2769,9 +2781,8 @@ void run_gui()
 
             if (ImGui::BeginPopupModal(message_box_title, &message_box_open, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings))
             {
-                // Scrollable message area; height scales with viewport
-                const float max_child_h = vh * 0.65f;
-                ImGui::BeginChild("MessageScroll", ImVec2(0, max_child_h), true, ImGuiWindowFlags_HorizontalScrollbar);
+				// Scroll only when wrapped content reaches the viewport-relative height cap.
+				ImGui::BeginChild("MessageScroll", ImVec2(0, child_h), true);
                 ImGui::TextWrapped("%s", message_box_message.c_str());
                 ImGui::EndChild();
 

--- a/src/osdep/imgui/filter.cpp
+++ b/src/osdep/imgui/filter.cpp
@@ -60,6 +60,13 @@ static void scan_bezels()
 	bezels_initialized = true;
 }
 
+const std::vector<std::string>& get_available_bezel_names()
+{
+	if (!bezels_initialized)
+		scan_bezels();
+	return bezel_names;
+}
+
 static int find_bezel_index(const char* bezel_name)
 {
 	for (size_t i = 0; i < bezel_names.size(); i++) {

--- a/src/osdep/imgui/global_settings.cpp
+++ b/src/osdep/imgui/global_settings.cpp
@@ -145,6 +145,86 @@ static bool render_shader_combo_row(const char* label, char* value, const size_t
 	return changed;
 }
 
+static bool render_catalog_combo_row(const char* label, char* value, const size_t value_size,
+	const std::vector<std::string>& options, const char* help)
+{
+	next_setting_row(label);
+	const char* preview = value[0] ? value : (options.empty() ? "none" : options.front().c_str());
+
+	bool changed = false;
+	ImGui::SetNextItemWidth(-1.0f);
+	if (ImGui::BeginCombo("##value", preview)) {
+		for (const auto& option : options) {
+			const bool selected = stricmp(option.c_str(), value) == 0;
+			if (ImGui::Selectable(option.c_str(), selected)) {
+				strncpy(value, option.c_str(), value_size - 1);
+				value[value_size - 1] = '\0';
+				changed = true;
+			}
+			if (selected)
+				ImGui::SetItemDefaultFocus();
+		}
+		ImGui::EndCombo();
+	}
+	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActive());
+	finish_setting_row(help);
+	return changed;
+}
+
+static bool render_sound_device_row(const char* label, int* value, const char* help)
+{
+	next_setting_row(label);
+	const auto& device_names = get_sound_device_names();
+	const char* preview = "System default";
+	if (*value > 0 && *value < static_cast<int>(device_names.size()))
+		preview = device_names[*value].c_str();
+	else if (*value > 0)
+		preview = "Unknown device";
+
+	bool changed = false;
+	ImGui::SetNextItemWidth(-1.0f);
+	if (ImGui::BeginCombo("##value", preview)) {
+		if (ImGui::Selectable("System default", *value == 0)) {
+			*value = 0;
+			changed = true;
+		}
+		if (*value == 0)
+			ImGui::SetItemDefaultFocus();
+
+		// Index zero is represented by the system-default choice in amiberry.conf.
+		for (int i = 1; i < static_cast<int>(device_names.size()); ++i) {
+			const bool selected = *value == i;
+			if (ImGui::Selectable(device_names[i].c_str(), selected)) {
+				*value = i;
+				changed = true;
+			}
+			if (selected)
+				ImGui::SetItemDefaultFocus();
+		}
+		ImGui::EndCombo();
+	}
+	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActive());
+	finish_setting_row(help);
+	return changed;
+}
+
+static bool render_sound_buffer_row(const char* label, int* value, const char* help)
+{
+	next_setting_row(label);
+	int buffer_index = get_sound_buffer_size_index(*value);
+	const float value_width = BUTTON_WIDTH * 1.6f;
+	ImGui::SetNextItemWidth(std::max(BUTTON_WIDTH, ImGui::GetContentRegionAvail().x - value_width));
+	const bool changed = ImGui::SliderInt("##value", &buffer_index, 0,
+		IM_ARRAYSIZE(SOUND_BUFFER_SIZES), "");
+	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
+	if (changed)
+		*value = buffer_index == 0 ? 0 : SOUND_BUFFER_SIZES[buffer_index - 1];
+	ImGui::SameLine();
+	ImGui::TextUnformatted(buffer_index == 0 ? "Min" : std::to_string(*value).c_str());
+	finish_setting_row(help);
+	return changed;
+}
+
 static bool render_combo_row(const char* label, int* value, const ComboOption* options,
 	const int option_count, const char* help)
 {
@@ -303,6 +383,26 @@ void render_panel_global_settings()
 		{3, "Low compatibility"},
 		{4, "Low compatibility (JIT)"},
 	};
+	static const ComboOption stereo_separation_options[] = {
+		{10, "100%"},
+		{9, "90%"},
+		{8, "80%"},
+		{7, "70%"},
+		{6, "60%"},
+		{5, "50%"},
+		{4, "40%"},
+		{3, "30%"},
+		{2, "20%"},
+		{1, "10%"},
+		{0, "0%"},
+	};
+	static const ComboOption sound_frequency_options[] = {
+		{11025, "11025"},
+		{22050, "22050"},
+		{32000, "32000"},
+		{44100, "44100"},
+		{48000, "48000"},
+	};
 	static const StringComboOption vkbd_language_options[] = {
 		{"US", "US"},
 		{"UK", "UK"},
@@ -404,14 +504,16 @@ void render_panel_global_settings()
 	});
 
 	render_group("Sound defaults", "GlobalSoundDefaults", [&]() {
-		render_int_row("Stereo separation", &amiberry_options.default_stereo_separation,
-			"Default stereo separation, from 0 to 10.", 1, 0, 10);
-		render_int_row("Sound frequency", &amiberry_options.default_sound_frequency,
-			"Default audio output frequency. Values above 48000 are ignored by startup defaults.", 1000, 1, 192000);
-		render_int_row("Sound buffer", &amiberry_options.default_sound_buffer,
-			"Default sound buffer size in bytes.", 256, 1, 65536);
-		render_int_row("Sound card", &amiberry_options.default_soundcard,
-			"Default sound device index. 0 means the system default device.", 1, 0, INT_MAX);
+		render_combo_row("Stereo separation", &amiberry_options.default_stereo_separation,
+			stereo_separation_options, IM_ARRAYSIZE(stereo_separation_options),
+			"Default stereo separation between the left and right channels.");
+		render_combo_row("Sound frequency", &amiberry_options.default_sound_frequency,
+			sound_frequency_options, IM_ARRAYSIZE(sound_frequency_options),
+			"Default audio output sample rate in Hz.");
+		render_sound_buffer_row("Sound buffer", &amiberry_options.default_sound_buffer,
+			"Default emulator audio buffer size. Smaller values reduce latency but may cause glitches on slower systems.");
+		render_sound_device_row("Audio device", &amiberry_options.default_soundcard,
+			"Default sound output device. Index zero uses the operating system default.");
 	});
 
 	render_group("WHDLoad defaults", "GlobalWHDLoadDefaults", [&]() {
@@ -449,8 +551,8 @@ void render_panel_global_settings()
 	});
 
 	render_group("Visual defaults", "GlobalVisualDefaults", [&]() {
-		render_string_row("GUI theme", amiberry_options.gui_theme,
-			sizeof amiberry_options.gui_theme,
+		render_catalog_combo_row("GUI theme", amiberry_options.gui_theme,
+			sizeof amiberry_options.gui_theme, get_available_theme_names(),
 			"Theme file loaded by the ImGui interface.");
 		render_shader_combo_row("Native shader", amiberry_options.shader,
 			sizeof amiberry_options.shader,
@@ -458,13 +560,25 @@ void render_panel_global_settings()
 		render_shader_combo_row("RTG shader", amiberry_options.shader_rtg,
 			sizeof amiberry_options.shader_rtg,
 			"Default shader preset for RTG modes. Use none to disable.");
-		render_bool_row("Use bezel", &amiberry_options.use_bezel,
-			"Show the default CRT bezel overlay.");
-		render_bool_row("Use custom bezel", &amiberry_options.use_custom_bezel,
-			"Use the custom bezel path below instead of the default bezel.");
-		render_string_row("Custom bezel", amiberry_options.custom_bezel,
-			sizeof amiberry_options.custom_bezel,
-			"Custom bezel image path or none.");
+		const bool custom_bezel_active = amiberry_options.use_custom_bezel
+			&& stricmp(amiberry_options.custom_bezel, "none") != 0;
+		if (custom_bezel_active)
+			amiberry_options.use_bezel = false;
+		ImGui::BeginDisabled(custom_bezel_active);
+		if (render_bool_row("Use bezel", &amiberry_options.use_bezel,
+			"Show the built-in CRT bezel overlay.") && amiberry_options.use_bezel)
+			amiberry_options.use_custom_bezel = false;
+		ImGui::EndDisabled();
+
+		ImGui::BeginDisabled(amiberry_options.use_bezel);
+		if (render_catalog_combo_row("Custom bezel", amiberry_options.custom_bezel,
+			sizeof amiberry_options.custom_bezel, get_available_bezel_names(),
+			"Select a custom bezel overlay from the Bezels directory, or none to disable it.")) {
+			amiberry_options.use_custom_bezel = stricmp(amiberry_options.custom_bezel, "none") != 0;
+			if (amiberry_options.use_custom_bezel)
+				amiberry_options.use_bezel = false;
+		}
+		ImGui::EndDisabled();
 	});
 
 	render_group("Paths and logging", "GlobalPathsLogging", [&]() {

--- a/src/osdep/imgui/imgui_panels.h
+++ b/src/osdep/imgui/imgui_panels.h
@@ -15,6 +15,26 @@ extern std::vector<const char*> qs_models;
 extern std::vector<const char*> qs_configs;
 extern ImTextureID about_logo_texture;
 
+// Shared catalogs used by panels that expose the same choices.
+const std::vector<std::string>& get_sound_device_names();
+const std::vector<std::string>& get_available_theme_names();
+const std::vector<std::string>& get_available_bezel_names();
+
+inline constexpr int SOUND_BUFFER_SIZES[] = {
+	1024, 2048, 3072, 4096, 6144, 8192, 12288, 16384, 32768, 65536
+};
+
+inline int get_sound_buffer_size_index(const int size)
+{
+	if (size < SOUND_BUFFER_SIZES[0])
+		return 0;
+
+	int index = 0;
+	while (index + 1 < IM_ARRAYSIZE(SOUND_BUFFER_SIZES) && SOUND_BUFFER_SIZES[index] < size)
+		++index;
+	return index + 1;
+}
+
 // Texture helpers that abstract SDL_Texture (SDLRenderer2) vs GLuint (OpenGL3)
 struct SDL_Surface;
 ImTextureID gui_create_texture(SDL_Surface* surface, int* out_w, int* out_h);

--- a/src/osdep/imgui/sound.cpp
+++ b/src/osdep/imgui/sound.cpp
@@ -15,42 +15,42 @@ static std::vector<const char *> sound_device_items;
 static int selected_floppy_drive = 0;
 static int master_volume = 100;
 static int selected_volume_type = 0; // 0=Paula, 1=CD, 2=AHI, 3=MIDI
-static constexpr int sndbufsizes[] = {1024, 2048, 3072, 4096, 6144, 8192, 12288, 16384, 32768, 65536, -1};
 
-static int getsoundbufsizeindex(int size) {
-    int idx;
-    if (size < sndbufsizes[0])
-        return 0;
-    for (idx = 0; sndbufsizes[idx] < size && sndbufsizes[idx + 1] >= 0; idx++);
-    return idx + 1;
+const std::vector<std::string>& get_sound_device_names()
+{
+	if (!sound_device_names.empty())
+		return sound_device_names;
+
+	const int numdevs = enumerate_sound_devices();
+	for (int i = 0; i < numdevs; ++i) {
+		char tmp[256];
+		const int type = sound_devices[i]->type;
+		snprintf(tmp, sizeof tmp, "%s: %s",
+			type == SOUND_DEVICE_SDL2
+				? "SDL"
+				: (type == SOUND_DEVICE_DS
+					? "DSOUND"
+					: (type == SOUND_DEVICE_AL
+						? "OpenAL"
+						: (type == SOUND_DEVICE_PA
+							? "PortAudio"
+							: (type == SOUND_DEVICE_WASAPI ? "WASAPI" : "WASAPI EX")))),
+			sound_devices[i]->name);
+		sound_device_names.emplace_back(tmp);
+	}
+	if (sound_device_names.empty())
+		sound_device_names.emplace_back("None");
+	for (const auto& name : sound_device_names)
+		sound_device_items.push_back(name.c_str());
+	return sound_device_names;
 }
 
 void render_panel_sound() {
     // Global padding for the whole panel
     ImGui::Indent(4.0f);
 
-    // Initialize Audio Devices
-    if (sound_device_names.empty()) {
-        int numdevs = enumerate_sound_devices();
-        for (int i = 0; i < numdevs; ++i) {
-            char tmp[256];
-            int type = sound_devices[i]->type;
-            snprintf(tmp, sizeof(tmp), "%s: %s",
-                     type == SOUND_DEVICE_SDL2
-                         ? "SDL"
-                         : (type == SOUND_DEVICE_DS
-                                ? "DSOUND"
-                                : (type == SOUND_DEVICE_AL
-                                       ? "OpenAL"
-                                       : (type == SOUND_DEVICE_PA
-                                              ? "PortAudio"
-                                              : (type == SOUND_DEVICE_WASAPI ? "WASAPI" : "WASAPI EX")))),
-                     sound_devices[i]->name);
-            sound_device_names.push_back(tmp);
-        }
-        if (sound_device_names.empty()) sound_device_names.push_back("None");
-        for (const auto &name: sound_device_names) sound_device_items.push_back(name.c_str());
-    }
+	// Initialize Audio Devices
+	get_sound_device_names();
 
     // ---------------------------------------------------------
     // Audio Device
@@ -521,11 +521,11 @@ void render_panel_sound() {
         // --- Buffer Size ---
         BeginGroupBox("Sound Buffer Size");
 
-        int buf_idx = getsoundbufsizeindex(changed_prefs.sound_maxbsiz);
+        int buf_idx = get_sound_buffer_size_index(changed_prefs.sound_maxbsiz);
         ImGui::SetNextItemWidth(-ImGui::GetStyle().ItemSpacing.x * 2);
-        if (ImGui::SliderInt("##BufSize", &buf_idx, 0, 10, "")) {
+        if (ImGui::SliderInt("##BufSize", &buf_idx, 0, IM_ARRAYSIZE(SOUND_BUFFER_SIZES), "")) {
             if (buf_idx == 0) changed_prefs.sound_maxbsiz = 0;
-            else changed_prefs.sound_maxbsiz = sndbufsizes[buf_idx - 1];
+            else changed_prefs.sound_maxbsiz = SOUND_BUFFER_SIZES[buf_idx - 1];
         }
         AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
         if (buf_idx == 0) {

--- a/src/osdep/imgui/themes.cpp
+++ b/src/osdep/imgui/themes.cpp
@@ -75,6 +75,13 @@ static void scan_theme_files()
 	}
 }
 
+const std::vector<std::string>& get_available_theme_names()
+{
+	if (s_theme_files.empty())
+		scan_theme_files();
+	return s_theme_files;
+}
+
 static void select_theme_by_name(const std::string& name)
 {
 	for (int i = 0; i < static_cast<int>(s_theme_files.size()); i++)


### PR DESCRIPTION
## Summary

- size message dialogs to their content while retaining capped scrolling for long messages
- mirror the Sound panel's dropdown and stepped-slider controls in Global Settings
- populate GUI theme and custom bezel dropdowns from the same catalogs as their dedicated panels
- keep built-in and custom bezel defaults mutually exclusive

## Why

Global Settings exposed several sound and visual defaults as raw numeric or text inputs, unlike the dedicated panels. Its one-line save confirmation also inherited a fixed viewport-sized message area.

## Validation

- `cmake --build build --parallel` on macOS
- manual Global Settings UI check, including dropdowns and the save confirmation dialog
- `git diff --check`
