### PR TITLE
Fix remaining Global Settings input controls

### DIFF
--- a/src/osdep/imgui/global_settings.cpp
+++ b/src/osdep/imgui/global_settings.cpp
@@ -115,9 +115,7 @@ static bool render_input_device_row(const char* label, char* value, const size_t
 	int selected_index = current_index;
 	const bool changed = InputDeviceCombo("##value", current_index, preview, &selected_index);
 	if (changed) {
-		const char* config_value = options[selected_index].id == JPORT_NONE
-			? ""
-			: options[selected_index].config_value.c_str();
+		const char* config_value = options[selected_index].config_value.c_str();
 		strncpy(value, config_value, value_size - 1);
 		value[value_size - 1] = '\0';
 	}

--- a/src/osdep/imgui/global_settings.cpp
+++ b/src/osdep/imgui/global_settings.cpp
@@ -85,6 +85,46 @@ static bool render_string_row(const char* label, char* value, const size_t value
 	return changed;
 }
 
+static bool render_hotkey_row(const char* label, char* value, const size_t value_size, const char* help)
+{
+	next_setting_row(label);
+	const bool changed = HotkeyPicker("##value", value, value_size);
+	finish_setting_row(help);
+	return changed;
+}
+
+static bool render_input_device_row(const char* label, char* value, const size_t value_size,
+	const char* help)
+{
+	next_setting_row(label);
+	const auto& options = get_input_device_options();
+	int current_index = -1;
+	for (int i = 0; i < static_cast<int>(options.size()); ++i) {
+		if ((!value[0] && options[i].id == JPORT_NONE)
+			|| stricmp(options[i].config_value.c_str(), value) == 0) {
+			current_index = i;
+			break;
+		}
+	}
+
+	const char* preview = value[0] ? value : "<none>";
+	if (current_index >= 0)
+		preview = options[current_index].label.c_str();
+
+	ImGui::SetNextItemWidth(-1.0f);
+	int selected_index = current_index;
+	const bool changed = InputDeviceCombo("##value", current_index, preview, &selected_index);
+	if (changed) {
+		const char* config_value = options[selected_index].id == JPORT_NONE
+			? ""
+			: options[selected_index].config_value.c_str();
+		strncpy(value, config_value, value_size - 1);
+		value[value_size - 1] = '\0';
+	}
+	finish_setting_row(help);
+	return changed;
+}
+
 static bool render_string_combo_row(const char* label, char* value, const size_t value_size,
 	const StringComboOption* options, const int option_count, const char* help)
 {
@@ -432,18 +472,21 @@ void render_panel_global_settings()
 		render_bool_row("Keyboard joystick stops keypresses",
 			&amiberry_options.input_keyboard_as_joystick_stop_keypresses,
 			"Stop keyboard-as-joystick mappings from also generating normal Amiga key presses.");
-		render_int_row("Joystick deadzone", &amiberry_options.default_joystick_deadzone,
-			"Default joystick and joystick-mouse deadzone percentage.", 1, 0, 100);
-		render_string_row("Open GUI key", amiberry_options.default_open_gui_key,
+		next_setting_row("Joystick deadzone");
+		ImGui::SetNextItemWidth(-1.0f);
+		ImGui::SliderInt("##value", &amiberry_options.default_joystick_deadzone, 0, 100, "%d%%");
+		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
+		finish_setting_row("Default joystick and joystick-mouse deadzone percentage.");
+		render_hotkey_row("Open GUI key", amiberry_options.default_open_gui_key,
 			sizeof amiberry_options.default_open_gui_key,
 			"Default keyboard shortcut for opening the GUI.");
-		render_string_row("Quit key", amiberry_options.default_quit_key,
+		render_hotkey_row("Quit key", amiberry_options.default_quit_key,
 			sizeof amiberry_options.default_quit_key,
 			"Default keyboard shortcut for quitting Amiberry.");
-		render_string_row("Action Replay key", amiberry_options.default_ar_key,
+		render_hotkey_row("Action Replay key", amiberry_options.default_ar_key,
 			sizeof amiberry_options.default_ar_key,
 			"Default keyboard shortcut for activating Action Replay/HRTmon.");
-		render_string_row("Full-window toggle key", amiberry_options.default_fullscreen_toggle_key,
+		render_hotkey_row("Full-window toggle key", amiberry_options.default_fullscreen_toggle_key,
 			sizeof amiberry_options.default_fullscreen_toggle_key,
 			"Default keyboard shortcut for toggling Windowed and Full-window modes.");
 		render_bool_row("RetroArch quit", &amiberry_options.default_retroarch_quit,
@@ -452,22 +495,22 @@ void render_panel_global_settings()
 			"Enable RetroArch-style menu button mapping by default when a mapping exists.");
 		render_bool_row("RetroArch reset", &amiberry_options.default_retroarch_reset,
 			"Enable RetroArch-style reset button mapping by default when a mapping exists.");
-		render_string_row("Controller 1", amiberry_options.default_controller1,
+		render_input_device_row("Controller 1", amiberry_options.default_controller1,
 			sizeof amiberry_options.default_controller1,
-			"Default controller mapping for port 1, such as joy1.");
-		render_string_row("Controller 2", amiberry_options.default_controller2,
+			"Default controller mapping for port 1.");
+		render_input_device_row("Controller 2", amiberry_options.default_controller2,
 			sizeof amiberry_options.default_controller2,
-			"Default controller mapping for port 2, such as joy2.");
-		render_string_row("Controller 3", amiberry_options.default_controller3,
+			"Default controller mapping for port 2.");
+		render_input_device_row("Controller 3", amiberry_options.default_controller3,
 			sizeof amiberry_options.default_controller3,
 			"Default controller mapping for port 3.");
-		render_string_row("Controller 4", amiberry_options.default_controller4,
+		render_input_device_row("Controller 4", amiberry_options.default_controller4,
 			sizeof amiberry_options.default_controller4,
 			"Default controller mapping for port 4.");
-		render_string_row("Mouse 1", amiberry_options.default_mouse1,
+		render_input_device_row("Mouse 1", amiberry_options.default_mouse1,
 			sizeof amiberry_options.default_mouse1,
 			"Default mouse mapping for mouse port 1.");
-		render_string_row("Mouse 2", amiberry_options.default_mouse2,
+		render_input_device_row("Mouse 2", amiberry_options.default_mouse2,
 			sizeof amiberry_options.default_mouse2,
 			"Default mouse mapping for mouse port 2.");
 	});
@@ -693,4 +736,6 @@ void render_panel_global_settings()
 			"Swap host End and Page Up before they reach the Amiga. Saved in amiberry.ini."))
 			key_swap_end_pgup = swap_end_pageup ? 1 : 0;
 	});
+
+	HotkeyCapture_RenderPopup();
 }

--- a/src/osdep/imgui/imgui_panels.h
+++ b/src/osdep/imgui/imgui_panels.h
@@ -20,6 +20,17 @@ const std::vector<std::string>& get_sound_device_names();
 const std::vector<std::string>& get_available_theme_names();
 const std::vector<std::string>& get_available_bezel_names();
 
+struct InputDeviceOption
+{
+	std::string label;
+	std::string config_value;
+	int id;
+};
+
+const std::vector<InputDeviceOption>& get_input_device_options();
+bool InputDeviceCombo(const char* id, int current_index, const char* fallback_preview,
+	int* selected_index);
+
 inline constexpr int SOUND_BUFFER_SIZES[] = {
 	1024, 2048, 3072, 4096, 6144, 8192, 12288, 16384, 32768, 65536
 };
@@ -84,7 +95,10 @@ void render_panel_custom();
 void render_panel_diskswapper();
 void render_panel_misc();
 void render_panel_global_settings();
-// Returns true while the Misc panel's hotkey-capture modal is open.
+// Shared hotkey picker used by panels that edit host keyboard shortcuts.
+bool HotkeyPicker(const char* id, char* config_value, size_t config_value_size);
+void HotkeyCapture_RenderPopup();
+// Returns true while the hotkey-capture modal is open.
 // Used by the GUI main loop to suppress its own keyboard shortcuts while
 // the user is picking a key combination.
 bool HotkeyCapture_IsActive();

--- a/src/osdep/imgui/input.cpp
+++ b/src/osdep/imgui/input.cpp
@@ -23,80 +23,128 @@
 #define MOUSEUNTRAP_MAGIC 2
 #endif
 
-static std::vector<std::string> input_device_names;
-static std::vector<const char *> input_device_items;
-static std::vector<int> input_device_ids;
+static std::vector<InputDeviceOption> input_device_options;
 
-static void poll_input_devices() {
-    input_device_names.clear();
-    input_device_items.clear();
-    input_device_ids.clear();
-
-    // Static Items
-    auto add = [](const char *name, int id) {
-        input_device_names.emplace_back(name);
-        input_device_ids.push_back(id);
-    };
-
-    add("<none>", JPORT_NONE);
-    add("Keyboard Layout A (Numpad, 0/5=Fire, Decimal/DEL=2nd Fire)", JSEM_KBDLAYOUT);
-    add("Keyboard Layout B (Cursor, RCtrl/RAlt=Fire, RShift=2nd Fire)", JSEM_KBDLAYOUT + 1);
-    add("Keyboard Layout C (WSAD, LAlt=Fire, LShift=2nd Fire)", JSEM_KBDLAYOUT + 2);
-    add("Keyboard Layout D (Cursor, LCtrl/LAlt=Fire, LShift=2nd Fire)", JSEM_KBDLAYOUT + 8);
-    add("Keyrah Layout (Cursor, Space/RAlt=Fire, RShift=2nd Fire)", JSEM_KBDLAYOUT + 3);
-
-    for (int j = 0; j < 4; j++) {
-        char buf[64];
-        snprintf(buf, sizeof(buf), "Retroarch KBD as Joystick Player%d", j + 1);
-        add(buf, JSEM_KBDLAYOUT + j + 4);
-    }
-
-    // Joysticks — add type prefix so users can identify device types
-    int num_joys = inputdevice_get_device_total(IDTYPE_JOYSTICK);
-    for (int j = 0; j < num_joys; j++) {
-        const char* name = inputdevice_get_device_name(IDTYPE_JOYSTICK, j);
-        std::string label;
-        if (j < MAX_INPUT_DEVICES && di_joystick[j].is_controller)
-            label = std::string("[Gamepad] ") + (name ? name : "?");
-        else
-            label = std::string("[Joystick] ") + (name ? name : "?");
-        input_device_names.push_back(label);
-        input_device_ids.push_back(JSEM_JOYS + j);
-    }
-
-    // Mice — always prefixed with [Mouse] for parity with [Joystick] /
-    // [Gamepad] entries. In single-mouse mode there is exactly one entry
-    // ("[Mouse] System mouse"); in multi-mouse mode one entry per physical
-    // device.
-    int num_mice = inputdevice_get_device_total(IDTYPE_MOUSE);
-    for (int j = 0; j < num_mice; j++) {
-        const char* name = inputdevice_get_device_name(IDTYPE_MOUSE, j);
-        std::string label = std::string("[Mouse] ") + (name && name[0] ? name : "?");
-        input_device_names.push_back(label);
-        input_device_ids.push_back(JSEM_MICE + j);
-    }
-
-    // Disambiguate duplicate device names by appending instance numbers
-    std::unordered_map<std::string, int> name_counts;
-    for (const auto &name : input_device_names) {
-        name_counts[name]++;
-    }
-    std::unordered_map<std::string, int> name_seen;
-    for (auto &name : input_device_names) {
-        if (name_counts[name] > 1) {
-            int instance = ++name_seen[name];
-            name = name + " (" + std::to_string(instance) + ")";
-        }
-    }
-
-    for (const auto &name: input_device_names) input_device_items.push_back(name.c_str());
+static std::string get_input_device_config_value(const int id)
+{
+	if (id == JPORT_NONE)
+		return "none";
+	if (id < JSEM_CUSTOM)
+		return "kbd" + std::to_string(id - JSEM_KBDLAYOUT + 1);
+	if (id < JSEM_MICE)
+		return "joy" + std::to_string(id - JSEM_JOYS);
+	if (id == JSEM_MICE)
+		return "mouse";
+	return "mouse" + std::to_string(id - JSEM_MICE);
 }
 
-static int get_device_index(int id) {
-    for (size_t i = 0; i < input_device_ids.size(); ++i) {
-        if (input_device_ids[i] == id) return (int) i;
-    }
-    return 0; // Default to <none>
+static void poll_input_devices()
+{
+	input_device_options.clear();
+
+	// Static items
+	auto add = [](const char* name, const int id) {
+		input_device_options.push_back({name, get_input_device_config_value(id), id});
+	};
+
+	add("<none>", JPORT_NONE);
+	add("Keyboard Layout A (Numpad, 0/5=Fire, Decimal/DEL=2nd Fire)", JSEM_KBDLAYOUT);
+	add("Keyboard Layout B (Cursor, RCtrl/RAlt=Fire, RShift=2nd Fire)", JSEM_KBDLAYOUT + 1);
+	add("Keyboard Layout C (WSAD, LAlt=Fire, LShift=2nd Fire)", JSEM_KBDLAYOUT + 2);
+	add("Keyboard Layout D (Cursor, LCtrl/LAlt=Fire, LShift=2nd Fire)", JSEM_KBDLAYOUT + 8);
+	add("Keyrah Layout (Cursor, Space/RAlt=Fire, RShift=2nd Fire)", JSEM_KBDLAYOUT + 3);
+
+	for (int j = 0; j < 4; ++j) {
+		char buf[64];
+		snprintf(buf, sizeof buf, "Retroarch KBD as Joystick Player%d", j + 1);
+		add(buf, JSEM_KBDLAYOUT + j + 4);
+	}
+
+	// Joysticks — add type prefix so users can identify device types
+	const int num_joys = inputdevice_get_device_total(IDTYPE_JOYSTICK);
+	for (int j = 0; j < num_joys; ++j) {
+		const char* name = inputdevice_get_device_name(IDTYPE_JOYSTICK, j);
+		std::string label;
+		if (j < MAX_INPUT_DEVICES && di_joystick[j].is_controller)
+			label = std::string("[Gamepad] ") + (name ? name : "?");
+		else
+			label = std::string("[Joystick] ") + (name ? name : "?");
+		add(label.c_str(), JSEM_JOYS + j);
+	}
+
+	// Mice — always prefixed with [Mouse] for parity with [Joystick] /
+	// [Gamepad] entries. In single-mouse mode there is exactly one entry
+	// ("[Mouse] System mouse"); in multi-mouse mode one entry per physical
+	// device.
+	const int num_mice = inputdevice_get_device_total(IDTYPE_MOUSE);
+	for (int j = 0; j < num_mice; ++j) {
+		const char* name = inputdevice_get_device_name(IDTYPE_MOUSE, j);
+		const std::string label = std::string("[Mouse] ") + (name && name[0] ? name : "?");
+		add(label.c_str(), JSEM_MICE + j);
+	}
+
+	// Disambiguate duplicate device names by appending instance numbers
+	std::unordered_map<std::string, int> name_counts;
+	for (const auto& option : input_device_options) {
+		name_counts[option.label]++;
+	}
+	std::unordered_map<std::string, int> name_seen;
+	for (auto& option : input_device_options) {
+		if (name_counts[option.label] > 1) {
+			const int instance = ++name_seen[option.label];
+			option.label += " (" + std::to_string(instance) + ")";
+		}
+	}
+}
+
+static int get_device_index(const int id)
+{
+	for (size_t i = 0; i < input_device_options.size(); ++i) {
+		if (input_device_options[i].id == id)
+			return static_cast<int>(i);
+	}
+	return 0; // Default to <none>
+}
+
+const std::vector<InputDeviceOption>& get_input_device_options()
+{
+	if (input_device_options.empty() || joystick_refresh_needed) {
+		joystick_refresh_needed = false;
+		poll_input_devices();
+	}
+	return input_device_options;
+}
+
+bool InputDeviceCombo(const char* id, const int current_index, const char* fallback_preview,
+	int* selected_index)
+{
+	const auto& options = get_input_device_options();
+	const bool current_valid = current_index >= 0 && current_index < static_cast<int>(options.size());
+	const char* preview = current_valid
+		? options[current_index].label.c_str()
+		: (fallback_preview ? fallback_preview : "<none>");
+
+	bool changed = false;
+	if (ImGui::BeginCombo(id, preview)) {
+		for (int n = 0; n < static_cast<int>(options.size()); ++n) {
+			const bool is_selected = current_index == n;
+			if (is_selected)
+				ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyle().Colors[ImGuiCol_HeaderActive]);
+			ImGui::PushID(n);
+			if (ImGui::Selectable(options[n].label.c_str(), is_selected)) {
+				*selected_index = n;
+				changed = true;
+			}
+			ImGui::PopID();
+			if (is_selected) {
+				ImGui::PopStyleColor();
+				ImGui::SetItemDefaultFocus();
+			}
+		}
+		ImGui::EndCombo();
+	}
+	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
+	return changed;
 }
 
 void render_panel_input() {
@@ -106,10 +154,7 @@ void render_panel_input() {
         save_mapping_to_file(mapping);
     }
 
-	if (input_device_names.empty() || joystick_refresh_needed) {
-		joystick_refresh_needed = false;
-		poll_input_devices();
-	}
+	get_input_device_options();
 
     ImGui::Indent(4.0f);
 
@@ -131,27 +176,12 @@ void render_panel_input() {
 
             int dev_idx = get_device_index(changed_prefs.jports[port_idx].id);
             ImGui::SetNextItemWidth(-ImGui::GetStyle().ItemSpacing.x * 2);
-            if (ImGui::BeginCombo(std::string("##Dev").append(std::to_string(port_idx)).c_str(),
-                                  input_device_items[dev_idx])) {
-                for (int n = 0; n < static_cast<int>(input_device_items.size()); n++) {
-                    const bool is_selected = (dev_idx == n);
-                    if (is_selected)
-                        ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyle().Colors[ImGuiCol_HeaderActive]);
-                    ImGui::PushID(n);
-                    if (ImGui::Selectable(input_device_items[n], is_selected)) {
-                        dev_idx = n;
-                        changed_prefs.jports[port_idx].id = input_device_ids[dev_idx];
-                        inputdevice_validate_jports(&changed_prefs, port_idx, nullptr); // Validate change
-                    }
-                    ImGui::PopID();
-                    if (is_selected) {
-                        ImGui::PopStyleColor();
-                        ImGui::SetItemDefaultFocus();
-                    }
-                }
-                ImGui::EndCombo();
-            }
-            AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
+			int selected_idx = dev_idx;
+			const std::string combo_id = "##Dev" + std::to_string(port_idx);
+			if (InputDeviceCombo(combo_id.c_str(), dev_idx, nullptr, &selected_idx)) {
+				changed_prefs.jports[port_idx].id = input_device_options[selected_idx].id;
+				inputdevice_validate_jports(&changed_prefs, port_idx, nullptr); // Validate change
+			}
             ShowHelpMarker("Select the input device to use for this Amiga port. Port 0 is typically for mouse, Port 1 for joystick");
 
             float avail_w = ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 2;
@@ -315,26 +345,10 @@ void render_panel_input() {
 
             int dev_idx = get_device_index(changed_prefs.jports[port_idx].id);
             ImGui::SetNextItemWidth(-ImGui::GetStyle().ItemSpacing.x * 2);
-            if (ImGui::BeginCombo(std::string("##ParDev").append(std::to_string(port_idx)).c_str(),
-                                  input_device_items[dev_idx])) {
-                for (int n = 0; n < static_cast<int>(input_device_items.size()); n++) {
-                    const bool is_selected = (dev_idx == n);
-                    if (is_selected)
-                        ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyle().Colors[ImGuiCol_HeaderActive]);
-                    ImGui::PushID(n);
-                    if (ImGui::Selectable(input_device_items[n], is_selected)) {
-                        dev_idx = n;
-                        changed_prefs.jports[port_idx].id = input_device_ids[dev_idx];
-                    }
-                    ImGui::PopID();
-                    if (is_selected) {
-                        ImGui::PopStyleColor();
-                        ImGui::SetItemDefaultFocus();
-                    }
-                }
-                ImGui::EndCombo();
-            }
-            AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
+			int selected_idx = dev_idx;
+			const std::string combo_id = "##ParDev" + std::to_string(port_idx);
+			if (InputDeviceCombo(combo_id.c_str(), dev_idx, nullptr, &selected_idx))
+				changed_prefs.jports[port_idx].id = input_device_options[selected_idx].id;
 
             // Row 2: Autofire | Remap
             float avail_w = ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 2;

--- a/src/osdep/imgui/misc.cpp
+++ b/src/osdep/imgui/misc.cpp
@@ -193,6 +193,7 @@ static MiscListItem misc_items[] = {
 static constexpr int misc_items_count = IM_ARRAYSIZE(misc_items);
 
 static char* target_hotkey_string = nullptr;
+static size_t target_hotkey_string_size = 0;
 static bool  open_hotkey_popup = false;
 static bool  hotkey_capture_active = false;
 
@@ -204,7 +205,52 @@ bool HotkeyCapture_IsActive()
 	return hotkey_capture_active;
 }
 
-static void ShowHotkeyPopup()
+static void set_captured_hotkey(const char* value)
+{
+	if (!target_hotkey_string || target_hotkey_string_size == 0)
+		return;
+	strncpy(target_hotkey_string, value, target_hotkey_string_size - 1);
+	target_hotkey_string[target_hotkey_string_size - 1] = '\0';
+}
+
+bool HotkeyPicker(const char* id, char* config_value, const size_t config_value_size)
+{
+	bool changed = false;
+	ImGui::PushID(id);
+	if (ImGui::BeginTable("##HotkeyPicker", 2, ImGuiTableFlags_SizingStretchProp))
+	{
+		ImGui::TableSetupColumn("Input", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+		ImGui::TableSetupColumn("Btns", ImGuiTableColumnFlags_WidthFixed,
+			SMALL_BUTTON_WIDTH * 2 + ImGui::GetStyle().ItemSpacing.x);
+
+		ImGui::TableNextRow();
+		ImGui::TableNextColumn();
+
+		ImGui::SetNextItemWidth(-FLT_MIN);
+		ImGui::BeginDisabled();
+		ImGui::InputText("##Display", config_value, config_value_size, ImGuiInputTextFlags_ReadOnly);
+		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), true);
+		ImGui::EndDisabled();
+
+		ImGui::TableNextColumn();
+		if (AmigaButton("...")) {
+			target_hotkey_string = config_value;
+			target_hotkey_string_size = config_value_size;
+			open_hotkey_popup = true;
+		}
+		ImGui::SameLine();
+		if (AmigaButton(ICON_FA_XMARK "##clear") && config_value[0]) {
+			config_value[0] = '\0';
+			changed = true;
+		}
+
+		ImGui::EndTable();
+	}
+	ImGui::PopID();
+	return changed;
+}
+
+void HotkeyCapture_RenderPopup()
 {
 	// Per-capture state used to distinguish "modifier-only" bindings (where the
 	// user presses and releases a single qualifier with nothing else) from the
@@ -292,7 +338,7 @@ static void ShowHotkeyPopup()
 					if      (ImGui::IsKeyDown(ImGuiKey_LeftSuper))  full_key += "LGUI+";
 					else if (ImGui::IsKeyDown(ImGuiKey_RightSuper)) full_key += "RGUI+";
 					full_key += key_name;
-					strncpy(target_hotkey_string, full_key.c_str(), 255);
+					set_captured_hotkey(full_key.c_str());
 					ImGui::CloseCurrentPopup();
 					emitted = true;
 				}
@@ -310,7 +356,7 @@ static void ShowHotkeyPopup()
 						if (SDL_GetGamepadButton(gp, static_cast<SDL_GamepadButton>(b))) {
 							const char* name = SDL_GetGamepadStringForButton(static_cast<SDL_GamepadButton>(b));
 							if (name && target_hotkey_string) {
-								strncpy(target_hotkey_string, name, 255);
+								set_captured_hotkey(name);
 								non_mod_pressed_session = true;
 								ImGui::CloseCurrentPopup();
 								emitted = true;
@@ -330,7 +376,7 @@ static void ShowHotkeyPopup()
 			for (const auto& m : mods) {
 				if (ImGui::IsKeyReleased(m.key)) {
 					if (target_hotkey_string) {
-						strncpy(target_hotkey_string, m.name, 255);
+						set_captured_hotkey(m.name);
 						ImGui::CloseCurrentPopup();
 					}
 					break;
@@ -429,32 +475,7 @@ void render_panel_misc()
 		auto HotkeyRow = [&](const char* label, char* config_val) {
 			ImGui::PushID(label);
 			ImGui::Text("%s", label);
-
-			if (ImGui::BeginTable("##HotkeyRow", 2, ImGuiTableFlags_SizingStretchProp))
-			{
-				ImGui::TableSetupColumn("Input", ImGuiTableColumnFlags_WidthStretch, 1.0f);
-				ImGui::TableSetupColumn("Btns",  ImGuiTableColumnFlags_WidthFixed, SMALL_BUTTON_WIDTH * 2 + ImGui::GetStyle().ItemSpacing.x);
-
-				ImGui::TableNextRow();
-				ImGui::TableNextColumn();
-
-				ImGui::SetNextItemWidth(-FLT_MIN);
-				ImGui::BeginDisabled();
-				ImGui::InputText("##Display", config_val, 256, ImGuiInputTextFlags_ReadOnly);
-				AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), true);
-				ImGui::EndDisabled();
-
-				ImGui::TableNextColumn();
-				if (AmigaButton("...")) {
-					target_hotkey_string = config_val;
-					open_hotkey_popup = true;
-				}
-				ImGui::SameLine();
-				if (AmigaButton(ICON_FA_XMARK "##clear"))
-					config_val[0] = '\0';
-
-				ImGui::EndTable();
-			}
+			HotkeyPicker("##picker", config_val, 256);
 			ImGui::PopID();
 		};
 
@@ -521,5 +542,5 @@ void render_panel_misc()
 		ImGui::EndTable();
 	}
 
-	ShowHotkeyPopup();
+	HotkeyCapture_RenderPopup();
 }


### PR DESCRIPTION
## Summary

- replace the remaining raw controller and mouse default fields with the shared Input device dropdown
- reuse the Misc panel's hotkey capture and clear controls for all Global Settings hotkeys
- match the Input panel's percentage slider for joystick deadzone
- keep unknown or temporarily unplugged `joyN`/`mouseN` values visible without rewriting them

## Why

The initial Global Settings panel rendered these input defaults with generic string and integer fields. That left the section inconsistent with the dedicated Input and Misc panels and required users to know internal configuration values such as `joy1`.

The device catalog, dropdown renderer, and hotkey picker are now shared so the panels expose the same labels, selection behavior, refresh handling, and capture workflow.

## User impact

Controller, mouse, hotkey, and deadzone defaults can now be configured with the same controls users already see elsewhere in the GUI. Existing configuration strings remain compatible, including values for devices that are not currently connected.

## Validation

- `cmake --build build --parallel` on macOS
- `git diff --check`
