### PR TITLE
fix(gfx): preserve visible content in autocrop

### DIFF
--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -1,0 +1,174 @@
+#ifndef AMIBERRY_AUTOCROP_HELPERS_H
+#define AMIBERRY_AUTOCROP_HELPERS_H
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+struct AmiberryAutoCropRect {
+	int x;
+	int y;
+	int w;
+	int h;
+};
+
+struct AmiberryAutoCropPixelBuffer {
+	const uint8_t* pixels;
+	int width;
+	int height;
+	int pitch;
+	int bytes_per_pixel;
+	uint32_t rgb_mask;
+};
+
+struct AmiberryAutoCropScanState {
+	std::vector<uint8_t> visited;
+	std::vector<int> pending;
+};
+
+static inline int amiberry_auto_crop_rect_right(const AmiberryAutoCropRect& rect)
+{
+	return rect.x + rect.w;
+}
+
+static inline int amiberry_auto_crop_rect_bottom(const AmiberryAutoCropRect& rect)
+{
+	return rect.y + rect.h;
+}
+
+static inline bool amiberry_auto_crop_rect_contains(const AmiberryAutoCropRect& rect,
+	const int x, const int y)
+{
+	return x >= rect.x && x < amiberry_auto_crop_rect_right(rect)
+		&& y >= rect.y && y < amiberry_auto_crop_rect_bottom(rect);
+}
+
+static inline bool amiberry_auto_crop_buffer_valid(const AmiberryAutoCropPixelBuffer& buffer)
+{
+	return buffer.pixels
+		&& buffer.width > 0
+		&& buffer.height > 0
+		&& buffer.pitch >= buffer.width * buffer.bytes_per_pixel
+		&& buffer.bytes_per_pixel > 0
+		&& buffer.bytes_per_pixel <= static_cast<int>(sizeof(uint32_t))
+		&& buffer.rgb_mask != 0;
+}
+
+static inline uint32_t amiberry_auto_crop_read_pixel(
+	const AmiberryAutoCropPixelBuffer& buffer, const int x, const int y)
+{
+	uint32_t pixel = 0;
+	std::memcpy(&pixel,
+		buffer.pixels + y * buffer.pitch + x * buffer.bytes_per_pixel,
+		buffer.bytes_per_pixel);
+	return pixel;
+}
+
+static inline bool amiberry_auto_crop_pixel_is_visible(
+	const AmiberryAutoCropPixelBuffer& buffer, const int x, const int y,
+	const uint32_t border_rgb)
+{
+	return (amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)
+		!= border_rgb;
+}
+
+static inline bool amiberry_auto_crop_expand_to_visible_content(
+	const AmiberryAutoCropPixelBuffer& buffer, const int min_outside_pixels,
+	AmiberryAutoCropRect& crop, AmiberryAutoCropScanState& state)
+{
+	if (!amiberry_auto_crop_buffer_valid(buffer)
+		|| crop.w <= 0 || crop.h <= 0
+		|| crop.x < 0 || crop.y < 0
+		|| amiberry_auto_crop_rect_right(crop) > buffer.width
+		|| amiberry_auto_crop_rect_bottom(crop) > buffer.height) {
+		return false;
+	}
+
+	const uint32_t border_rgb = amiberry_auto_crop_read_pixel(buffer, 0, 0)
+		& buffer.rgb_mask;
+	if (border_rgb != 0) {
+		return false;
+	}
+
+	const size_t pixel_count = static_cast<size_t>(buffer.width) * buffer.height;
+	state.visited.assign(pixel_count, 0);
+	state.pending.clear();
+	const int required_pixels = std::max(1, min_outside_pixels);
+	AmiberryAutoCropRect expanded = crop;
+	bool changed = false;
+
+	for (int y = 0; y < buffer.height; y++) {
+		for (int x = 0; x < buffer.width; x++) {
+			if (amiberry_auto_crop_rect_contains(crop, x, y)) {
+				continue;
+			}
+
+			const int start_index = y * buffer.width + x;
+			if (state.visited[start_index]) {
+				continue;
+			}
+			state.visited[start_index] = 1;
+			if (!amiberry_auto_crop_pixel_is_visible(buffer, x, y, border_rgb)) {
+				continue;
+			}
+
+			state.pending.push_back(start_index);
+			int component_pixels = 0;
+			int component_min_x = x;
+			int component_min_y = y;
+			int component_max_x = x;
+			int component_max_y = y;
+			while (!state.pending.empty()) {
+				const int index = state.pending.back();
+				state.pending.pop_back();
+				const int pixel_x = index % buffer.width;
+				const int pixel_y = index / buffer.width;
+				component_pixels++;
+				component_min_x = std::min(component_min_x, pixel_x);
+				component_min_y = std::min(component_min_y, pixel_y);
+				component_max_x = std::max(component_max_x, pixel_x);
+				component_max_y = std::max(component_max_y, pixel_y);
+
+				for (int neighbor_y = std::max(0, pixel_y - 1);
+					neighbor_y <= std::min(buffer.height - 1, pixel_y + 1); neighbor_y++) {
+					for (int neighbor_x = std::max(0, pixel_x - 1);
+						neighbor_x <= std::min(buffer.width - 1, pixel_x + 1); neighbor_x++) {
+						if (amiberry_auto_crop_rect_contains(crop, neighbor_x, neighbor_y)) {
+							continue;
+						}
+						const int neighbor_index = neighbor_y * buffer.width + neighbor_x;
+						if (state.visited[neighbor_index]) {
+							continue;
+						}
+						state.visited[neighbor_index] = 1;
+						if (amiberry_auto_crop_pixel_is_visible(
+							buffer, neighbor_x, neighbor_y, border_rgb)) {
+							state.pending.push_back(neighbor_index);
+						}
+					}
+				}
+			}
+
+			if (component_pixels < required_pixels) {
+				continue;
+			}
+			const int right = std::max(amiberry_auto_crop_rect_right(expanded),
+				component_max_x + 1);
+			const int bottom = std::max(amiberry_auto_crop_rect_bottom(expanded),
+				component_max_y + 1);
+			expanded.x = std::min(expanded.x, component_min_x);
+			expanded.y = std::min(expanded.y, component_min_y);
+			expanded.w = right - expanded.x;
+			expanded.h = bottom - expanded.y;
+			changed = true;
+		}
+	}
+
+	if (changed) {
+		crop = expanded;
+	}
+	return changed;
+}
+
+#endif // AMIBERRY_AUTOCROP_HELPERS_H

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -62,6 +62,7 @@
 #include "display_modes.h"
 #include "renderer_factory.h"
 #include "amiberry_input_helpers.h"
+#include "amiberry_autocrop_helpers.h"
 #include "amiberry_gfx_geometry.h"
 
 #ifdef USE_OPENGL
@@ -216,18 +217,8 @@ static void clamp_auto_crop_rect(const SDL_Surface* surface, SDL_Rect& rect)
 	}
 }
 
-static uint32_t auto_crop_read_pixel(const SDL_Surface* surface, const int x,
-	const int y, const int bytes_per_pixel)
-{
-	uint32_t pixel = 0;
-	const auto* pixels = static_cast<const uint8_t*>(surface->pixels);
-	std::memcpy(&pixel, pixels + y * surface->pitch + x * bytes_per_pixel,
-		bytes_per_pixel);
-	return pixel;
-}
-
 static void expand_auto_crop_rect_to_visible_content(const SDL_Surface* surface,
-	SDL_Rect& rect)
+	SDL_Rect& rect, AmiberryAutoCropScanState& scan_state)
 {
 	if (!surface || !surface->pixels || surface->w <= 0 || surface->h <= 0) {
 		return;
@@ -246,49 +237,19 @@ static void expand_auto_crop_rect_to_visible_content(const SDL_Surface* surface,
 	if (!details) {
 		return;
 	}
-	const uint32_t rgb_mask = details->Rmask | details->Gmask | details->Bmask;
-	if (!rgb_mask) {
-		return;
+	AmiberryAutoCropPixelBuffer buffer = {
+		static_cast<const uint8_t*>(surface->pixels),
+		surface->w,
+		surface->h,
+		surface->pitch,
+		bytes_per_pixel,
+		details->Rmask | details->Gmask | details->Bmask
+	};
+	AmiberryAutoCropRect visible_rect = { rect.x, rect.y, rect.w, rect.h };
+	if (amiberry_auto_crop_expand_to_visible_content(buffer,
+		auto_crop_min_outside_pixels, visible_rect, scan_state)) {
+		rect = { visible_rect.x, visible_rect.y, visible_rect.w, visible_rect.h };
 	}
-
-	const uint32_t border_rgb = auto_crop_read_pixel(surface, 0, 0,
-		bytes_per_pixel) & rgb_mask;
-	// A non-black border may be intentional game output. In that case the
-	// hardware display limits remain the safer crop source.
-	if (border_rgb != 0) {
-		return;
-	}
-
-	int outside_pixels = 0;
-	int min_x = rect.x;
-	int min_y = rect.y;
-	int max_x = auto_crop_rect_right(rect) - 1;
-	int max_y = auto_crop_rect_bottom(rect) - 1;
-	for (int y = 0; y < surface->h; y++) {
-		for (int x = 0; x < surface->w; x++) {
-			if (x >= rect.x && x < auto_crop_rect_right(rect)
-				&& y >= rect.y && y < auto_crop_rect_bottom(rect)) {
-				continue;
-			}
-			if ((auto_crop_read_pixel(surface, x, y, bytes_per_pixel) & rgb_mask)
-				== border_rgb) {
-				continue;
-			}
-
-			outside_pixels++;
-			min_x = std::min(min_x, x);
-			min_y = std::min(min_y, y);
-			max_x = std::max(max_x, x);
-			max_y = std::max(max_y, y);
-		}
-	}
-
-	if (outside_pixels < auto_crop_min_outside_pixels) {
-		return;
-	}
-
-	rect = { min_x, min_y, max_x - min_x + 1, max_y - min_y + 1 };
-	clamp_auto_crop_rect(surface, rect);
 }
 
 static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
@@ -2060,6 +2021,7 @@ void auto_crop_image()
 		static AutoCropState crop_state;
 #else
 		static AutoCropVisibleState visible_state;
+		static AmiberryAutoCropScanState scan_state;
 #endif
 		int cw, ch, cx, cy, crealh = 0;
 		int hres = currprefs.gfx_resolution;
@@ -2091,7 +2053,7 @@ void auto_crop_image()
 		// DIW/bitplane limits can exclude visible sprites or raster content.
 		// Preserve real pixels outside those limits without restoring the
 		// conservative minimum frame that keeps intentional black borders.
-		expand_auto_crop_rect_to_visible_content(surface, crop_rect);
+		expand_auto_crop_rect_to_visible_content(surface, crop_rect, scan_state);
 		preserve_auto_crop_visible_content(surface, source_crop_rect, crop_rect,
 			hres, vres, visible_state,
 			force_auto_crop || last_autocrop != currprefs.gfx_auto_crop);

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -122,6 +122,18 @@ constexpr int auto_crop_guard_top_base_tolerance = 8;
 constexpr int auto_crop_wide_aspect_w = 21;
 constexpr int auto_crop_wide_aspect_h = 9;
 constexpr int auto_crop_shrink_stable_frames = 6;
+constexpr int auto_crop_min_outside_pixels = 16;
+
+struct AutoCropVisibleState {
+	const SDL_Surface* surface = nullptr;
+	int surface_w = 0;
+	int surface_h = 0;
+	SDL_Rect source_rect{};
+	SDL_Rect visible_rect{};
+	int hres = 0;
+	int vres = 0;
+	bool valid = false;
+};
 
 static int auto_crop_source_origin_x;
 static int auto_crop_source_origin_y;
@@ -202,6 +214,119 @@ static void clamp_auto_crop_rect(const SDL_Surface* surface, SDL_Rect& rect)
 	if (auto_crop_rect_bottom(rect) > surface->h) {
 		rect.h = surface->h - rect.y;
 	}
+}
+
+static uint32_t auto_crop_read_pixel(const SDL_Surface* surface, const int x,
+	const int y, const int bytes_per_pixel)
+{
+	uint32_t pixel = 0;
+	const auto* pixels = static_cast<const uint8_t*>(surface->pixels);
+	std::memcpy(&pixel, pixels + y * surface->pitch + x * bytes_per_pixel,
+		bytes_per_pixel);
+	return pixel;
+}
+
+static void expand_auto_crop_rect_to_visible_content(const SDL_Surface* surface,
+	SDL_Rect& rect)
+{
+	if (!surface || !surface->pixels || surface->w <= 0 || surface->h <= 0) {
+		return;
+	}
+
+	clamp_auto_crop_rect(surface, rect);
+	if (rect.w <= 0 || rect.h <= 0) {
+		return;
+	}
+
+	const int bytes_per_pixel = SDL_BYTESPERPIXEL(surface->format);
+	if (bytes_per_pixel <= 0 || bytes_per_pixel > static_cast<int>(sizeof(uint32_t))) {
+		return;
+	}
+	const SDL_PixelFormatDetails* details = SDL_GetPixelFormatDetails(surface->format);
+	if (!details) {
+		return;
+	}
+	const uint32_t rgb_mask = details->Rmask | details->Gmask | details->Bmask;
+	if (!rgb_mask) {
+		return;
+	}
+
+	const uint32_t border_rgb = auto_crop_read_pixel(surface, 0, 0,
+		bytes_per_pixel) & rgb_mask;
+	// A non-black border may be intentional game output. In that case the
+	// hardware display limits remain the safer crop source.
+	if (border_rgb != 0) {
+		return;
+	}
+
+	int outside_pixels = 0;
+	int min_x = rect.x;
+	int min_y = rect.y;
+	int max_x = auto_crop_rect_right(rect) - 1;
+	int max_y = auto_crop_rect_bottom(rect) - 1;
+	for (int y = 0; y < surface->h; y++) {
+		for (int x = 0; x < surface->w; x++) {
+			if (x >= rect.x && x < auto_crop_rect_right(rect)
+				&& y >= rect.y && y < auto_crop_rect_bottom(rect)) {
+				continue;
+			}
+			if ((auto_crop_read_pixel(surface, x, y, bytes_per_pixel) & rgb_mask)
+				== border_rgb) {
+				continue;
+			}
+
+			outside_pixels++;
+			min_x = std::min(min_x, x);
+			min_y = std::min(min_y, y);
+			max_x = std::max(max_x, x);
+			max_y = std::max(max_y, y);
+		}
+	}
+
+	if (outside_pixels < auto_crop_min_outside_pixels) {
+		return;
+	}
+
+	rect = { min_x, min_y, max_x - min_x + 1, max_y - min_y + 1 };
+	clamp_auto_crop_rect(surface, rect);
+}
+
+static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
+	const SDL_Rect& source_rect, SDL_Rect& visible_rect, const int hres,
+	const int vres, AutoCropVisibleState& state, const bool reset)
+{
+	if (!surface || surface->w <= 0 || surface->h <= 0
+		|| source_rect.w <= 0 || source_rect.h <= 0
+		|| visible_rect.w <= 0 || visible_rect.h <= 0) {
+		state = {};
+		return;
+	}
+
+	const bool source_changed = state.surface != surface
+		|| state.surface_w != surface->w
+		|| state.surface_h != surface->h
+		|| !auto_crop_rect_equals(state.source_rect, source_rect)
+		|| state.hres != hres
+		|| state.vres != vres;
+	if (reset || source_changed || !state.valid) {
+		state = {};
+		state.surface = surface;
+		state.surface_w = surface->w;
+		state.surface_h = surface->h;
+		state.source_rect = source_rect;
+		state.visible_rect = visible_rect;
+		state.hres = hres;
+		state.vres = vres;
+		state.valid = true;
+		return;
+	}
+
+	// Pixel content beyond DIW/bitplane limits may be intermittent (sprites,
+	// raster effects, or blank frames between screens). Once observed, retain
+	// those bounds until the hardware source geometry actually changes.
+	visible_rect = auto_crop_rect_union(visible_rect, state.visible_rect);
+	clamp_auto_crop_rect(surface, visible_rect);
+	state.visible_rect = visible_rect;
 }
 
 static int auto_crop_minimum_width(const int hres)
@@ -1933,11 +2058,17 @@ void auto_crop_image()
 		static int last_surface_w = 0, last_surface_h = 0;
 #ifdef LIBRETRO
 		static AutoCropState crop_state;
+#else
+		static AutoCropVisibleState visible_state;
 #endif
 		int cw, ch, cx, cy, crealh = 0;
 		int hres = currprefs.gfx_resolution;
 		int vres = currprefs.gfx_vresolution;
 		get_custom_limits(&cw, &ch, &cx, &cy, &crealh, &hres, &vres);
+		const int raw_cw = cw;
+		const int raw_ch = ch;
+		const int raw_cx = cx;
+		const int raw_cy = cy;
 		// Cache the raw source origin at render cadence. Input must not call
 		// get_custom_limits(), which advances its interlace sampling state.
 		auto_crop_source_origin_x = cx;
@@ -1953,6 +2084,22 @@ void auto_crop_image()
 		SDL_Surface* surface = get_amiga_surface(0);
 		const int surface_w = surface ? surface->w : 0;
 		const int surface_h = surface ? surface->h : 0;
+		SDL_Rect crop_rect = { cx, cy, cw, ch };
+#ifndef LIBRETRO
+		clamp_auto_crop_rect(surface, crop_rect);
+		const SDL_Rect source_crop_rect = crop_rect;
+		// DIW/bitplane limits can exclude visible sprites or raster content.
+		// Preserve real pixels outside those limits without restoring the
+		// conservative minimum frame that keeps intentional black borders.
+		expand_auto_crop_rect_to_visible_content(surface, crop_rect);
+		preserve_auto_crop_visible_content(surface, source_crop_rect, crop_rect,
+			hres, vres, visible_state,
+			force_auto_crop || last_autocrop != currprefs.gfx_auto_crop);
+		cx = crop_rect.x;
+		cy = crop_rect.y;
+		cw = crop_rect.w;
+		ch = crop_rect.h;
+#endif
 		bool crop_is_stable = true;
 #ifdef LIBRETRO
 		crop_is_stable = crop_state.shrink_frames == 0;
@@ -1970,10 +2117,6 @@ void auto_crop_image()
 			return;
 		}
 
-		const int raw_cw = cw;
-		const int raw_ch = ch;
-		const int raw_cx = cx;
-		const int raw_cy = cy;
 #ifdef LIBRETRO
 		const bool reset_policy = force_auto_crop || last_autocrop != currprefs.gfx_auto_crop
 			|| last_hres != hres || last_vres != vres
@@ -1995,15 +2138,10 @@ void auto_crop_image()
 		last_surface_h = surface_h;
 		force_auto_crop = false;
 
-		SDL_Rect crop_rect = { cx, cy, cw, ch };
 #ifdef LIBRETRO
 		apply_auto_crop_policy(surface, crop_rect, hres, vres, is_ntsc, crop_state, reset_policy);
 #else
-		// Native Auto Crop follows the detected display limits exactly. The
-		// conservative minimum-frame and edge guards in apply_auto_crop_policy()
-		// are retained only for libretro's changing frontend geometry; applying
-		// them here keeps valid black borders in standalone output.
-		clamp_auto_crop_rect(surface, crop_rect);
+		// The native crop was clamped and checked for visible content above.
 #endif
 		cx = crop_rect.x;
 		cy = crop_rect.y;

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -1,0 +1,112 @@
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include "amiberry_autocrop_helpers.h"
+
+static int failures;
+
+static void expect_true(const bool actual, const char* message)
+{
+	if (!actual) {
+		std::cerr << message << '\n';
+		failures++;
+	}
+}
+
+template<typename T>
+static void expect_eq(const T actual, const T expected, const char* message)
+{
+	if (actual != expected) {
+		std::cerr << message << ": expected " << expected << ", got " << actual << '\n';
+		failures++;
+	}
+}
+
+static AmiberryAutoCropPixelBuffer make_buffer(const std::vector<uint32_t>& pixels,
+	const int width, const int height)
+{
+	return {
+		reinterpret_cast<const uint8_t*>(pixels.data()),
+		width,
+		height,
+		width * static_cast<int>(sizeof(uint32_t)),
+		static_cast<int>(sizeof(uint32_t)),
+		0x00ffffffu
+	};
+}
+
+static void add_lower_content(std::vector<uint32_t>& pixels, const int width)
+{
+	for (int y = 26; y < 28; y++) {
+		for (int x = 8; x < 24; x++) {
+			pixels[y * width + x] = 0x0000ff00u;
+		}
+	}
+}
+
+static void test_expands_to_connected_visible_content()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	std::vector<uint32_t> pixels(width * height, 0);
+	add_lower_content(pixels, width);
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 6, 8, 20, 12 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(changed, "Crop should expand to connected content below it");
+	expect_eq(crop.x, 6, "Crop x should stay anchored");
+	expect_eq(crop.y, 8, "Crop y should stay anchored");
+	expect_eq(crop.w, 20, "Crop width should not change for bottom-only content");
+	expect_eq(crop.h, 20, "Crop bottom should expand to include lower content");
+}
+
+static void test_ignores_distant_speck_when_content_expands()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	std::vector<uint32_t> pixels(width * height, 0);
+	add_lower_content(pixels, width);
+	pixels[39 * width + 39] = 0x00ffffffu;
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 6, 8, 20, 12 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(changed, "Connected lower content should still expand the crop");
+	expect_eq(crop.x, 6, "A distant speck must not move the crop left edge");
+	expect_eq(crop.y, 8, "A distant speck must not move the crop top edge");
+	expect_eq(crop.w, 20, "A distant speck must not widen the crop");
+	expect_eq(crop.h, 20, "A distant speck must not extend the crop bottom");
+}
+
+static void test_ignores_scattered_outside_pixels()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	std::vector<uint32_t> pixels(width * height, 0);
+	for (int i = 0; i < 16; i++) {
+		pixels[(22 + i) * width + (i * 2)] = 0x00ffffffu;
+	}
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 6, 8, 20, 12 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(!changed, "Scattered outside pixels must not expand the crop");
+	expect_eq(crop.w, 20, "Scattered pixels must not change crop width");
+	expect_eq(crop.h, 12, "Scattered pixels must not change crop height");
+}
+
+int main()
+{
+	test_expands_to_connected_visible_content();
+	test_ignores_distant_speck_when_content_expands();
+	test_ignores_scattered_outside_pixels();
+	return failures == 0 ? 0 : 1;
+}

--- a/tests/test_autocrop_helpers.sh
+++ b/tests/test_autocrop_helpers.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+cxx=${CXX:-c++}
+out="${TMPDIR:-/tmp}/autocrop_helpers_test.$$"
+trap 'rm -f "$out"' EXIT
+
+"$cxx" -std=c++17 -Wall -Wextra -Werror -Isrc/osdep \
+	-o "$out" tests/autocrop_helpers_test.cpp
+"$out"


### PR DESCRIPTION
## Summary

- expand native AutoCrop bounds when meaningful visible pixels exist outside the detected DIW/bitplane region
- ignore isolated pixel noise and retain observed visible bounds while the hardware source geometry remains stable
- keep the existing libretro policy and WHDBooter manual-crop path unchanged

## Root cause

`get_custom_limits()` derives its crop from DIW and bitplane DMA limits, but sprites and raster effects can still produce visible output beyond those limits. Fuzzball NoIntro therefore reported a 320x200 crop while rendering part of its playfield below that region, clipping the bottom of the game screen.

Disabling and re-enabling AutoCrop appeared to improve the result because it reset the cached custom limits and temporarily fell back to the full source surface.

## User impact

Native AutoCrop now preserves real content outside the hardware-reported limits without restoring the broad minimum-frame guard that previously retained intentional black borders. Intermittent content remains included until the hardware source geometry changes, preventing crop oscillation across blank or transition frames.

## Validation

- `cmake --build build --parallel`
- `bash tests/test_libretro_crop_policy.sh`
- `tests/test_gfx_geometry.sh`
- Fuzzball NoIntro: detected 320x200 bounds expand to a stable 320x258 crop from startup, preserving the lower playfield without toggling AutoCrop
- Fuzzball WHDBooter entry: AutoCrop remains disabled and its configured 720x512 manual crop remains unchanged
