### PR TITLE
fix(gfx): detect non-black autocrop borders

### DIFF
--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -117,6 +117,30 @@ static inline bool amiberry_auto_crop_detect_surface_background_color(
 	return true;
 }
 
+static inline bool amiberry_auto_crop_find_dominant_color(
+	std::vector<uint32_t>& samples, uint32_t& dominant_rgb)
+{
+	if (samples.empty()) {
+		return false;
+	}
+	std::sort(samples.begin(), samples.end());
+	dominant_rgb = samples.front();
+	size_t dominant_count = 1;
+	size_t run_start = 0;
+	for (size_t i = 1; i <= samples.size(); i++) {
+		if (i < samples.size() && samples[i] == samples[run_start]) {
+			continue;
+		}
+		const size_t run_count = i - run_start;
+		if (run_count > dominant_count) {
+			dominant_rgb = samples[run_start];
+			dominant_count = run_count;
+		}
+		run_start = i;
+	}
+	return dominant_count * 4 >= samples.size() * 3;
+}
+
 static inline bool amiberry_auto_crop_detect_border_color(
 	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& crop,
 	AmiberryAutoCropScanState& state)
@@ -127,38 +151,49 @@ static inline bool amiberry_auto_crop_detect_border_color(
 	const int bottom = amiberry_auto_crop_rect_bottom(crop);
 	const int horizontal_step = std::max(1, crop.w / 64);
 	const int vertical_step = std::max(1, crop.h / 64);
+	uint32_t side_rgb[4];
 	int sampled_sides = 0;
+	int side_color_count = 0;
 	const auto add_sample = [&](const int x, const int y) {
 		state.border_samples.push_back(
 			amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask);
 	};
+	const auto finish_side = [&]() {
+		uint32_t dominant_rgb;
+		sampled_sides++;
+		if (amiberry_auto_crop_find_dominant_color(
+			state.border_samples, dominant_rgb)) {
+			side_rgb[side_color_count++] = dominant_rgb;
+		}
+		state.border_samples.clear();
+	};
 
 	if (crop.y > 0) {
-		sampled_sides++;
 		for (int x = crop.x; x < right; x += horizontal_step) {
 			add_sample(x, crop.y - 1);
 		}
+		finish_side();
 	}
 	if (bottom < buffer.height) {
-		sampled_sides++;
 		for (int x = crop.x; x < right; x += horizontal_step) {
 			add_sample(x, bottom);
 		}
+		finish_side();
 	}
 	if (crop.x > 0) {
-		sampled_sides++;
 		for (int y = crop.y; y < bottom; y += vertical_step) {
 			add_sample(crop.x - 1, y);
 		}
+		finish_side();
 	}
 	if (right < buffer.width) {
-		sampled_sides++;
 		for (int y = crop.y; y < bottom; y += vertical_step) {
 			add_sample(right, y);
 		}
+		finish_side();
 	}
 
-	if (state.border_samples.empty()) {
+	if (sampled_sides == 0) {
 		return false;
 	}
 	const auto use_surface_background = [&]() {
@@ -174,26 +209,27 @@ static inline bool amiberry_auto_crop_detect_border_color(
 	if (sampled_sides < 2) {
 		return use_surface_background();
 	}
-	std::sort(state.border_samples.begin(), state.border_samples.end());
-	uint32_t most_common = state.border_samples.front();
-	size_t most_common_count = 1;
-	size_t run_start = 0;
-	for (size_t i = 1; i <= state.border_samples.size(); i++) {
-		if (i < state.border_samples.size()
-			&& state.border_samples[i] == state.border_samples[run_start]) {
-			continue;
+
+	uint32_t most_common = 0;
+	int most_common_sides = 0;
+	bool tied = false;
+	for (int i = 0; i < side_color_count; i++) {
+		int matches = 0;
+		for (int j = 0; j < side_color_count; j++) {
+			matches += side_rgb[i] == side_rgb[j];
 		}
-		const size_t run_count = i - run_start;
-		if (run_count > most_common_count) {
-			most_common = state.border_samples[run_start];
-			most_common_count = run_count;
+		if (matches > most_common_sides) {
+			most_common = side_rgb[i];
+			most_common_sides = matches;
+			tied = false;
+		} else if (matches == most_common_sides && side_rgb[i] != most_common) {
+			tied = true;
 		}
-		run_start = i;
 	}
 
-	// A mixed perimeter may contain real display output. Use the cleared
-	// surface background so the component scan can preserve that content.
-	if (most_common_count * 4 < state.border_samples.size() * 3) {
+	// Give each side one vote so a long content edge cannot outweigh a
+	// consistent border on multiple shorter edges.
+	if (most_common_sides < 2 || tied) {
 		return use_surface_background();
 	}
 	state.border_rgb = most_common;

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -224,9 +224,9 @@ static inline bool amiberry_auto_crop_detect_border_color(
 	}
 
 	// Give each side one vote so a long content edge cannot outweigh a
-	// consistent border on multiple shorter edges. Require a strict majority
-	// of all sampled sides before hiding pixels of the selected color.
-	if (most_common_sides * 2 <= sampled_sides) {
+	// consistent border on multiple shorter edges. Require at least 75% of
+	// all sampled sides before hiding pixels of the selected color.
+	if (most_common_sides * 4 < sampled_sides * 3) {
 		return use_surface_background();
 	}
 	state.border_rgb = most_common;

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -84,6 +84,39 @@ static inline bool amiberry_auto_crop_pixel_is_visible(
 		!= border_rgb;
 }
 
+static inline bool amiberry_auto_crop_detect_surface_background_color(
+	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& crop,
+	uint32_t& background_rgb)
+{
+	const int corner_x[] = { 0, buffer.width - 1, 0, buffer.width - 1 };
+	const int corner_y[] = { 0, 0, buffer.height - 1, buffer.height - 1 };
+	uint32_t corner_rgb[4];
+	int corner_count = 0;
+	for (int i = 0; i < 4; i++) {
+		if (!amiberry_auto_crop_rect_contains(crop, corner_x[i], corner_y[i])) {
+			corner_rgb[corner_count++] = amiberry_auto_crop_read_pixel(
+				buffer, corner_x[i], corner_y[i]) & buffer.rgb_mask;
+		}
+	}
+	if (corner_count == 0) {
+		return false;
+	}
+
+	background_rgb = corner_rgb[0];
+	int background_count = 0;
+	for (int i = 0; i < corner_count; i++) {
+		int matches = 0;
+		for (int j = 0; j < corner_count; j++) {
+			matches += corner_rgb[i] == corner_rgb[j];
+		}
+		if (matches > background_count) {
+			background_rgb = corner_rgb[i];
+			background_count = matches;
+		}
+	}
+	return true;
+}
+
 static inline bool amiberry_auto_crop_detect_border_color(
 	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& crop,
 	AmiberryAutoCropScanState& state)
@@ -94,27 +127,32 @@ static inline bool amiberry_auto_crop_detect_border_color(
 	const int bottom = amiberry_auto_crop_rect_bottom(crop);
 	const int horizontal_step = std::max(1, crop.w / 64);
 	const int vertical_step = std::max(1, crop.h / 64);
+	int sampled_sides = 0;
 	const auto add_sample = [&](const int x, const int y) {
 		state.border_samples.push_back(
 			amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask);
 	};
 
 	if (crop.y > 0) {
+		sampled_sides++;
 		for (int x = crop.x; x < right; x += horizontal_step) {
 			add_sample(x, crop.y - 1);
 		}
 	}
 	if (bottom < buffer.height) {
+		sampled_sides++;
 		for (int x = crop.x; x < right; x += horizontal_step) {
 			add_sample(x, bottom);
 		}
 	}
 	if (crop.x > 0) {
+		sampled_sides++;
 		for (int y = crop.y; y < bottom; y += vertical_step) {
 			add_sample(crop.x - 1, y);
 		}
 	}
 	if (right < buffer.width) {
+		sampled_sides++;
 		for (int y = crop.y; y < bottom; y += vertical_step) {
 			add_sample(right, y);
 		}
@@ -122,6 +160,16 @@ static inline bool amiberry_auto_crop_detect_border_color(
 
 	if (state.border_samples.empty()) {
 		return false;
+	}
+	// A single uniform edge may be real overscan content. Without a second
+	// side to corroborate it, use the cleared surface background instead.
+	if (sampled_sides < 2) {
+		if (!amiberry_auto_crop_detect_surface_background_color(
+			buffer, crop, state.border_rgb)) {
+			return false;
+		}
+		state.border_valid = true;
+		return true;
 	}
 	std::sort(state.border_samples.begin(), state.border_samples.end());
 	uint32_t most_common = state.border_samples.front();
@@ -157,33 +205,9 @@ static inline void amiberry_auto_crop_exclude_surface_background(
 	// Pixels outside the emulated raster are cleared to an outside corner color.
 	// Exclude only edge-connected regions of that exact color so real content
 	// in another color can still extend all the way to a surface edge.
-	const int corner_x[] = { 0, buffer.width - 1, 0, buffer.width - 1 };
-	const int corner_y[] = { 0, 0, buffer.height - 1, buffer.height - 1 };
-	uint32_t corner_rgb[4];
-	int corner_count = 0;
-	for (int i = 0; i < 4; i++) {
-		if (!amiberry_auto_crop_rect_contains(crop, corner_x[i], corner_y[i])) {
-			corner_rgb[corner_count++] = amiberry_auto_crop_read_pixel(
-				buffer, corner_x[i], corner_y[i]) & buffer.rgb_mask;
-		}
-	}
-	if (corner_count == 0) {
-		return;
-	}
-
-	uint32_t background_rgb = corner_rgb[0];
-	int background_count = 0;
-	for (int i = 0; i < corner_count; i++) {
-		int matches = 0;
-		for (int j = 0; j < corner_count; j++) {
-			matches += corner_rgb[i] == corner_rgb[j];
-		}
-		if (matches > background_count) {
-			background_rgb = corner_rgb[i];
-			background_count = matches;
-		}
-	}
-	if (background_rgb == border_rgb) {
+	uint32_t background_rgb;
+	if (!amiberry_auto_crop_detect_surface_background_color(
+		buffer, crop, background_rgb) || background_rgb == border_rgb) {
 		return;
 	}
 

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -30,6 +30,14 @@ struct AmiberryAutoCropScanState {
 	bool border_valid = false;
 };
 
+static inline bool amiberry_auto_crop_border_state_changed(
+	const uint32_t previous_rgb, const bool previous_valid,
+	const uint32_t current_rgb, const bool current_valid)
+{
+	return previous_valid != current_valid
+		|| (current_valid && previous_rgb != current_rgb);
+}
+
 static inline int amiberry_auto_crop_rect_right(const AmiberryAutoCropRect& rect)
 {
 	return rect.x + rect.w;

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -161,15 +161,18 @@ static inline bool amiberry_auto_crop_detect_border_color(
 	if (state.border_samples.empty()) {
 		return false;
 	}
-	// A single uniform edge may be real overscan content. Without a second
-	// side to corroborate it, use the cleared surface background instead.
-	if (sampled_sides < 2) {
+	const auto use_surface_background = [&]() {
 		if (!amiberry_auto_crop_detect_surface_background_color(
 			buffer, crop, state.border_rgb)) {
 			return false;
 		}
 		state.border_valid = true;
 		return true;
+	};
+	// A single uniform edge may be real overscan content. Without a second
+	// side to corroborate it, use the cleared surface background instead.
+	if (sampled_sides < 2) {
+		return use_surface_background();
 	}
 	std::sort(state.border_samples.begin(), state.border_samples.end());
 	uint32_t most_common = state.border_samples.front();
@@ -188,10 +191,10 @@ static inline bool amiberry_auto_crop_detect_border_color(
 		run_start = i;
 	}
 
-	// If the immediate perimeter is not predominantly one color, it may
-	// contain real display output rather than a removable border.
+	// A mixed perimeter may contain real display output. Use the cleared
+	// surface background so the component scan can preserve that content.
 	if (most_common_count * 4 < state.border_samples.size() * 3) {
-		return false;
+		return use_surface_background();
 	}
 	state.border_rgb = most_common;
 	state.border_valid = true;

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -212,7 +212,6 @@ static inline bool amiberry_auto_crop_detect_border_color(
 
 	uint32_t most_common = 0;
 	int most_common_sides = 0;
-	bool tied = false;
 	for (int i = 0; i < side_color_count; i++) {
 		int matches = 0;
 		for (int j = 0; j < side_color_count; j++) {
@@ -221,15 +220,13 @@ static inline bool amiberry_auto_crop_detect_border_color(
 		if (matches > most_common_sides) {
 			most_common = side_rgb[i];
 			most_common_sides = matches;
-			tied = false;
-		} else if (matches == most_common_sides && side_rgb[i] != most_common) {
-			tied = true;
 		}
 	}
 
 	// Give each side one vote so a long content edge cannot outweigh a
-	// consistent border on multiple shorter edges.
-	if (most_common_sides < 2 || tied) {
+	// consistent border on multiple shorter edges. Require a strict majority
+	// of all sampled sides before hiding pixels of the selected color.
+	if (most_common_sides * 2 <= sampled_sides) {
 		return use_surface_background();
 	}
 	state.border_rgb = most_common;

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -25,6 +25,9 @@ struct AmiberryAutoCropPixelBuffer {
 struct AmiberryAutoCropScanState {
 	std::vector<uint8_t> visited;
 	std::vector<int> pending;
+	std::vector<uint32_t> border_samples;
+	uint32_t border_rgb = 0;
+	bool border_valid = false;
 };
 
 static inline int amiberry_auto_crop_rect_right(const AmiberryAutoCropRect& rect)
@@ -73,10 +76,77 @@ static inline bool amiberry_auto_crop_pixel_is_visible(
 		!= border_rgb;
 }
 
+static inline bool amiberry_auto_crop_detect_border_color(
+	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& crop,
+	AmiberryAutoCropScanState& state)
+{
+	state.border_samples.clear();
+	state.border_valid = false;
+	const int right = amiberry_auto_crop_rect_right(crop);
+	const int bottom = amiberry_auto_crop_rect_bottom(crop);
+	const int horizontal_step = std::max(1, crop.w / 64);
+	const int vertical_step = std::max(1, crop.h / 64);
+	const auto add_sample = [&](const int x, const int y) {
+		state.border_samples.push_back(
+			amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask);
+	};
+
+	if (crop.y > 0) {
+		for (int x = crop.x; x < right; x += horizontal_step) {
+			add_sample(x, crop.y - 1);
+		}
+	}
+	if (bottom < buffer.height) {
+		for (int x = crop.x; x < right; x += horizontal_step) {
+			add_sample(x, bottom);
+		}
+	}
+	if (crop.x > 0) {
+		for (int y = crop.y; y < bottom; y += vertical_step) {
+			add_sample(crop.x - 1, y);
+		}
+	}
+	if (right < buffer.width) {
+		for (int y = crop.y; y < bottom; y += vertical_step) {
+			add_sample(right, y);
+		}
+	}
+
+	if (state.border_samples.empty()) {
+		return false;
+	}
+	std::sort(state.border_samples.begin(), state.border_samples.end());
+	uint32_t most_common = state.border_samples.front();
+	size_t most_common_count = 1;
+	size_t run_start = 0;
+	for (size_t i = 1; i <= state.border_samples.size(); i++) {
+		if (i < state.border_samples.size()
+			&& state.border_samples[i] == state.border_samples[run_start]) {
+			continue;
+		}
+		const size_t run_count = i - run_start;
+		if (run_count > most_common_count) {
+			most_common = state.border_samples[run_start];
+			most_common_count = run_count;
+		}
+		run_start = i;
+	}
+
+	// If the immediate perimeter is not predominantly one color, it may
+	// contain real display output rather than a removable border.
+	if (most_common_count * 4 < state.border_samples.size() * 3) {
+		return false;
+	}
+	state.border_rgb = most_common;
+	state.border_valid = true;
+	return true;
+}
+
 static inline bool amiberry_auto_crop_expand_to_visible_content(
 	const AmiberryAutoCropPixelBuffer& buffer, const int min_outside_pixels,
 	AmiberryAutoCropRect& crop, AmiberryAutoCropScanState& state)
 {
+	state.border_valid = false;
 	if (!amiberry_auto_crop_buffer_valid(buffer)
 		|| crop.w <= 0 || crop.h <= 0
 		|| crop.x < 0 || crop.y < 0
@@ -85,11 +155,10 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 		return false;
 	}
 
-	const uint32_t border_rgb = amiberry_auto_crop_read_pixel(buffer, 0, 0)
-		& buffer.rgb_mask;
-	if (border_rgb != 0) {
+	if (!amiberry_auto_crop_detect_border_color(buffer, crop, state)) {
 		return false;
 	}
+	const uint32_t border_rgb = state.border_rgb;
 
 	const size_t pixel_count = static_cast<size_t>(buffer.width) * buffer.height;
 	state.visited.assign(pixel_count, 0);
@@ -119,6 +188,7 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 			int component_min_y = y;
 			int component_max_x = x;
 			int component_max_y = y;
+			bool component_touches_surface_edge = false;
 			while (!state.pending.empty()) {
 				const int index = state.pending.back();
 				state.pending.pop_back();
@@ -129,6 +199,8 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 				component_min_y = std::min(component_min_y, pixel_y);
 				component_max_x = std::max(component_max_x, pixel_x);
 				component_max_y = std::max(component_max_y, pixel_y);
+				component_touches_surface_edge |= pixel_x == 0 || pixel_y == 0
+					|| pixel_x == buffer.width - 1 || pixel_y == buffer.height - 1;
 
 				for (int neighbor_y = std::max(0, pixel_y - 1);
 					neighbor_y <= std::min(buffer.height - 1, pixel_y + 1); neighbor_y++) {
@@ -150,7 +222,7 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 				}
 			}
 
-			if (component_pixels < required_pixels) {
+			if (component_pixels < required_pixels || component_touches_surface_edge) {
 				continue;
 			}
 			const int right = std::max(amiberry_auto_crop_rect_right(expanded),

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -150,6 +150,57 @@ static inline bool amiberry_auto_crop_detect_border_color(
 	return true;
 }
 
+static inline void amiberry_auto_crop_exclude_surface_background(
+	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& crop,
+	const uint32_t border_rgb, AmiberryAutoCropScanState& state)
+{
+	// Pixels outside the emulated raster are cleared to the corner color.
+	// Exclude only edge-connected regions of that exact color so real content
+	// in another color can still extend all the way to a surface edge.
+	const uint32_t background_rgb = amiberry_auto_crop_read_pixel(buffer, 0, 0)
+		& buffer.rgb_mask;
+	if (background_rgb == border_rgb) {
+		return;
+	}
+
+	const auto add_background_pixel = [&](const int x, const int y) {
+		if (amiberry_auto_crop_rect_contains(crop, x, y)) {
+			return;
+		}
+		const int index = y * buffer.width + x;
+		if (state.visited[index]
+			|| (amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)
+				!= background_rgb) {
+			return;
+		}
+		state.visited[index] = 1;
+		state.pending.push_back(index);
+	};
+
+	for (int x = 0; x < buffer.width; x++) {
+		add_background_pixel(x, 0);
+		add_background_pixel(x, buffer.height - 1);
+	}
+	for (int y = 1; y < buffer.height - 1; y++) {
+		add_background_pixel(0, y);
+		add_background_pixel(buffer.width - 1, y);
+	}
+
+	while (!state.pending.empty()) {
+		const int index = state.pending.back();
+		state.pending.pop_back();
+		const int pixel_x = index % buffer.width;
+		const int pixel_y = index / buffer.width;
+		for (int neighbor_y = std::max(0, pixel_y - 1);
+			neighbor_y <= std::min(buffer.height - 1, pixel_y + 1); neighbor_y++) {
+			for (int neighbor_x = std::max(0, pixel_x - 1);
+				neighbor_x <= std::min(buffer.width - 1, pixel_x + 1); neighbor_x++) {
+				add_background_pixel(neighbor_x, neighbor_y);
+			}
+		}
+	}
+}
+
 static inline bool amiberry_auto_crop_expand_to_visible_content(
 	const AmiberryAutoCropPixelBuffer& buffer, const int min_outside_pixels,
 	AmiberryAutoCropRect& crop, AmiberryAutoCropScanState& state)
@@ -171,6 +222,7 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 	const size_t pixel_count = static_cast<size_t>(buffer.width) * buffer.height;
 	state.visited.assign(pixel_count, 0);
 	state.pending.clear();
+	amiberry_auto_crop_exclude_surface_background(buffer, crop, border_rgb, state);
 	const int required_pixels = std::max(1, min_outside_pixels);
 	AmiberryAutoCropRect expanded = crop;
 	bool changed = false;
@@ -196,7 +248,6 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 			int component_min_y = y;
 			int component_max_x = x;
 			int component_max_y = y;
-			bool component_touches_surface_edge = false;
 			while (!state.pending.empty()) {
 				const int index = state.pending.back();
 				state.pending.pop_back();
@@ -207,8 +258,6 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 				component_min_y = std::min(component_min_y, pixel_y);
 				component_max_x = std::max(component_max_x, pixel_x);
 				component_max_y = std::max(component_max_y, pixel_y);
-				component_touches_surface_edge |= pixel_x == 0 || pixel_y == 0
-					|| pixel_x == buffer.width - 1 || pixel_y == buffer.height - 1;
 
 				for (int neighbor_y = std::max(0, pixel_y - 1);
 					neighbor_y <= std::min(buffer.height - 1, pixel_y + 1); neighbor_y++) {
@@ -230,7 +279,7 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 				}
 			}
 
-			if (component_pixels < required_pixels || component_touches_surface_edge) {
+			if (component_pixels < required_pixels) {
 				continue;
 			}
 			const int right = std::max(amiberry_auto_crop_rect_right(expanded),

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -154,11 +154,35 @@ static inline void amiberry_auto_crop_exclude_surface_background(
 	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& crop,
 	const uint32_t border_rgb, AmiberryAutoCropScanState& state)
 {
-	// Pixels outside the emulated raster are cleared to the corner color.
+	// Pixels outside the emulated raster are cleared to an outside corner color.
 	// Exclude only edge-connected regions of that exact color so real content
 	// in another color can still extend all the way to a surface edge.
-	const uint32_t background_rgb = amiberry_auto_crop_read_pixel(buffer, 0, 0)
-		& buffer.rgb_mask;
+	const int corner_x[] = { 0, buffer.width - 1, 0, buffer.width - 1 };
+	const int corner_y[] = { 0, 0, buffer.height - 1, buffer.height - 1 };
+	uint32_t corner_rgb[4];
+	int corner_count = 0;
+	for (int i = 0; i < 4; i++) {
+		if (!amiberry_auto_crop_rect_contains(crop, corner_x[i], corner_y[i])) {
+			corner_rgb[corner_count++] = amiberry_auto_crop_read_pixel(
+				buffer, corner_x[i], corner_y[i]) & buffer.rgb_mask;
+		}
+	}
+	if (corner_count == 0) {
+		return;
+	}
+
+	uint32_t background_rgb = corner_rgb[0];
+	int background_count = 0;
+	for (int i = 0; i < corner_count; i++) {
+		int matches = 0;
+		for (int j = 0; j < corner_count; j++) {
+			matches += corner_rgb[i] == corner_rgb[j];
+		}
+		if (matches > background_count) {
+			background_rgb = corner_rgb[i];
+			background_count = matches;
+		}
+	}
 	if (background_rgb == border_rgb) {
 		return;
 	}

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -133,6 +133,8 @@ struct AutoCropVisibleState {
 	SDL_Rect visible_rect{};
 	int hres = 0;
 	int vres = 0;
+	uint32_t border_rgb = 0;
+	bool border_valid = false;
 	bool valid = false;
 };
 
@@ -254,7 +256,8 @@ static void expand_auto_crop_rect_to_visible_content(const SDL_Surface* surface,
 
 static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 	const SDL_Rect& source_rect, SDL_Rect& visible_rect, const int hres,
-	const int vres, AutoCropVisibleState& state, const bool reset)
+	const int vres, const uint32_t border_rgb, const bool border_valid,
+	AutoCropVisibleState& state, const bool reset)
 {
 	if (!surface || surface->w <= 0 || surface->h <= 0
 		|| source_rect.w <= 0 || source_rect.h <= 0
@@ -268,7 +271,8 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 		|| state.surface_h != surface->h
 		|| !auto_crop_rect_equals(state.source_rect, source_rect)
 		|| state.hres != hres
-		|| state.vres != vres;
+		|| state.vres != vres
+		|| (border_valid && (!state.border_valid || state.border_rgb != border_rgb));
 	if (reset || source_changed || !state.valid) {
 		state = {};
 		state.surface = surface;
@@ -278,16 +282,22 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 		state.visible_rect = visible_rect;
 		state.hres = hres;
 		state.vres = vres;
+		state.border_rgb = border_rgb;
+		state.border_valid = border_valid;
 		state.valid = true;
 		return;
 	}
 
 	// Pixel content beyond DIW/bitplane limits may be intermittent (sprites,
 	// raster effects, or blank frames between screens). Once observed, retain
-	// those bounds until the hardware source geometry actually changes.
+	// those bounds until the hardware geometry or border color changes.
 	visible_rect = auto_crop_rect_union(visible_rect, state.visible_rect);
 	clamp_auto_crop_rect(surface, visible_rect);
 	state.visible_rect = visible_rect;
+	if (border_valid) {
+		state.border_rgb = border_rgb;
+		state.border_valid = true;
+	}
 }
 
 static int auto_crop_minimum_width(const int hres)
@@ -2055,7 +2065,7 @@ void auto_crop_image()
 		// conservative minimum frame that keeps intentional black borders.
 		expand_auto_crop_rect_to_visible_content(surface, crop_rect, scan_state);
 		preserve_auto_crop_visible_content(surface, source_crop_rect, crop_rect,
-			hres, vres, visible_state,
+			hres, vres, scan_state.border_rgb, scan_state.border_valid, visible_state,
 			force_auto_crop || last_autocrop != currprefs.gfx_auto_crop);
 		cx = crop_rect.x;
 		cy = crop_rect.y;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -272,7 +272,8 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 		|| !auto_crop_rect_equals(state.source_rect, source_rect)
 		|| state.hres != hres
 		|| state.vres != vres
-		|| (border_valid && (!state.border_valid || state.border_rgb != border_rgb));
+		|| amiberry_auto_crop_border_state_changed(state.border_rgb, state.border_valid,
+			border_rgb, border_valid);
 	if (reset || source_changed || !state.valid) {
 		state = {};
 		state.surface = surface;

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -160,6 +160,23 @@ static void test_expands_past_non_black_border_for_real_content()
 	expect_eq(crop.h, 24, "Crop should expand to the connected content bottom");
 }
 
+static void test_border_state_changes_reset_preserved_crop()
+{
+	constexpr uint32_t first_color = 0x00112233u;
+	constexpr uint32_t second_color = 0x00445566u;
+
+	expect_true(amiberry_auto_crop_border_state_changed(first_color, true,
+		first_color, false), "Losing a valid border must reset preserved crop bounds");
+	expect_true(amiberry_auto_crop_border_state_changed(first_color, false,
+		first_color, true), "Detecting a valid border must reset preserved crop bounds");
+	expect_true(amiberry_auto_crop_border_state_changed(first_color, true,
+		second_color, true), "Changing border color must reset preserved crop bounds");
+	expect_true(!amiberry_auto_crop_border_state_changed(first_color, true,
+		first_color, true), "An unchanged valid border must preserve crop bounds");
+	expect_true(!amiberry_auto_crop_border_state_changed(first_color, false,
+		second_color, false), "Ambiguous border samples must ignore stale colors");
+}
+
 int main()
 {
 	test_expands_to_connected_visible_content();
@@ -167,5 +184,6 @@ int main()
 	test_ignores_scattered_outside_pixels();
 	test_keeps_crop_inside_non_black_border();
 	test_expands_past_non_black_border_for_real_content();
+	test_border_state_changes_reset_preserved_crop();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -281,6 +281,37 @@ static void test_mixed_perimeter_keeps_non_black_border()
 	expect_eq(crop.h, 21, "Crop should include content without including gray border");
 }
 
+static void test_two_sided_color_is_not_perimeter_majority()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t horizontal_color = 0x0000ff00u;
+	constexpr uint32_t left_color = 0x00ff0000u;
+	constexpr uint32_t right_color = 0x000000ffu;
+	std::vector<uint32_t> pixels(width * height, 0);
+	for (int x = 8; x < 32; x++) {
+		pixels[7 * width + x] = horizontal_color;
+		pixels[28 * width + x] = horizontal_color;
+	}
+	for (int y = 8; y < 28; y++) {
+		pixels[y * width + 7] = left_color;
+		pixels[y * width + 32] = right_color;
+	}
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(changed, "A two-of-four side color must remain visible content");
+	expect_true(state.border_valid, "Split perimeter should use surface background");
+	expect_eq(state.border_rgb, 0u, "A perimeter plurality must not become border color");
+	expect_eq(crop.x, 7, "Visible left edge should expand the crop left");
+	expect_eq(crop.y, 7, "Visible top edge should expand the crop upward");
+	expect_eq(crop.w, 26, "Visible side edges should expand the crop width");
+	expect_eq(crop.h, 22, "Visible horizontal edges should expand the crop height");
+}
+
 static void test_border_state_changes_reset_preserved_crop()
 {
 	constexpr uint32_t first_color = 0x00112233u;
@@ -310,6 +341,7 @@ int main()
 	test_one_sided_uniform_content_is_not_border();
 	test_ambiguous_perimeter_preserves_content();
 	test_mixed_perimeter_keeps_non_black_border();
+	test_two_sided_color_is_not_perimeter_majority();
 	test_border_state_changes_reset_preserved_crop();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -185,6 +185,27 @@ static void test_preserves_content_reaching_surface_edge()
 	expect_eq(crop.h, 32, "Crop should include content through the surface bottom");
 }
 
+static void test_chooses_background_outside_origin_anchored_crop()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t border_color = 0x00aaaaaau;
+	std::vector<uint32_t> pixels(width * height, 0);
+	add_colored_border(pixels, width, height, border_color);
+	pixels[0] = 0x00ff0000u;
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 0, 0, 24, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(!changed, "An in-crop origin pixel must not become the surface background");
+	expect_eq(crop.x, 0, "Origin-anchored crop must keep its x origin");
+	expect_eq(crop.y, 0, "Origin-anchored crop must keep its y origin");
+	expect_eq(crop.w, 24, "Cleared right edge must not widen an origin-anchored crop");
+	expect_eq(crop.h, 20, "Cleared bottom edge must not increase crop height");
+}
+
 static void test_border_state_changes_reset_preserved_crop()
 {
 	constexpr uint32_t first_color = 0x00112233u;
@@ -210,6 +231,7 @@ int main()
 	test_keeps_crop_inside_non_black_border();
 	test_expands_past_non_black_border_for_real_content();
 	test_preserves_content_reaching_surface_edge();
+	test_chooses_background_outside_origin_anchored_crop();
 	test_border_state_changes_reset_preserved_crop();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -45,6 +45,16 @@ static void add_lower_content(std::vector<uint32_t>& pixels, const int width)
 	}
 }
 
+static void add_colored_border(std::vector<uint32_t>& pixels, const int width,
+	const int height, const uint32_t color)
+{
+	for (int y = 2; y < height - 2; y++) {
+		for (int x = 2; x < width - 2; x++) {
+			pixels[y * width + x] = color;
+		}
+	}
+}
+
 static void test_expands_to_connected_visible_content()
 {
 	constexpr int width = 40;
@@ -103,10 +113,59 @@ static void test_ignores_scattered_outside_pixels()
 	expect_eq(crop.h, 12, "Scattered pixels must not change crop height");
 }
 
+static void test_keeps_crop_inside_non_black_border()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t border_color = 0x00aaaaaau;
+	std::vector<uint32_t> pixels(width * height, 0);
+	add_colored_border(pixels, width, height, border_color);
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(!changed, "A non-black border must not expand the hardware crop");
+	expect_true(state.border_valid, "A consistent non-black border should be detected");
+	expect_eq(state.border_rgb, border_color, "Detected border color should match the perimeter");
+	expect_eq(crop.x, 8, "Outer black surface edge must not move the crop left");
+	expect_eq(crop.y, 8, "Outer black surface edge must not move the crop top");
+	expect_eq(crop.w, 24, "Outer black surface edge must not widen the crop");
+	expect_eq(crop.h, 20, "Outer black surface edge must not increase crop height");
+}
+
+static void test_expands_past_non_black_border_for_real_content()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t border_color = 0x00aaaaaau;
+	std::vector<uint32_t> pixels(width * height, 0);
+	add_colored_border(pixels, width, height, border_color);
+	for (int y = 30; y < 32; y++) {
+		for (int x = 12; x < 28; x++) {
+			pixels[y * width + x] = 0x0000ff00u;
+		}
+	}
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(changed, "Connected content should expand through a non-black border");
+	expect_eq(crop.x, 8, "Bottom-only content should keep the crop x origin");
+	expect_eq(crop.y, 8, "Bottom-only content should keep the crop y origin");
+	expect_eq(crop.w, 24, "Bottom-only content should keep the crop width");
+	expect_eq(crop.h, 24, "Crop should expand to the connected content bottom");
+}
+
 int main()
 {
 	test_expands_to_connected_visible_content();
 	test_ignores_distant_speck_when_content_expands();
 	test_ignores_scattered_outside_pixels();
+	test_keeps_crop_inside_non_black_border();
+	test_expands_past_non_black_border_for_real_content();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -160,6 +160,31 @@ static void test_expands_past_non_black_border_for_real_content()
 	expect_eq(crop.h, 24, "Crop should expand to the connected content bottom");
 }
 
+static void test_preserves_content_reaching_surface_edge()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t border_color = 0x00aaaaaau;
+	std::vector<uint32_t> pixels(width * height, 0);
+	add_colored_border(pixels, width, height, border_color);
+	for (int y = 30; y < height; y++) {
+		for (int x = 12; x < 28; x++) {
+			pixels[y * width + x] = 0x0000ff00u;
+		}
+	}
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(changed, "Content reaching the surface edge should expand the crop");
+	expect_eq(crop.x, 8, "Edge-reaching bottom content should keep the crop x origin");
+	expect_eq(crop.y, 8, "Edge-reaching bottom content should keep the crop y origin");
+	expect_eq(crop.w, 24, "Edge-reaching bottom content should keep the crop width");
+	expect_eq(crop.h, 32, "Crop should include content through the surface bottom");
+}
+
 static void test_border_state_changes_reset_preserved_crop()
 {
 	constexpr uint32_t first_color = 0x00112233u;
@@ -184,6 +209,7 @@ int main()
 	test_ignores_scattered_outside_pixels();
 	test_keeps_crop_inside_non_black_border();
 	test_expands_past_non_black_border_for_real_content();
+	test_preserves_content_reaching_surface_edge();
 	test_border_state_changes_reset_preserved_crop();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -206,6 +206,30 @@ static void test_chooses_background_outside_origin_anchored_crop()
 	expect_eq(crop.h, 20, "Cleared bottom edge must not increase crop height");
 }
 
+static void test_one_sided_uniform_content_is_not_border()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t content_color = 0x0000ff00u;
+	std::vector<uint32_t> pixels(width * height, 0);
+	for (int x = 0; x < width; x++) {
+		pixels[20 * width + x] = content_color;
+	}
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 0, 0, width, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(changed, "Uniform content on the only outside edge must remain visible");
+	expect_true(state.border_valid, "Outside corners should provide a fallback background");
+	expect_eq(state.border_rgb, 0u, "One-sided content must not become the border color");
+	expect_eq(crop.x, 0, "Full-width content must keep the crop x origin");
+	expect_eq(crop.y, 0, "Content below the crop must keep its y origin");
+	expect_eq(crop.w, width, "Full-width content must keep the crop width");
+	expect_eq(crop.h, 21, "Crop should expand through the adjacent content row");
+}
+
 static void test_border_state_changes_reset_preserved_crop()
 {
 	constexpr uint32_t first_color = 0x00112233u;
@@ -232,6 +256,7 @@ int main()
 	test_expands_past_non_black_border_for_real_content();
 	test_preserves_content_reaching_surface_edge();
 	test_chooses_background_outside_origin_anchored_crop();
+	test_one_sided_uniform_content_is_not_border();
 	test_border_state_changes_reset_preserved_crop();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -312,6 +312,31 @@ static void test_two_sided_color_is_not_perimeter_majority()
 	expect_eq(crop.h, 22, "Visible horizontal edges should expand the crop height");
 }
 
+static void test_two_of_three_sides_is_not_border_confidence()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t content_color = 0x0000ff00u;
+	std::vector<uint32_t> pixels(width * height, 0);
+	for (int x = 0; x < 24; x++) {
+		pixels[7 * width + x] = content_color;
+		pixels[28 * width + x] = content_color;
+	}
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 0, 8, 24, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(changed, "A two-of-three side color must remain visible content");
+	expect_true(state.border_valid, "Low-confidence perimeter should use surface background");
+	expect_eq(state.border_rgb, 0u, "Two-of-three agreement must not become border color");
+	expect_eq(crop.x, 0, "Left-aligned crop must keep its x origin");
+	expect_eq(crop.y, 7, "Visible top edge should expand the crop upward");
+	expect_eq(crop.w, 24, "Horizontal content must keep the crop width");
+	expect_eq(crop.h, 22, "Visible top and bottom edges should expand crop height");
+}
+
 static void test_border_state_changes_reset_preserved_crop()
 {
 	constexpr uint32_t first_color = 0x00112233u;
@@ -342,6 +367,7 @@ int main()
 	test_ambiguous_perimeter_preserves_content();
 	test_mixed_perimeter_keeps_non_black_border();
 	test_two_sided_color_is_not_perimeter_majority();
+	test_two_of_three_sides_is_not_border_confidence();
 	test_border_state_changes_reset_preserved_crop();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -230,6 +230,30 @@ static void test_one_sided_uniform_content_is_not_border()
 	expect_eq(crop.h, 21, "Crop should expand through the adjacent content row");
 }
 
+static void test_ambiguous_perimeter_preserves_content()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t content_color = 0x0000ff00u;
+	std::vector<uint32_t> pixels(width * height, 0);
+	for (int x = 4; x < 36; x++) {
+		pixels[20 * width + x] = content_color;
+	}
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 4, 0, 32, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(changed, "Content on an ambiguous perimeter must remain visible");
+	expect_true(state.border_valid, "Ambiguous perimeter should use surface background");
+	expect_eq(state.border_rgb, 0u, "Ambiguous content must not become the border color");
+	expect_eq(crop.x, 4, "Lower content must keep the crop x origin");
+	expect_eq(crop.y, 0, "Top-aligned crop must keep its y origin");
+	expect_eq(crop.w, 32, "Lower content must keep the crop width");
+	expect_eq(crop.h, 21, "Crop should expand through ambiguous lower content");
+}
+
 static void test_border_state_changes_reset_preserved_crop()
 {
 	constexpr uint32_t first_color = 0x00112233u;
@@ -257,6 +281,7 @@ int main()
 	test_preserves_content_reaching_surface_edge();
 	test_chooses_background_outside_origin_anchored_crop();
 	test_one_sided_uniform_content_is_not_border();
+	test_ambiguous_perimeter_preserves_content();
 	test_border_state_changes_reset_preserved_crop();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -254,6 +254,33 @@ static void test_ambiguous_perimeter_preserves_content()
 	expect_eq(crop.h, 21, "Crop should expand through ambiguous lower content");
 }
 
+static void test_mixed_perimeter_keeps_non_black_border()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t border_color = 0x00aaaaaau;
+	constexpr uint32_t content_color = 0x0000ff00u;
+	std::vector<uint32_t> pixels(width * height, 0);
+	add_colored_border(pixels, width, height, border_color);
+	for (int x = 8; x < 32; x++) {
+		pixels[28 * width + x] = content_color;
+	}
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(changed, "Content on one side should expand a non-black border crop");
+	expect_true(state.border_valid, "Other sides should confirm the non-black border");
+	expect_eq(state.border_rgb, border_color,
+		"One content side must not replace the non-black border color");
+	expect_eq(crop.x, 8, "Mixed perimeter content must keep the crop x origin");
+	expect_eq(crop.y, 8, "Mixed perimeter content must keep the crop y origin");
+	expect_eq(crop.w, 24, "Mixed perimeter content must keep the crop width");
+	expect_eq(crop.h, 21, "Crop should include content without including gray border");
+}
+
 static void test_border_state_changes_reset_preserved_crop()
 {
 	constexpr uint32_t first_color = 0x00112233u;
@@ -282,6 +309,7 @@ int main()
 	test_chooses_background_outside_origin_anchored_crop();
 	test_one_sided_uniform_content_is_not_border();
 	test_ambiguous_perimeter_preserves_content();
+	test_mixed_perimeter_keeps_non_black_border();
 	test_border_state_changes_reset_preserved_crop();
 	return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

- detect the dominant border color immediately outside the hardware crop instead of assuming the surface corner is representative
- require at least 75% perimeter agreement before treating a color as border
- ignore outside components that touch the surface edge and reset stabilized bounds when the detected border color changes
- add regression coverage for non-black borders with and without real content beyond the hardware crop

## Root cause

The visible-content expansion added in #2205 used the top-left surface pixel as the border reference and only accepted black. PPC-OS3.1 uses gray overscan around its 640x256 guest screen, represented as a 640x512 line-doubled hardware crop. Because the surface corner remained black, the connected gray overscan was classified as visible content and expanded the crop to roughly 754x574.

## User impact

AutoCrop now keeps the PPC-OS3.1 presentation at the detected 640x512 physical rectangle while still preserving meaningful pixels rendered beyond DIW/bitplane limits. Ambiguous perimeters fall back to the hardware crop instead of guessing.

## Validation

- `cmake --build build --parallel`
- `tests/test_autocrop_helpers.sh`
- `bash tests/test_libretro_crop_policy.sh`
- `tests/test_gfx_geometry.sh`
- PPC-OS3.1: live crop remains `raw=640x512` / `final=640x512`, removing the gray overscan from the presented window
- Fuzzball NoIntro: live crop still expands from `raw=320x200` to `final=320x258`, preserving the lower playfield
