### PR TITLE
Fix live AutoCrop updates and filtered edge seams

### DIFF
--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -5436,8 +5436,8 @@ static bool inputdevice_handle_inputcode2(int monid, int code, int state, const 
 		break;
 #endif
 	case AKS_AUTO_CROP_IMAGE:
-		currprefs.gfx_auto_crop = !currprefs.gfx_auto_crop;
-		check_prefs_changed_gfx();
+		changed_prefs.gfx_auto_crop = !changed_prefs.gfx_auto_crop;
+		set_config_changed();
 		break;
 	case AKS_OSK:
 		if (vkbd_allowed(0))

--- a/src/osdep/crtemu.h
+++ b/src/osdep/crtemu.h
@@ -118,6 +118,7 @@ void crtemu_coordinates_window_to_bitmap( crtemu_t* crtemu, int width, int heigh
     #define CRTEMU_GL_COLOR_ATTACHMENT0 0x8ce0
     #define CRTEMU_GL_TEXTURE_WRAP_S 0x2802
     #define CRTEMU_GL_TEXTURE_WRAP_T 0x2803
+    #define CRTEMU_GL_CLAMP_TO_EDGE 0x812F
     #define CRTEMU_GL_CLAMP_TO_BORDER 0x812D
     #define CRTEMU_GL_TEXTURE_BORDER_COLOR 0x1004
 
@@ -178,6 +179,7 @@ typedef GLbitfield CRTEMU_GLbitfield;
 #define CRTEMU_GL_COLOR_ATTACHMENT0 GL_COLOR_ATTACHMENT0
 #define CRTEMU_GL_TEXTURE_WRAP_S GL_TEXTURE_WRAP_S
 #define CRTEMU_GL_TEXTURE_WRAP_T GL_TEXTURE_WRAP_T
+#define CRTEMU_GL_CLAMP_TO_EDGE GL_CLAMP_TO_EDGE
 #ifndef CRTEMU_WEBGL
     #if defined(GL_CLAMP_TO_BORDER) && !defined(__ANDROID__)
         #define CRTEMU_GL_CLAMP_TO_BORDER GL_CLAMP_TO_BORDER
@@ -2133,27 +2135,27 @@ crtemu_t* crtemu_create( crtemu_type_t type, void* memctx, bool force_mobile ) {
 		crtemu->VertexAttribPointer( 0, 4, CRTEMU_GL_FLOAT, CRTEMU_GL_FALSE, 4 * sizeof( CRTEMU_GLfloat ), 0 );
 	}
 
-#ifdef CRTEMU_WEBGL
-	// Avoid WebGL error "TEXTURE_2D at unit 0 is incomplete: Non-power-of-two textures must have a wrap mode of CLAMP_TO_EDGE."
+	// Full-screen passes sample all the way to the texture edges. Clamp them so
+	// linear filtering cannot blend the opposite edges of an auto-cropped frame.
+	// This is also required for non-power-of-two WebGL textures.
         crtemu->BindTexture( CRTEMU_GL_TEXTURE_2D, crtemu->accumulatetexture_a );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, CRTEMU_GL_CLAMP_TO_EDGE );
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, CRTEMU_GL_CLAMP_TO_EDGE );
         crtemu->BindTexture( CRTEMU_GL_TEXTURE_2D, crtemu->accumulatetexture_b );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, CRTEMU_GL_CLAMP_TO_EDGE );
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, CRTEMU_GL_CLAMP_TO_EDGE );
         crtemu->BindTexture( CRTEMU_GL_TEXTURE_2D, crtemu->blurtexture_a );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, CRTEMU_GL_CLAMP_TO_EDGE );
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, CRTEMU_GL_CLAMP_TO_EDGE );
         crtemu->BindTexture( CRTEMU_GL_TEXTURE_2D, crtemu->blurtexture_b );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, CRTEMU_GL_CLAMP_TO_EDGE );
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, CRTEMU_GL_CLAMP_TO_EDGE );
         crtemu->BindTexture( CRTEMU_GL_TEXTURE_2D, crtemu->frametexture );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, CRTEMU_GL_CLAMP_TO_EDGE );
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, CRTEMU_GL_CLAMP_TO_EDGE );
         crtemu->BindTexture( CRTEMU_GL_TEXTURE_2D, crtemu->backbuffer );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
-#endif
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_S, CRTEMU_GL_CLAMP_TO_EDGE );
+        crtemu->TexParameteri( CRTEMU_GL_TEXTURE_2D, CRTEMU_GL_TEXTURE_WRAP_T, CRTEMU_GL_CLAMP_TO_EDGE );
 
     if (crtemu->BindVertexArray) crtemu->BindVertexArray(0);
 

--- a/src/osdep/gfx_prefs_check.cpp
+++ b/src/osdep/gfx_prefs_check.cpp
@@ -59,6 +59,7 @@ int check_prefs_changed_gfx()
 {
 	int c = 0;
 	bool monitors[MAX_AMIGAMONITORS]{};
+	const bool auto_crop_enabled = !currprefs.gfx_auto_crop && changed_prefs.gfx_auto_crop;
 
 	const bool native_code_changed = currprefs.native_code != changed_prefs.native_code;
 	if (native_code_changed) {
@@ -314,6 +315,9 @@ int check_prefs_changed_gfx()
 		currprefs.gfx_manual_crop_height = changed_prefs.gfx_manual_crop_height;
 		currprefs.gfx_auto_crop = changed_prefs.gfx_auto_crop;
 		currprefs.gfx_manual_crop = changed_prefs.gfx_manual_crop;
+
+		if (auto_crop_enabled)
+			force_auto_crop = true;
 
 		if (currprefs.gfx_auto_crop)
 		{


### PR DESCRIPTION
## Summary

- route mapped AutoCrop toggles through pending preference handling
- force a fresh crop calculation when AutoCrop is enabled at runtime
- clamp CRTEMU presentation textures to prevent opposite-edge bleed under linear scaling

## Root cause

AutoCrop's cached native crop could survive a disable/re-enable cycle because crop processing only runs while enabled. Separately, desktop CRTEMU textures retained OpenGL's repeat wrap mode, so linear sampling blended the opposite edge of a cropped frame.

## Validation

- Debug macOS OpenGL build
- Debug macOS SDL-only build
- all `tests/test_*.sh`
- live Toki disable-to-enable test during the map screen
- live Toki AutoCrop with linear scaling edge inspection
