### PR TITLE
fix(gui): honor WHDLoad splash and expose shader params

### DIFF
--- a/src/osdep/amiberry_whdbooter.cpp
+++ b/src/osdep/amiberry_whdbooter.cpp
@@ -1500,11 +1500,12 @@ void create_startup_sequence()
 	// SPLASH
 	if (!whdload_prefs.show_splash)
 	{
-		whd_bootscript << " SPLASHDELAY=0";
+		// Slaves with configurable options still show the startup window unless both delays are zero.
+		whd_bootscript << " SPLASHDELAY=0 CONFIGDELAY=0";
 	}
 
 	// CONFIGDELAY
-	if (whdload_prefs.config_delay != 0)
+	if (whdload_prefs.show_splash && whdload_prefs.config_delay != 0)
 	{
 		whd_bootscript << " CONFIGDELAY=" << whdload_prefs.config_delay;
 	}

--- a/src/osdep/imgui/filter.cpp
+++ b/src/osdep/imgui/filter.cpp
@@ -106,7 +106,7 @@ static void save_filter_defaults()
 }
 
 #ifdef USE_OPENGL
-static void open_shader_parameters_popup(const char* shader_name, const bool rtg)
+void ShaderParameters_Open(const char* shader_name, const bool rtg)
 {
 	shader_params_popup_name = shader_name ? shader_name : "none";
 	shader_params_popup_rtg = rtg;
@@ -114,7 +114,7 @@ static void open_shader_parameters_popup(const char* shader_name, const bool rtg
 }
 #endif
 
-static void render_shader_parameters_popup()
+void ShaderParameters_RenderPopup()
 {
 	if (!show_shader_params_popup) return;
 
@@ -284,7 +284,7 @@ void render_panel_filter()
 #ifdef USE_OPENGL
 		if (AmigaButton(ICON_FA_SLIDERS " Shader Parameters...##NativeShaderParameters",
 			ImVec2(BUTTON_WIDTH * 1.75f, BUTTON_HEIGHT))) {
-			open_shader_parameters_popup(changed_prefs.shader, false);
+			ShaderParameters_Open(changed_prefs.shader, false);
 		}
 		ShowHelpMarker("Edit parameters for the native display shader.");
 #endif
@@ -321,7 +321,7 @@ void render_panel_filter()
 #ifdef USE_OPENGL
 		if (AmigaButton(ICON_FA_SLIDERS " Shader Parameters...##RTGShaderParameters",
 			ImVec2(BUTTON_WIDTH * 1.75f, BUTTON_HEIGHT))) {
-			open_shader_parameters_popup(changed_prefs.shader_rtg, true);
+			ShaderParameters_Open(changed_prefs.shader_rtg, true);
 		}
 		ShowHelpMarker("Edit parameters for the RTG display shader.");
 #endif
@@ -400,5 +400,5 @@ void render_panel_filter()
 	ShowHelpMarker("Save the shader selections and bezel settings as application defaults.");
 
 	// Render the shader parameters popup if open
-	render_shader_parameters_popup();
+	ShaderParameters_RenderPopup();
 }

--- a/src/osdep/imgui/filter.cpp
+++ b/src/osdep/imgui/filter.cpp
@@ -110,6 +110,8 @@ void ShaderParameters_Open(const char* shader_name, const bool rtg)
 {
 	shader_params_popup_name = shader_name ? shader_name : "none";
 	shader_params_popup_rtg = rtg;
+	if (auto* gl_renderer = get_opengl_renderer())
+		gl_renderer->ensure_shader_parameters(shader_params_popup_name.c_str(), rtg);
 	show_shader_params_popup = true;
 }
 #endif

--- a/src/osdep/imgui/global_settings.cpp
+++ b/src/osdep/imgui/global_settings.cpp
@@ -157,14 +157,20 @@ static bool render_string_combo_row(const char* label, char* value, const size_t
 }
 
 static bool render_shader_combo_row(const char* label, char* value, const size_t value_size,
-	const char* help)
+	const bool rtg, const char* help)
 {
 	next_setting_row(label);
 	const auto& shader_names = get_available_shader_names();
 	const char* preview = value[0] ? value : "none";
 
 	bool changed = false;
+#ifdef USE_OPENGL
+	const float parameters_button_width = BUTTON_WIDTH * 1.75f;
+	ImGui::SetNextItemWidth(std::max(BUTTON_WIDTH,
+		ImGui::GetContentRegionAvail().x - parameters_button_width - ImGui::GetStyle().ItemSpacing.x));
+#else
 	ImGui::SetNextItemWidth(-1.0f);
+#endif
 	if (ImGui::BeginCombo("##value", preview)) {
 		for (const auto& shader_name : shader_names) {
 			const bool selected = strcmp(shader_name.c_str(), value) == 0;
@@ -179,6 +185,13 @@ static bool render_shader_combo_row(const char* label, char* value, const size_t
 		ImGui::EndCombo();
 	}
 	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActive());
+#ifdef USE_OPENGL
+	ImGui::SameLine();
+	if (AmigaButton(ICON_FA_SLIDERS " Shader Parameters...",
+		ImVec2(parameters_button_width, BUTTON_HEIGHT))) {
+		ShaderParameters_Open(value, rtg);
+	}
+#endif
 	finish_setting_row(help);
 	return changed;
 }
@@ -596,10 +609,10 @@ void render_panel_global_settings()
 			sizeof amiberry_options.gui_theme, get_available_theme_names(),
 			"Theme file loaded by the ImGui interface.");
 		render_shader_combo_row("Native shader", amiberry_options.shader,
-			sizeof amiberry_options.shader,
+			sizeof amiberry_options.shader, false,
 			"Default shader preset for native chipset modes. Use none to disable.");
 		render_shader_combo_row("RTG shader", amiberry_options.shader_rtg,
-			sizeof amiberry_options.shader_rtg,
+			sizeof amiberry_options.shader_rtg, true,
 			"Default shader preset for RTG modes. Use none to disable.");
 		const bool custom_bezel_active = amiberry_options.use_custom_bezel
 			&& stricmp(amiberry_options.custom_bezel, "none") != 0;
@@ -736,4 +749,5 @@ void render_panel_global_settings()
 	});
 
 	HotkeyCapture_RenderPopup();
+	ShaderParameters_RenderPopup();
 }

--- a/src/osdep/imgui/imgui_panels.h
+++ b/src/osdep/imgui/imgui_panels.h
@@ -108,6 +108,8 @@ void render_panel_virtual_keyboard();
 void render_panel_whdload();
 void render_panel_themes();
 void render_panel_filter();
+void ShaderParameters_Open(const char* shader_name, bool rtg);
+void ShaderParameters_RenderPopup();
 
 // Controller mapping modal (ImGui)
 void ControllerMap_Open(int device, bool map_touchpad);

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -37,6 +37,7 @@
 #include "gui/gui_handling.h"
 #include <algorithm>
 #include <cmath>
+#include <utility>
 #include <SDL3_image/SDL_image.h>
 
 #ifndef GL_BGRA
@@ -1894,6 +1895,45 @@ const std::vector<ShaderParameter>* OpenGLRenderer::shader_parameters(const char
 		return &cache.parameters;
 
 	return nullptr;
+}
+
+bool OpenGLRenderer::ensure_shader_parameters(const char* shader_name, const bool rtg)
+{
+	if (!shader_name)
+		return false;
+
+	// Reuse active, target-cached, template, or opposite-target metadata first.
+	if (shader_parameters(shader_name, rtg))
+		return true;
+
+	std::vector<ShaderParameter> parameters;
+	if (is_shader_preset(shader_name)) {
+		auto* preset = create_shader_preset(shader_name);
+		if (!preset)
+			return false;
+		parameters = preset->get_all_parameters();
+		destroy_shader_preset(preset);
+	} else if (is_external_shader(shader_name)) {
+		auto* shader = create_external_shader(shader_name);
+		if (!shader)
+			return false;
+		parameters = shader->get_parameters();
+		destroy_external_shader(shader);
+	}
+
+	auto& cache = rtg ? m_shader.rtg_parameter_cache : m_shader.native_parameter_cache;
+	cache.shader_name = shader_name;
+	cache.parameters = std::move(parameters);
+	for (auto& parameter : cache.parameters) {
+		for (const auto& saved : amiberry_options.shader_parameters) {
+			if (saved.rtg == rtg && saved.shader == shader_name && saved.name == parameter.name) {
+				parameter.current_value = std::max(parameter.min_value,
+					std::min(parameter.max_value, saved.value));
+				break;
+			}
+		}
+	}
+	return true;
 }
 
 bool OpenGLRenderer::has_shader_parameters(const char* shader_name, const bool rtg) const

--- a/src/osdep/opengl_renderer.h
+++ b/src/osdep/opengl_renderer.h
@@ -144,6 +144,7 @@ public:
 	const ShaderState& shader_state() const;
 	std::vector<ShaderParameter>* shader_parameters(const char* shader_name, bool rtg);
 	const std::vector<ShaderParameter>* shader_parameters(const char* shader_name, bool rtg) const;
+	bool ensure_shader_parameters(const char* shader_name, bool rtg);
 	bool has_shader_parameters(const char* shader_name, bool rtg) const;
 	bool set_shader_parameter(const char* shader_name, bool rtg, const std::string& name, float value);
 	void save_shader_parameters(const char* shader_name, bool rtg);


### PR DESCRIPTION
## Summary

- fully suppress the WHDLoad startup window when **Show splash** is disabled
- restore **Shader Parameters** actions for the Native and RTG defaults in **Global Settings > Visual defaults**
- reuse the existing mode-specific shader parameter editor from the Filter panel

## Root cause

Amiberry only passed `SPLASHDELAY=0` when the WHDLoad splash was disabled. Slaves with configurable options can still display the startup window unless `CONFIGDELAY=0` is also passed.

Global Settings exposed the default shader selectors, but the parameter editor remained local to the Filter panel and had no action in Visual defaults.

## User impact

Disabling **Show splash** now consistently skips the WHDLoad startup window. Users can also edit Native and RTG shader parameters directly from Global Settings again.

## Validation

- `cmake --build build --parallel`
- `bash tests/test_shader_catalog.sh`
- `git diff --check`
- launched the rebuilt startup GUI
- booted the configurable Toki WHDLoad slave with the splash disabled and confirmed the generated command contains `SPLASHDELAY=0 CONFIGDELAY=0` and starts the game directly
