### PR TITLE
Fix Host Only cursors with ZZ9000

### DIFF
--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -4486,11 +4486,16 @@ static void denise_collide_sprites(uae_u8 apixel, uae_u32 vs)
 
 static uae_u8 denise_render_sprites2(uae_u8 apixel, uae_u32 vs)
 {
-	uae_u8 c = vs >> 16;
-	uae_u16 v = (uae_u16)vs;
 	if (currprefs.collision_level) {
 		denise_collide_sprites(apixel, vs);
 	}
+#ifdef AMIBERRY
+	// Host Only keeps chipset sprite 0 available for collision and cursor
+	// extraction, but removes it from the rendered Denise output.
+	vs &= magic_sprite_mask;
+#endif
+	uae_u8 c = vs >> 16;
+	uae_u16 v = (uae_u16)vs;
 	int *shift_lookup = bpldualpf ? (bpldualpfpri ? dblpf_ms2 : dblpf_ms1) : dblpf_ms;
 	int maskshift, plfmask;
 	maskshift = shift_lookup[apixel];

--- a/src/include/amiberry_cursor.h
+++ b/src/include/amiberry_cursor.h
@@ -47,6 +47,23 @@ static inline int amiberry_cursor_hotspot_from_p96_offset(std::uint8_t raw_point
 	return hotspot_offset;
 }
 
+static inline int amiberry_cursor_hotspot_from_zz9000_offset(int pointer_offset, int extent)
+{
+	if (extent <= 0) {
+		return 0;
+	}
+
+	// ZZ9000 stores the pointer-to-sprite displacement as hotspot + 1.
+	const int hotspot_offset = pointer_offset - 1;
+	if (hotspot_offset < 0) {
+		return 0;
+	}
+	if (hotspot_offset >= extent) {
+		return extent - 1;
+	}
+	return hotspot_offset;
+}
+
 static inline bool amiberry_cursor_p96_hotspot_needs_tracking(
 	std::uint8_t raw_x_offset, std::uint8_t raw_y_offset)
 {

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -2248,6 +2248,7 @@ static uae_u32 tmp_sprite_colors[4];
 static int tmp_sprite_hotspot_x, tmp_sprite_hotspot_y;
 static int tmp_sprite_residual_x, tmp_sprite_residual_y;
 static int tmp_sprite_chipset = -1;
+static int tmp_sprite_monid = -1;
 #endif
 
 extern uaecptr sprite_0;
@@ -2369,7 +2370,8 @@ static int createwindowscursor(int monid, int set, int chipset)
 		}
 	}
 	cursor_cache_matches = p96_cursor
-		&& w == tmp_sprite_w && h == tmp_sprite_h && chipset == tmp_sprite_chipset
+		&& w == tmp_sprite_w && h == tmp_sprite_h
+		&& chipset == tmp_sprite_chipset && monid == tmp_sprite_monid
 		&& !memcmp(tmp_sprite_data, image, datasize)
 		&& !memcmp(tmp_sprite_colors, ct, sizeof(uae_u32) * 4);
 
@@ -2445,6 +2447,7 @@ static int createwindowscursor(int monid, int set, int chipset)
 	tmp_sprite_hotspot_x = tmp_sprite_hotspot_y = 0;
 	tmp_sprite_residual_x = tmp_sprite_residual_y = 0;
 	tmp_sprite_chipset = -1;
+	tmp_sprite_monid = -1;
 
 	cursor_surface = SDL_CreateSurface(w, h, SDL_PIXELFORMAT_RGBA32);
 	if (!cursor_surface)
@@ -2473,6 +2476,7 @@ end:
 		tmp_sprite_residual_x = residual_x;
 		tmp_sprite_residual_y = residual_y;
 		tmp_sprite_chipset = chipset;
+		tmp_sprite_monid = monid;
 		memcpy(tmp_sprite_data, image, datasize);
 		memcpy(tmp_sprite_colors, ct, sizeof(uae_u32) * 4);
 	}
@@ -2692,13 +2696,14 @@ void picasso_update_external_host_cursor(const int monid, const uae_u8* image, c
 	if (!picasso_uses_host_cursor(monid) || !image || !colors
 		|| width <= 0 || height <= 0 || image_pitch < width
 		|| width > CURSORMAXWIDTH || height > CURSORMAXHEIGHT) {
-		picasso_clear_external_host_cursor();
+		picasso_clear_external_host_cursor(monid);
 		return;
 	}
 
 	hotspot_x = std::clamp(hotspot_x, 0, width - 1);
 	hotspot_y = std::clamp(hotspot_y, 0, height - 1);
 	bool same_image = p96_cursor && tmp_sprite_chipset == 2
+		&& tmp_sprite_monid == monid
 		&& tmp_sprite_w == width && tmp_sprite_h == height
 		&& tmp_sprite_hotspot_x == hotspot_x && tmp_sprite_hotspot_y == hotspot_y
 		&& !memcmp(tmp_sprite_colors, colors, sizeof(uae_u32) * 4);
@@ -2734,7 +2739,7 @@ void picasso_update_external_host_cursor(const int monid, const uae_u8* image, c
 		: nullptr;
 	SDL_DestroySurface(cursor_surface);
 	if (!new_cursor) {
-		picasso_clear_external_host_cursor();
+		picasso_clear_external_host_cursor(monid);
 		return;
 	}
 
@@ -2747,6 +2752,7 @@ void picasso_update_external_host_cursor(const int monid, const uae_u8* image, c
 	tmp_sprite_residual_x = 0;
 	tmp_sprite_residual_y = 0;
 	tmp_sprite_chipset = 2;
+	tmp_sprite_monid = monid;
 	for (int y = 0; y < height; ++y) {
 		memcpy(tmp_sprite_data + y * width, image + y * image_pitch, width);
 	}
@@ -2761,9 +2767,9 @@ void picasso_update_external_host_cursor(const int monid, const uae_u8* image, c
 	}
 }
 
-void picasso_clear_external_host_cursor()
+void picasso_clear_external_host_cursor(const int monid)
 {
-	if (tmp_sprite_chipset == 2) {
+	if (tmp_sprite_chipset == 2 && tmp_sprite_monid == monid) {
 		destroy_p96_host_cursor();
 		tmp_sprite_w = 0;
 		tmp_sprite_h = 0;
@@ -2772,6 +2778,7 @@ void picasso_clear_external_host_cursor()
 		tmp_sprite_residual_x = 0;
 		tmp_sprite_residual_y = 0;
 		tmp_sprite_chipset = -1;
+		tmp_sprite_monid = -1;
 	}
 }
 #endif

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -305,6 +305,7 @@ static bool magic_mouse_host_only_enabled()
 bool picasso_uses_host_cursor(const int monid)
 {
 	return monid >= 0 && monid < MAX_AMIGAMONITORS
+		&& adisplays[monid].picasso_on
 		&& mouse_monid == monid && magic_mouse_host_only_enabled();
 }
 

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -302,6 +302,12 @@ static bool magic_mouse_host_only_enabled()
 		host_cursor_available);
 }
 
+bool picasso_uses_host_cursor(const int monid)
+{
+	return monid >= 0 && monid < MAX_AMIGAMONITORS
+		&& mouse_monid == monid && magic_mouse_host_only_enabled();
+}
+
 static bool p96_needs_separate_cursor_sprite()
 {
 	return amiberry_cursor_rtg_needs_separate_sprite(currprefs.rtg_hardwaresprite, magic_mouse_host_only_enabled());
@@ -1628,10 +1634,17 @@ void picasso_handle_vsync()
 	if (monid < 0 || monid >= MAX_AMIGAMONITORS) {
 		return;
 	}
-	if (mouse_monid == monid && adisplays[monid].picasso_on) {
+	const int rtg_type = currprefs.rtgboards[0].rtgmem_type;
+	const bool external_cursor_board = rtg_type == GFXBOARD_ID_ZZ9000_Z2
+		|| rtg_type == GFXBOARD_ID_ZZ9000_Z3;
+	if (!external_cursor_board && mouse_monid == monid && adisplays[monid].picasso_on) {
 		// P96 does not consistently expose cursor offsets, so sample the live
 		// pointer-to-sprite displacement while the RTG display is active.
 		createwindowscursor(monid, 0, 0);
+	} else if (external_cursor_board && !magic_mouse_host_only_enabled()) {
+		// ZZ9000 owns the Host Only cursor while its RTG display is active.
+		// Drop any cursor retained from the preceding native display otherwise.
+		destroy_p96_host_cursor();
 	}
 #endif
 	struct AmigaMonitor *mon = &AMonitors[monid];
@@ -2669,6 +2682,98 @@ exit:
 	return ret;
 #endif
 }
+
+#ifdef AMIBERRY
+void picasso_update_external_host_cursor(const int monid, const uae_u8* image, const int image_pitch,
+	const int width, const int height, const uae_u32* colors,
+	int hotspot_x, int hotspot_y)
+{
+	if (!picasso_uses_host_cursor(monid) || !image || !colors
+		|| width <= 0 || height <= 0 || image_pitch < width
+		|| width > CURSORMAXWIDTH || height > CURSORMAXHEIGHT) {
+		picasso_clear_external_host_cursor();
+		return;
+	}
+
+	hotspot_x = std::clamp(hotspot_x, 0, width - 1);
+	hotspot_y = std::clamp(hotspot_y, 0, height - 1);
+	bool same_image = p96_cursor && tmp_sprite_chipset == 2
+		&& tmp_sprite_w == width && tmp_sprite_h == height
+		&& tmp_sprite_hotspot_x == hotspot_x && tmp_sprite_hotspot_y == hotspot_y
+		&& !memcmp(tmp_sprite_colors, colors, sizeof(uae_u32) * 4);
+	for (int y = 0; same_image && y < height; ++y) {
+		same_image = !memcmp(tmp_sprite_data + y * width, image + y * image_pitch, width);
+	}
+	if (same_image) {
+		if (SDL_GetCursor() != p96_cursor) {
+			SDL_SetCursor(p96_cursor);
+		}
+		SDL_ShowCursor();
+		input_mousehack_set_host_cursor_uses_hotspot(true, 0, 0);
+		wincursor_shown = 1;
+		return;
+	}
+
+	SDL_Surface* cursor_surface = SDL_CreateSurface(width, height, SDL_PIXELFORMAT_RGBA32);
+	if (!cursor_surface) {
+		return;
+	}
+
+	bool has_visible_pixel = false;
+	for (int y = 0; y < height; ++y) {
+		for (int x = 0; x < width; ++x) {
+			const int color = image[y * image_pitch + x];
+			putmousepixel(cursor_surface, x, y, color, colors);
+			has_visible_pixel |= color != 0;
+		}
+	}
+
+	SDL_Cursor* new_cursor = has_visible_pixel
+		? SDL_CreateColorCursor(cursor_surface, hotspot_x, hotspot_y)
+		: nullptr;
+	SDL_DestroySurface(cursor_surface);
+	if (!new_cursor) {
+		picasso_clear_external_host_cursor();
+		return;
+	}
+
+	SDL_Cursor* old_cursor = p96_cursor;
+	p96_cursor = new_cursor;
+	tmp_sprite_w = width;
+	tmp_sprite_h = height;
+	tmp_sprite_hotspot_x = hotspot_x;
+	tmp_sprite_hotspot_y = hotspot_y;
+	tmp_sprite_residual_x = 0;
+	tmp_sprite_residual_y = 0;
+	tmp_sprite_chipset = 2;
+	for (int y = 0; y < height; ++y) {
+		memcpy(tmp_sprite_data + y * width, image + y * image_pitch, width);
+	}
+	memcpy(tmp_sprite_colors, colors, sizeof(uae_u32) * 4);
+
+	SDL_SetCursor(p96_cursor);
+	SDL_ShowCursor();
+	input_mousehack_set_host_cursor_uses_hotspot(true, 0, 0);
+	wincursor_shown = 1;
+	if (old_cursor) {
+		SDL_DestroyCursor(old_cursor);
+	}
+}
+
+void picasso_clear_external_host_cursor()
+{
+	if (tmp_sprite_chipset == 2) {
+		destroy_p96_host_cursor();
+		tmp_sprite_w = 0;
+		tmp_sprite_h = 0;
+		tmp_sprite_hotspot_x = 0;
+		tmp_sprite_hotspot_y = 0;
+		tmp_sprite_residual_x = 0;
+		tmp_sprite_residual_y = 0;
+		tmp_sprite_chipset = -1;
+	}
+}
+#endif
 
 int picasso_setwincursor(int monid)
 {

--- a/src/osdep/picasso96.h
+++ b/src/osdep/picasso96.h
@@ -713,7 +713,7 @@ void p96_cleanup_cursor_overlay();
 bool picasso_uses_host_cursor(int monid);
 void picasso_update_external_host_cursor(int monid, const uae_u8* image, int image_pitch,
 	int width, int height, const uae_u32* colors, int hotspot_x, int hotspot_y);
-void picasso_clear_external_host_cursor();
+void picasso_clear_external_host_cursor(int monid);
 #endif
 
 #define LIB_SIZE 34

--- a/src/osdep/picasso96.h
+++ b/src/osdep/picasso96.h
@@ -709,6 +709,12 @@ void p96_get_cursor_dimensions(int *w, int *h);
 SDL_Surface* p96_get_cursor_overlay_surface();
 bool p96_cursor_needs_update();
 void p96_cleanup_cursor_overlay();
+#ifdef AMIBERRY
+bool picasso_uses_host_cursor(int monid);
+void picasso_update_external_host_cursor(int monid, const uae_u8* image, int image_pitch,
+	int width, int height, const uae_u32* colors, int hotspot_x, int hotspot_y);
+void picasso_clear_external_host_cursor();
+#endif
 
 #define LIB_SIZE 34
 #define CARD_FLAGS LIB_SIZE

--- a/src/zz9000.cpp
+++ b/src/zz9000.cpp
@@ -15,6 +15,9 @@
 #include "memory.h"
 #include "picasso96.h"
 #include "gfxboard.h"
+#ifdef AMIBERRY
+#include "amiberry_cursor.h"
+#endif
 #include "xwin.h"
 
 #include <algorithm>
@@ -1693,6 +1696,19 @@ static bool zz9000_vsync(void *userdata, gfxboard_mode *mode)
 	mode->mode = rgb_format;
 	mode->hlinedbl = 1;
 	mode->vlinedbl = 1;
+#ifdef AMIBERRY
+	const bool host_only_cursor = picasso_uses_host_cursor(data->monitor_id);
+	if (host_only_cursor && data->sprite_visible) {
+		picasso_update_external_host_cursor(data->monitor_id, data->sprite_pixels, 32,
+			data->sprite_width, data->sprite_height, data->sprite_colors,
+			amiberry_cursor_hotspot_from_zz9000_offset(
+				data->sprite_x_offset, data->sprite_width),
+			amiberry_cursor_hotspot_from_zz9000_offset(
+				data->sprite_y_offset, data->sprite_height));
+	} else {
+		picasso_clear_external_host_cursor();
+	}
+#endif
 	const auto &state = picasso96_state[data->monitor_id];
 	if (data->mode_changed && (state.Width != data->width ||
 		state.Height != data->height || state.RGBFormat != rgb_format))
@@ -1724,7 +1740,13 @@ static bool zz9000_vsync(void *userdata, gfxboard_mode *mode)
 					memcpy(line, source, line_size);
 				if (!data->display_blank) {
 					zz_composite_overlay_row(data, line, y);
+#ifdef AMIBERRY
+					if (!host_only_cursor) {
+						zz_composite_sprite_row(data, line, y);
+					}
+#else
 					zz_composite_sprite_row(data, line, y);
+#endif
 				}
 				fb_copyrow(data->monitor_id, line, surface, 0, 0, data->width, bpp, y);
 			}
@@ -1749,6 +1771,9 @@ static bool zz9000_toggle(void *userdata, int mode)
 			return false;
 		data->enabled = false;
 		data->visible = false;
+#ifdef AMIBERRY
+		picasso_clear_external_host_cursor();
+#endif
 		return true;
 	}
 	if (data->enabled)
@@ -1780,6 +1805,9 @@ static void zz9000_hsync(void *userdata)
 static void zz9000_reset(void *userdata)
 {
 	auto *data = static_cast<zz9000_state *>(userdata);
+#ifdef AMIBERRY
+	picasso_clear_external_host_cursor();
+#endif
 	data->surface_count = 0;
 	memset(&data->overlay, 0, sizeof data->overlay);
 	data->overlay_feature = false;
@@ -1795,6 +1823,9 @@ static void zz9000_free(void *userdata)
 	auto *data = static_cast<zz9000_state *>(userdata);
 	if (!data)
 		return;
+#ifdef AMIBERRY
+	picasso_clear_external_host_cursor();
+#endif
 	if (data->devnum >= 0 && data->devnum < MAX_RTG_BOARDS)
 		zz9000_boards[data->devnum] = nullptr;
 	xfree(data->memory);

--- a/src/zz9000.cpp
+++ b/src/zz9000.cpp
@@ -1706,7 +1706,7 @@ static bool zz9000_vsync(void *userdata, gfxboard_mode *mode)
 			amiberry_cursor_hotspot_from_zz9000_offset(
 				data->sprite_y_offset, data->sprite_height));
 	} else {
-		picasso_clear_external_host_cursor();
+		picasso_clear_external_host_cursor(data->monitor_id);
 	}
 #endif
 	const auto &state = picasso96_state[data->monitor_id];
@@ -1772,7 +1772,7 @@ static bool zz9000_toggle(void *userdata, int mode)
 		data->enabled = false;
 		data->visible = false;
 #ifdef AMIBERRY
-		picasso_clear_external_host_cursor();
+		picasso_clear_external_host_cursor(data->monitor_id);
 #endif
 		return true;
 	}
@@ -1806,7 +1806,7 @@ static void zz9000_reset(void *userdata)
 {
 	auto *data = static_cast<zz9000_state *>(userdata);
 #ifdef AMIBERRY
-	picasso_clear_external_host_cursor();
+	picasso_clear_external_host_cursor(data->monitor_id);
 #endif
 	data->surface_count = 0;
 	memset(&data->overlay, 0, sizeof data->overlay);
@@ -1824,7 +1824,7 @@ static void zz9000_free(void *userdata)
 	if (!data)
 		return;
 #ifdef AMIBERRY
-	picasso_clear_external_host_cursor();
+	picasso_clear_external_host_cursor(data->monitor_id);
 #endif
 	if (data->devnum >= 0 && data->devnum < MAX_RTG_BOARDS)
 		zz9000_boards[data->devnum] = nullptr;

--- a/tests/cursor_pixel_format_test.cpp
+++ b/tests/cursor_pixel_format_test.cpp
@@ -102,6 +102,20 @@ static void test_rtg_cursor_hotspot_uses_pointer_offset()
 		"learned P96 y hotspot must not correct an already decoded offset later");
 }
 
+static void test_zz9000_cursor_hotspot_uses_pointer_offset()
+{
+	expect_int_eq(amiberry_cursor_hotspot_from_zz9000_offset(1, 16), 0,
+		"ZZ9000 arrow displacement must produce a top-left hotspot");
+	expect_int_eq(amiberry_cursor_hotspot_from_zz9000_offset(26, 51), 25,
+		"ZZ9000 centered x displacement must produce the visual hotspot");
+	expect_int_eq(amiberry_cursor_hotspot_from_zz9000_offset(31, 61), 30,
+		"ZZ9000 centered y displacement must produce the visual hotspot");
+	expect_int_eq(amiberry_cursor_hotspot_from_zz9000_offset(0, 16), 0,
+		"missing ZZ9000 displacement must clamp to the first pixel");
+	expect_int_eq(amiberry_cursor_hotspot_from_zz9000_offset(80, 16), 15,
+		"oversized ZZ9000 displacement must clamp to the last pixel");
+}
+
 static void test_rtg_declared_hotspot_disables_live_tracking()
 {
 	expect_true(!amiberry_cursor_p96_hotspot_needs_tracking(0xff, 0xfe),
@@ -506,6 +520,7 @@ int main()
 	test_rgba32_cursor_pixels_are_opaque();
 	test_rgba32_cursor_pixels_use_raw_rgb_order();
 	test_rtg_cursor_hotspot_uses_pointer_offset();
+	test_zz9000_cursor_hotspot_uses_pointer_offset();
 	test_rtg_declared_hotspot_disables_live_tracking();
 	test_host_only_forces_separate_rtg_sprite();
 	test_rtg_cursor_keeps_softsprite_fallback_disabled();


### PR DESCRIPTION
## Summary

- restore native Host Only sprite masking after the recent WinUAE update
- add ZZ9000 host-cursor ownership using its decoded sprite bitmap, palette, stride, and hotspot offsets
- suppress ZZ9000 framebuffer cursor composition in Host Only mode while preserving normal guest cursor rendering
- keep the WinUAE-facing integration points behind `#ifdef AMIBERRY` and add ZZ9000 hotspot coverage

## Root cause

The native regression occurred because the WinUAE update removed the application of `magic_sprite_mask` from the Denise sprite-rendering path. ZZ9000 exposed a separate problem: it composites its hardware cursor directly into the RTG framebuffer and therefore bypassed the generic P96 Host Only cursor path.

## Validation

- `bash tests/test_cursor_pixel_format.sh`
- `cmake --build build --parallel`
- clean macOS libretro build
- live A4000 + ZZ9000 RTG Host Only test: one cursor
- live native A4000 Workbench Host Only test: one cursor

Fixes #2135