### PR TITLE
Fix controller hotplug reconnection

### DIFF
--- a/libretro/sdl_compat.h
+++ b/libretro/sdl_compat.h
@@ -1008,6 +1008,8 @@ void SDL_CloseJoystick(SDL_Joystick* joystick);
 const char* SDL_GetJoystickName(SDL_Joystick* joystick);
 const char* SDL_GetJoystickNameForID(SDL_JoystickID joystick_id);
 const char* SDL_GetJoystickNameForIndex(int device_index);
+const char* SDL_GetJoystickPath(SDL_Joystick* joystick);
+const char* SDL_GetJoystickSerial(SDL_Joystick* joystick);
 SDL_JoystickID SDL_GetJoystickID(SDL_Joystick* joystick);
 SDL_JoystickGUID SDL_GetJoystickGUID(SDL_Joystick* joystick);
 void SDL_GetJoystickGUIDString(SDL_JoystickGUID guid, char* pszGUID, int cbGUID);

--- a/libretro/sdl_stub.cpp
+++ b/libretro/sdl_stub.cpp
@@ -1248,6 +1248,16 @@ const char* SDL_GetJoystickNameForIndex(int device_index)
 	(void)device_index;
 	return "Stub Joystick";
 }
+const char* SDL_GetJoystickPath(SDL_Joystick* joystick)
+{
+	(void)joystick;
+	return nullptr;
+}
+const char* SDL_GetJoystickSerial(SDL_Joystick* joystick)
+{
+	(void)joystick;
+	return nullptr;
+}
 SDL_JoystickID SDL_GetJoystickID(SDL_Joystick* joystick)
 {
 	return joystick ? joystick->index : -1;

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -2077,21 +2077,6 @@ static void cfgfile_writeramboard(struct uae_prefs *prefs, struct zfile *f, cons
 	}
 }
 
-#ifdef AMIBERRY
-static int cfgfile_get_joystick_index(const struct jport* jp)
-{
-	const TCHAR* digits = jp->idc.configname + 3;
-	if (_tcsncmp(jp->idc.configname, _T("JOY"), 3) != 0 || !digits[0])
-		return -1;
-
-	TCHAR* endptr;
-	const long index = _tcstol(digits, &endptr, 10);
-	if (endptr == digits || endptr[0] || index < 0 || index >= MAX_INPUT_DEVICES)
-		return -1;
-	return static_cast<int>(index);
-}
-#endif
-
 void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 {
 	struct strlist *sl;
@@ -2352,7 +2337,7 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		int v = jp->id;
 		TCHAR tmp1[MAX_DPATH], tmp2[MAX_DPATH];
 #ifdef AMIBERRY
-		const int configured_joystick = cfgfile_get_joystick_index(jp);
+		const int configured_joystick = amiberry_get_joystick_index(jp->idc.configname);
 		if (configured_joystick >= 0) {
 			_sntprintf(tmp2, sizeof tmp2, _T("joy%d"), configured_joystick);
 		} else
@@ -2407,7 +2392,7 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		std::string mode;
 		std::string buffer;
 
-		const int joy_index = cfgfile_get_joystick_index(jp);
+		const int joy_index = amiberry_get_joystick_index(jp->idc.configname);
 		if (joy_index == -1)
 			continue;
 

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -2392,11 +2392,10 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		std::string mode;
 		std::string buffer;
 
-		const int joy_index = amiberry_get_joystick_index(jp->idc.configname);
-		if (joy_index == -1)
+		controller_mapping mapping{};
+		if (!amiberry_get_port_joystick_custom_mapping(
+			i, jp->idc.name, jp->idc.configname, mapping))
 			continue;
-
-		didata* did = &di_joystick[joy_index];
 
 		for (int m = 0; m < 2; ++m)
 		{
@@ -2404,7 +2403,7 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 			for (int n = 0; n < SDL_GAMEPAD_BUTTON_COUNT; ++n) // loop through all buttons
 			{
 				buffer = "joyport" + std::to_string(i) + "_amiberry_custom_" + mode + "_" + SDL_GetGamepadStringForButton(static_cast<SDL_GamepadButton>(n));
-				const auto b = m == 0 ? did->mapping.amiberry_custom_none[n] : did->mapping.amiberry_custom_hotkey[n];
+				const auto b = m == 0 ? mapping.amiberry_custom_none[n] : mapping.amiberry_custom_hotkey[n];
 
 				_tcscpy(tmp2, b > 0 ? _T(find_inputevent_name(b)) : _T(""));
 				cfgfile_dwrite_str(f, buffer.c_str(), tmp2);
@@ -2413,7 +2412,7 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 			for (int n = 0; n < SDL_GAMEPAD_AXIS_COUNT; ++n)
 			{
 				buffer = "joyport" + std::to_string(i) + "_amiberry_custom_axis_" + mode + "_" + SDL_GetGamepadStringForAxis(static_cast<SDL_GamepadAxis>(n));
-				const auto b = m == 0 ? did->mapping.amiberry_custom_axis_none[n] : did->mapping.amiberry_custom_axis_hotkey[n];
+				const auto b = m == 0 ? mapping.amiberry_custom_axis_none[n] : mapping.amiberry_custom_axis_hotkey[n];
 
 				_tcscpy(tmp2, b > 0 ? _T(find_inputevent_name(b)) : _T(""));
 				cfgfile_dwrite_str(f, buffer.c_str(), tmp2);

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -2077,6 +2077,21 @@ static void cfgfile_writeramboard(struct uae_prefs *prefs, struct zfile *f, cons
 	}
 }
 
+#ifdef AMIBERRY
+static int cfgfile_get_joystick_index(const struct jport* jp)
+{
+	const TCHAR* digits = jp->idc.configname + 3;
+	if (_tcsncmp(jp->idc.configname, _T("JOY"), 3) != 0 || !digits[0])
+		return -1;
+
+	TCHAR* endptr;
+	const long index = _tcstol(digits, &endptr, 10);
+	if (endptr == digits || endptr[0] || index < 0 || index >= MAX_INPUT_DEVICES)
+		return -1;
+	return static_cast<int>(index);
+}
+#endif
+
 void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 {
 	struct strlist *sl;
@@ -2336,6 +2351,12 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		struct jport *jp = &p->jports[i];
 		int v = jp->id;
 		TCHAR tmp1[MAX_DPATH], tmp2[MAX_DPATH];
+#ifdef AMIBERRY
+		const int configured_joystick = cfgfile_get_joystick_index(jp);
+		if (configured_joystick >= 0) {
+			_sntprintf(tmp2, sizeof tmp2, _T("joy%d"), configured_joystick);
+		} else
+#endif
 		if (v == JPORT_NONE) {
 			_tcscpy (tmp2, _T("none"));
 		} else if (v < JSEM_CUSTOM) {
@@ -2386,13 +2407,7 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		std::string mode;
 		std::string buffer;
 
-		// Check if configname contains JOY0, JOY1, JOY2, or JOY3
-		int joy_index = -1;
-		if (jp->idc.configname[0] && strncmp(jp->idc.configname, "JOY", 3) == 0 &&
-			jp->idc.configname[4] == '\0' &&
-			jp->idc.configname[3] >= '0' && jp->idc.configname[3] <= '3') {
-			joy_index = jp->idc.configname[3] - '0';
-			}
+		const int joy_index = cfgfile_get_joystick_index(jp);
 		if (joy_index == -1)
 			continue;
 

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -2336,12 +2336,6 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 		struct jport *jp = &p->jports[i];
 		int v = jp->id;
 		TCHAR tmp1[MAX_DPATH], tmp2[MAX_DPATH];
-#ifdef AMIBERRY
-		const int configured_joystick = amiberry_get_joystick_index(jp->idc.configname);
-		if (configured_joystick >= 0) {
-			_sntprintf(tmp2, sizeof tmp2, _T("joy%d"), configured_joystick);
-		} else
-#endif
 		if (v == JPORT_NONE) {
 			_tcscpy (tmp2, _T("none"));
 		} else if (v < JSEM_CUSTOM) {

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -7483,6 +7483,10 @@ static int cfgfile_load_2 (struct uae_prefs *p, const TCHAR *filename, bool real
 	if (! fh)
 		return 0;
 #endif
+#ifdef AMIBERRY
+	if (real && (askedtype == 0 || (askedtype & CONFIG_TYPE_HOST)))
+		amiberry_clear_port_joystick_custom_mappings();
+#endif
 
 	while (cfg_fgets (linea, sizeof (linea), fh) != nullptr) {
 		trimwsa (linea);

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -586,6 +586,21 @@ struct stored_jport
 static struct stored_jport stored_jports[MAX_JPORTS][MAX_STORED_JPORTS];
 static uae_u32 stored_jport_cnt;
 
+static uae_u32 inputdevice_get_unplugged_ports(void)
+{
+	uae_u32 ports = 0;
+	for (int portnum = 0; portnum < MAX_JPORTS; portnum++) {
+		for (int i = 0; i < MAX_STORED_JPORTS; i++) {
+			const struct stored_jport *jp = &stored_jports[portnum][i];
+			if (jp->inuse && jp->jp.id == JPORT_UNPLUGGED) {
+				ports |= 1U << portnum;
+				break;
+			}
+		}
+	}
+	return ports;
+}
+
 // return port where idc was previously plugged if any and forgot it.
 static int inputdevice_get_unplugged_device(struct inputdevconfig *idc, struct stored_jport **sjp)
 {
@@ -602,6 +617,23 @@ static int inputdevice_get_unplugged_device(struct inputdevconfig *idc, struct s
 		}
 	}
 	return -1;
+}
+
+static int inputdevice_take_unplugged_device(int portnum, struct stored_jport **sjp)
+{
+	struct stored_jport *newest = NULL;
+	for (int i = 0; i < MAX_STORED_JPORTS; i++) {
+		struct stored_jport *jp = &stored_jports[portnum][i];
+		if (jp->inuse && jp->jp.id == JPORT_UNPLUGGED &&
+			(!newest || jp->age > newest->age)) {
+			newest = jp;
+		}
+	}
+	if (!newest)
+		return -1;
+	newest->inuse = false;
+	*sjp = newest;
+	return portnum;
 }
 
 // forget port's unplugged device
@@ -661,6 +693,18 @@ static void inputdevice_set_newest_used_device(int portnum, struct jport *jps)
 	}
 }
 
+static bool inputdevice_stored_jports_match(const struct jport *first, const struct jport *second)
+{
+	const bool matching_config =
+		first->idc.configname[0] != 0 && second->idc.configname[0] != 0 &&
+		!_tcscmp(first->idc.configname, second->idc.configname);
+	if (first->id == JPORT_UNPLUGGED || second->id == JPORT_UNPLUGGED) {
+		return matching_config &&
+			!_tcscmp(first->idc.name, second->idc.name);
+	}
+	return first->id == second->id || matching_config;
+}
+
 static void inputdevice_store_used_device(struct jport *jps, int portnum, bool defaultports)
 {
 	if (jps->id == JPORT_NONE)
@@ -669,7 +713,7 @@ static void inputdevice_store_used_device(struct jport *jps, int portnum, bool d
 	// already added? if custom or kbr layout: delete all old
 	for (int i = 0; i < MAX_STORED_JPORTS; i++) {
 		struct stored_jport *jp = &stored_jports[portnum][i];
-		if (jp->inuse && ((jps->id == jp->jp.id) || (jps->idc.configname[0] != 0 && jp->jp.idc.configname[0] != 0 && !_tcscmp(jps->idc.configname, jp->jp.idc.configname)))) {
+		if (jp->inuse && inputdevice_stored_jports_match(jps, &jp->jp)) {
 			if (!jp->defaultports) {
 				jp->inuse = false;
 			}
@@ -680,7 +724,7 @@ static void inputdevice_store_used_device(struct jport *jps, int portnum, bool d
 	for (int j = 0; j < MAX_JPORTS; j++) {
 		for (int i = 0; i < MAX_STORED_JPORTS; i++) {
 			struct stored_jport *jp = &stored_jports[j][i];
-			if (jp->inuse && ((jps->id == jp->jp.id) || (jps->idc.configname[0] != 0 && jp->jp.idc.configname[0] != 0 && !_tcscmp(jps->idc.configname, jp->jp.idc.configname)))) {
+			if (jp->inuse && inputdevice_stored_jports_match(jps, &jp->jp)) {
 				if (!jp->defaultports) {
 					jp->inuse = false;
 				}
@@ -723,21 +767,30 @@ static void inputdevice_store_used_device(struct jport *jps, int portnum, bool d
 	}
 }
 
-static uae_u32 inputdevice_store_unplugged_port(struct uae_prefs *p, struct inputdevconfig *idc)
+static void inputdevice_store_unplugged_binding(int portnum,
+	const TCHAR *name, const TCHAR *configname, int mode, int submode, int autofire)
 {
 	struct jport jpt = { 0 };
-	uae_u32 ports = 0;
-	_tcscpy(jpt.idc.configname, idc->configname);
-	_tcscpy(jpt.idc.name, idc->name);
+	_tcsncpy(jpt.idc.name, name, MAX_JPORT_NAME - 1);
+	_tcsncpy(jpt.idc.configname, configname, MAX_JPORT_CONFIG - 1);
+	jpt.idc.name[MAX_JPORT_NAME - 1] = 0;
+	jpt.idc.configname[MAX_JPORT_CONFIG - 1] = 0;
 	jpt.id = JPORT_UNPLUGGED;
+	jpt.mode = mode;
+	jpt.submode = submode;
+	jpt.autofire = autofire;
+	inputdevice_store_used_device(&jpt, portnum, false);
+}
+
+static uae_u32 inputdevice_store_unplugged_port(struct uae_prefs *p, struct inputdevconfig *idc)
+{
+	uae_u32 ports = 0;
 	for (int i = 0; i < MAX_JPORTS; i++) {
 		struct jport *jp = &p->jports[i];
 		if (!_tcscmp(jp->idc.name, idc->name) && !_tcscmp(jp->idc.configname, idc->configname)) {
-			write_log(_T("On the fly unplugged stored, port %d '%s' (%s)\n"), i, jpt.idc.name, jpt.idc.configname);
-			jpt.mode = jp->mode;
-			jpt.submode = jp->submode;
-			jpt.autofire = jp->autofire;
-			inputdevice_store_used_device(&jpt, i, false);
+			write_log(_T("On the fly unplugged stored, port %d '%s' (%s)\n"), i, idc->name, idc->configname);
+			inputdevice_store_unplugged_binding(
+				i, idc->name, idc->configname, jp->mode, jp->submode, jp->autofire);
 			ports |= 1U << i;
 		}
 	}
@@ -8434,7 +8487,7 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 	int jportssubmode[MAX_JPORTS];
 	int jportid[MAX_JPORTS], jportaf[MAX_JPORTS];
 	bool changed = false;
-	uae_u32 unplugged_ports = 0;
+	uae_u32 unplugged_ports = inputdevice_get_unplugged_ports();
 
 	for (i = 0; i < MAX_JPORTS; i++) {
 		jportskb[i] = -1;
@@ -8548,7 +8601,23 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 				_tcscpy(idc.name, inf->get_friendlyname(i));
 				write_log(_T("INSERTED: %d/%d %s (%s)\n"), j, i, idc.name, idc.configname);
 				changed = true;
-				int portnum = inputdevice_get_unplugged_device(&idc, &sjp);
+				int portnum = -1;
+				bool identity_matched = false;
+#ifdef AMIBERRY
+				if (j == IDTYPE_JOYSTICK) {
+					for (int candidate_port = 0; candidate_port < MAX_JPORTS; candidate_port++) {
+						int resolved_joystick = -1;
+						if (amiberry_resolve_port_joystick(candidate_port, resolved_joystick) &&
+							resolved_joystick == i) {
+							identity_matched = true;
+							portnum = inputdevice_take_unplugged_device(candidate_port, &sjp);
+							break;
+						}
+					}
+				}
+#endif
+				if (!identity_matched)
+					portnum = inputdevice_get_unplugged_device(&idc, &sjp);
 				if (portnum >= 0) {
 					write_log(_T("Inserting to port %d\n"), portnum);
 					unplugged_ports &= ~(1U << portnum);
@@ -8578,18 +8647,45 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 
 	for (int i = 0; i < MAX_JPORTS; i++) {
 		bool found = true;
+#ifdef AMIBERRY
+		bool identity_bound = false;
+#endif
 		if (jportscustom[i] >= 0) {
 			TCHAR tmp[10];
 			_sntprintf(tmp, sizeof tmp, _T("custom%d"), jportscustom[i]);
 			found = inputdevice_joyport_config(prefs, tmp, NULL, i, jportsmode[i], jportssubmode[i], 0, true) != 0;
 		} else if ((jports_name[i] && jports_name[i][0]) || (jports_configname[i] && jports_configname[i][0])) {
-			if (!inputdevice_joyport_config (prefs, jports_name[i], jports_configname[i], i, jportsmode[i], jportssubmode[i], 1, true)) {
-				found = inputdevice_joyport_config (prefs, jports_name[i], NULL, i, jportsmode[i], jportssubmode[i], 1, true) != 0;
+#ifdef AMIBERRY
+			int resolved_joystick = -1;
+			identity_bound = amiberry_resolve_port_joystick(i, resolved_joystick);
+			if (identity_bound) {
+				found = resolved_joystick >= 0 &&
+					inputdevice_joyport_config(
+						prefs,
+						idev[IDTYPE_JOYSTICK].get_friendlyname(resolved_joystick),
+						idev[IDTYPE_JOYSTICK].get_uniquename(resolved_joystick),
+						i, jportsmode[i], jportssubmode[i], 1, true) != 0;
+			} else
+#endif
+			{
+				if (!inputdevice_joyport_config (prefs, jports_name[i], jports_configname[i], i, jportsmode[i], jportssubmode[i], 1, true)) {
+					found = inputdevice_joyport_config (prefs, jports_name[i], NULL, i, jportsmode[i], jportssubmode[i], 1, true) != 0;
+				}
 			}
 			if (found) {
+				if (unplugged_ports & (1U << i))
+					inputdevice_forget_unplugged_device(i);
 				unplugged_ports &= ~(1U << i);
 			}
 			if (!found) {
+#ifdef AMIBERRY
+				if (identity_bound) {
+					inputdevice_store_unplugged_binding(
+						i, jports_name[i], jports_configname[i],
+						jportsmode[i], jportssubmode[i], jportaf[i]);
+					unplugged_ports |= 1U << i;
+				}
+#endif
 				inputdevice_joyport_config(prefs, _T("joydefault"), NULL, i, jportsmode[i], jportssubmode[i], 0, true);
 			}
 		} else if (jportskb[i] >= 0) {

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -10361,8 +10361,6 @@ static bool fixjport(struct jport *port, int add, bool always)
 {
 	bool wasinvalid = false;
 	int vv = port->id;
-	if (vv == JPORT_NONE)
-		return wasinvalid;
 	if (vv >= JSEM_JOYS && vv < JSEM_MICE) {
 		vv -= JSEM_JOYS;
 		vv += add;

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -8482,6 +8482,10 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 	}
 
 #ifdef AMIBERRY
+	for (int i = 0; i < MAX_JPORTS; ++i) {
+		amiberry_preserve_port_joystick_custom_mapping(
+			i, jports_name[i], jports_configname[i]);
+	}
 	amiberry_cache_joystick_custom_mappings();
 #endif
 	inputdevice_unacquire();
@@ -8594,6 +8598,10 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 			found = inputdevice_joyport_config (prefs, tmp, NULL, i, jportsmode[i], jportssubmode[i], 0, true) != 0;
 			
 		}
+#ifdef AMIBERRY
+		if (found)
+			amiberry_clear_port_joystick_custom_mapping(i);
+#endif
 		fixedports[i] = found;
 		prefs->jports[i].autofire = jportaf[i];
 		inputdevice_validate_jports(prefs, i, fixedports);

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -723,9 +723,10 @@ static void inputdevice_store_used_device(struct jport *jps, int portnum, bool d
 	}
 }
 
-static void inputdevice_store_unplugged_port(struct uae_prefs *p, struct inputdevconfig *idc)
+static uae_u32 inputdevice_store_unplugged_port(struct uae_prefs *p, struct inputdevconfig *idc)
 {
 	struct jport jpt = { 0 };
+	uae_u32 ports = 0;
 	_tcscpy(jpt.idc.configname, idc->configname);
 	_tcscpy(jpt.idc.name, idc->name);
 	jpt.id = JPORT_UNPLUGGED;
@@ -737,8 +738,10 @@ static void inputdevice_store_unplugged_port(struct uae_prefs *p, struct inputde
 			jpt.submode = jp->submode;
 			jpt.autofire = jp->autofire;
 			inputdevice_store_used_device(&jpt, i, false);
+			ports |= 1U << i;
 		}
 	}
+	return ports;
 }
 
 static bool isemptykey(int keyboard, int scancode)
@@ -8431,6 +8434,7 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 	int jportssubmode[MAX_JPORTS];
 	int jportid[MAX_JPORTS], jportaf[MAX_JPORTS];
 	bool changed = false;
+	uae_u32 unplugged_ports = 0;
 
 	for (i = 0; i < MAX_JPORTS; i++) {
 		jportskb[i] = -1;
@@ -8528,7 +8532,7 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 		for (int i = 0; i < MAX_INPUT_DEVICES; i++) {
 			if (devcfg[i][j].name[0]) {
 				write_log(_T("REMOVED: %d/%d %s (%s)\n"), j, i, devcfg[i][j].name, devcfg[i][j].configname);
-				inputdevice_store_unplugged_port(prefs, &devcfg[i][j]);
+				unplugged_ports |= inputdevice_store_unplugged_port(prefs, &devcfg[i][j]);
 				changed = true;
 			}
 		}
@@ -8543,6 +8547,7 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 				int portnum = inputdevice_get_unplugged_device(&idc, &sjp);
 				if (portnum >= 0) {
 					write_log(_T("Inserting to port %d\n"), portnum);
+					unplugged_ports &= ~(1U << portnum);
 					jportscustom[portnum] = -1;
 					xfree(jports_name[portnum]);
 					xfree(jports_configname[portnum]);
@@ -8588,9 +8593,15 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 		}
 		fixedports[i] = found;
 		prefs->jports[i].autofire = jportaf[i];
+		inputdevice_validate_jports(prefs, i, fixedports);
+		if (unplugged_ports & (1U << i)) {
+			_tcsncpy(prefs->jports[i].idc.name, jports_name[i], MAX_JPORT_NAME - 1);
+			_tcsncpy(prefs->jports[i].idc.configname, jports_configname[i], MAX_JPORT_CONFIG - 1);
+			prefs->jports[i].idc.name[MAX_JPORT_NAME - 1] = 0;
+			prefs->jports[i].idc.configname[MAX_JPORT_CONFIG - 1] = 0;
+		}
 		xfree (jports_name[i]);
 		xfree (jports_configname[i]);
-		inputdevice_validate_jports(prefs, i, fixedports);
 	}
 
 	write_log(_T("Input remapping done. Changed=%d.\n"), changed);

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -8599,12 +8599,23 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 			
 		}
 #ifdef AMIBERRY
-		if (found)
-			amiberry_clear_port_joystick_custom_mapping(i);
+		if (found) {
+			const int joystick_index = jsem_isjoy(i, prefs);
+			if (joystick_index >= 0) {
+				amiberry_apply_port_joystick_custom_mapping(
+					i,
+					idev[IDTYPE_JOYSTICK].get_friendlyname(joystick_index),
+					idev[IDTYPE_JOYSTICK].get_uniquename(joystick_index));
+			}
+		}
 #endif
 		fixedports[i] = found;
 		prefs->jports[i].autofire = jportaf[i];
 		inputdevice_validate_jports(prefs, i, fixedports);
+#ifdef AMIBERRY
+		if (found)
+			amiberry_clear_port_joystick_custom_mapping(i);
+#endif
 		if (unplugged_ports & (1U << i)) {
 			_tcsncpy(prefs->jports[i].idc.name, jports_name[i], MAX_JPORT_NAME - 1);
 			_tcsncpy(prefs->jports[i].idc.configname, jports_configname[i], MAX_JPORT_CONFIG - 1);

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -8582,6 +8582,9 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 			if (!inputdevice_joyport_config (prefs, jports_name[i], jports_configname[i], i, jportsmode[i], jportssubmode[i], 1, true)) {
 				found = inputdevice_joyport_config (prefs, jports_name[i], NULL, i, jportsmode[i], jportssubmode[i], 1, true) != 0;
 			}
+			if (found) {
+				unplugged_ports &= ~(1U << i);
+			}
 			if (!found) {
 				inputdevice_joyport_config(prefs, _T("joydefault"), NULL, i, jportsmode[i], jportssubmode[i], 0, true);
 			}

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -8477,6 +8477,9 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 		}
 	}
 
+#ifdef AMIBERRY
+	amiberry_cache_joystick_custom_mappings();
+#endif
 	inputdevice_unacquire();
 	idev[IDTYPE_JOYSTICK].close();
 	idev[IDTYPE_MOUSE].close();
@@ -8484,6 +8487,9 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 	idev[IDTYPE_JOYSTICK].init();
 	idev[IDTYPE_MOUSE].init();
 	idev[IDTYPE_KEYBOARD].init();
+#ifdef AMIBERRY
+	amiberry_restore_joystick_custom_mappings();
+#endif
 	for (int i = 0; i < MAX_INPUT_DEVICES; i++) {
 		for (int j = 0; j < IDTYPE_MAX; j++) {
 			gp_swappeddevices[i][j] = -1;
@@ -8537,7 +8543,7 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 				int portnum = inputdevice_get_unplugged_device(&idc, &sjp);
 				if (portnum >= 0) {
 					write_log(_T("Inserting to port %d\n"), portnum);
-					jportscustom[i] = -1;
+					jportscustom[portnum] = -1;
 					xfree(jports_name[portnum]);
 					xfree(jports_configname[portnum]);
 					jports_name[portnum] = my_strdup(idc.name);
@@ -8589,8 +8595,11 @@ bool inputdevice_devicechange (struct uae_prefs *prefs)
 
 	write_log(_T("Input remapping done. Changed=%d.\n"), changed);
 
-	if (!changed)
+	if (!changed) {
+		if (acc)
+			inputdevice_acquire (TRUE);
 		return false;
+	}
 
 	if (prefs == &changed_prefs)
 		inputdevice_copyconfig (&changed_prefs, &currprefs);

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -2350,7 +2350,7 @@ static void handle_clipboard_update_event()
 	}
 }
 
-void handle_joy_device_event(const SDL_JoystickID which, const bool removed, struct uae_prefs* prefs)
+void handle_joy_device_event(const SDL_JoystickID which, const bool removed)
 {
 	bool known_device = false;
 	for (int id = 0; id < MAX_INPUT_DEVICES; ++id)
@@ -2364,10 +2364,9 @@ void handle_joy_device_event(const SDL_JoystickID which, const bool removed, str
 	}
 	if (!known_device || removed)
 	{
-		write_log("SDL Gamepad/Joystick added or removed, re-running import joysticks...\n");
-		if (inputdevice_devicechange(prefs))
+		write_log("SDL Gamepad/Joystick added or removed, re-enumerating input devices...\n");
+		if (inputdevice_devicechange(&changed_prefs))
 		{
-			import_joysticks();
 			joystick_refresh_needed = true;
 		}
 	}
@@ -3282,10 +3281,10 @@ static void process_event(const SDL_Event& event)
 #endif
 
 		case SDL_EVENT_JOYSTICK_ADDED:
-			handle_joy_device_event(event.jdevice.which, false, &currprefs);
+			handle_joy_device_event(event.jdevice.which, false);
 			break;
 		case SDL_EVENT_JOYSTICK_REMOVED:
-			handle_joy_device_event(event.jdevice.which, true, &currprefs);
+			handle_joy_device_event(event.jdevice.which, true);
 			break;
 
 		case SDL_EVENT_GAMEPAD_BUTTON_DOWN:

--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <algorithm>
 #include <cctype>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -55,6 +56,118 @@ static int joystick_inited, retroarch_inited;
 static int osj_device_index = -1;
 constexpr auto analog_upper_bound = 32767;
 constexpr auto analog_lower_bound = -analog_upper_bound;
+
+namespace
+{
+struct cached_joystick_custom_mapping
+{
+	amiberry_joystick_identity identity;
+	std::array<int, SDL_GAMEPAD_BUTTON_COUNT> buttons;
+	std::array<int, SDL_GAMEPAD_BUTTON_COUNT> hotkey_buttons;
+	std::array<int, SDL_GAMEPAD_AXIS_COUNT> axes;
+	std::array<int, SDL_GAMEPAD_AXIS_COUNT> hotkey_axes;
+	uae_u64 last_seen{};
+};
+
+std::array<cached_joystick_custom_mapping, MAX_INPUT_DEVICES> cached_joystick_custom_mappings;
+int cached_joystick_custom_mapping_count;
+uae_u64 cached_joystick_custom_mapping_generation;
+
+amiberry_joystick_identity get_joystick_identity(const didata& did)
+{
+	return {
+		did.guid,
+		did.serial,
+		did.path,
+		did.name,
+		did.is_controller
+	};
+}
+
+int find_cached_joystick_mapping(const amiberry_joystick_identity& identity,
+	const std::array<bool, MAX_INPUT_DEVICES>& used)
+{
+	int best_index = -1;
+	int best_score = -1;
+	for (int i = 0; i < cached_joystick_custom_mapping_count; ++i) {
+		if (used[i])
+			continue;
+		const int score = amiberry_joystick_identity_score(
+			cached_joystick_custom_mappings[i].identity, identity);
+		if (score > best_score) {
+			best_index = i;
+			best_score = score;
+		}
+	}
+	return best_index;
+}
+
+void copy_custom_mapping_to_cache(const controller_mapping& source,
+	cached_joystick_custom_mapping& destination)
+{
+	destination.buttons = source.amiberry_custom_none;
+	destination.hotkey_buttons = source.amiberry_custom_hotkey;
+	destination.axes = source.amiberry_custom_axis_none;
+	destination.hotkey_axes = source.amiberry_custom_axis_hotkey;
+}
+
+void copy_custom_mapping_from_cache(const cached_joystick_custom_mapping& source,
+	controller_mapping& destination)
+{
+	destination.amiberry_custom_none = source.buttons;
+	destination.amiberry_custom_hotkey = source.hotkey_buttons;
+	destination.amiberry_custom_axis_none = source.axes;
+	destination.amiberry_custom_axis_hotkey = source.hotkey_axes;
+}
+}
+
+void amiberry_cache_joystick_custom_mappings()
+{
+	std::array<bool, MAX_INPUT_DEVICES> used{};
+	for (int i = 0; i < num_joystick; ++i) {
+		const auto identity = get_joystick_identity(di_joystick[i]);
+		int cache_index = find_cached_joystick_mapping(identity, used);
+		if (cache_index < 0) {
+			if (cached_joystick_custom_mapping_count < MAX_INPUT_DEVICES) {
+				cache_index = cached_joystick_custom_mapping_count++;
+			} else {
+				uae_u64 oldest_generation = std::numeric_limits<uae_u64>::max();
+				for (int candidate = 0; candidate < cached_joystick_custom_mapping_count; ++candidate) {
+					if (!used[candidate] &&
+						cached_joystick_custom_mappings[candidate].last_seen < oldest_generation) {
+						cache_index = candidate;
+						oldest_generation = cached_joystick_custom_mappings[candidate].last_seen;
+					}
+				}
+			}
+		}
+		if (cache_index < 0)
+			continue;
+
+		auto& cached = cached_joystick_custom_mappings[cache_index];
+		cached.identity = identity;
+		copy_custom_mapping_to_cache(di_joystick[i].mapping, cached);
+		cached.last_seen = ++cached_joystick_custom_mapping_generation;
+		used[cache_index] = true;
+	}
+}
+
+void amiberry_restore_joystick_custom_mappings()
+{
+	std::array<bool, MAX_INPUT_DEVICES> used{};
+	for (int i = 0; i < num_joystick; ++i) {
+		const int cache_index = find_cached_joystick_mapping(
+			get_joystick_identity(di_joystick[i]), used);
+		if (cache_index < 0)
+			continue;
+
+		copy_custom_mapping_from_cache(cached_joystick_custom_mappings[cache_index],
+			di_joystick[i].mapping);
+		cached_joystick_custom_mappings[cache_index].last_seen =
+			++cached_joystick_custom_mapping_generation;
+		used[cache_index] = true;
+	}
+}
 
 static int isrealbutton(const struct didata* did, const int num)
 {
@@ -1219,6 +1332,10 @@ void open_as_game_controller(struct didata* did, const int i)
 	did->joystick_id = SDL_GetJoystickID(did->joystick);
 	SDL_GUIDToString(SDL_GetJoystickGUID(did->joystick), guid_str, 33);
 	did->guid = std::string(guid_str);
+	if (const char* serial = SDL_GetJoystickSerial(did->joystick))
+		did->serial = serial;
+	if (const char* path = SDL_GetJoystickPath(did->joystick))
+		did->path = path;
 
 	if (SDL_GetGamepadNameForID(i) != nullptr)
 		did->controller_name.assign(SDL_GetGamepadNameForID(i));
@@ -1249,6 +1366,10 @@ void open_as_joystick(struct didata* did, const int i)
 	did->joystick_id = SDL_GetJoystickID(did->joystick);
 	SDL_GUIDToString(SDL_GetJoystickGUID(did->joystick), guid_str, 33);
 	did->guid = std::string(guid_str);
+	if (const char* serial = SDL_GetJoystickSerial(did->joystick))
+		did->serial = serial;
+	if (const char* path = SDL_GetJoystickPath(did->joystick))
+		did->path = path;
 
 	if (SDL_GetJoystickNameForID(i) != nullptr)
 		did->joystick_name.assign(SDL_GetJoystickNameForID(i));

--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -69,9 +69,24 @@ struct cached_joystick_custom_mapping
 	uae_u64 last_seen{};
 };
 
+struct preserved_port_joystick_custom_mapping
+{
+	struct inputdevconfig idc;
+	controller_mapping mapping;
+	bool valid{};
+};
+
 std::array<cached_joystick_custom_mapping, MAX_INPUT_DEVICES> cached_joystick_custom_mappings;
 int cached_joystick_custom_mapping_count;
 uae_u64 cached_joystick_custom_mapping_generation;
+std::array<preserved_port_joystick_custom_mapping, MAX_JPORTS> preserved_port_joystick_custom_mappings;
+
+bool matches_joystick_config(const struct inputdevconfig& idc,
+	const TCHAR* name, const TCHAR* configname)
+{
+	return name && configname &&
+		!_tcscmp(idc.name, name) && !_tcscmp(idc.configname, configname);
+}
 
 amiberry_joystick_identity get_joystick_identity(const didata& did)
 {
@@ -119,6 +134,65 @@ void copy_custom_mapping_from_cache(const cached_joystick_custom_mapping& source
 	destination.amiberry_custom_axis_none = source.axes;
 	destination.amiberry_custom_axis_hotkey = source.hotkey_axes;
 }
+}
+
+void amiberry_preserve_port_joystick_custom_mapping(const int portnum,
+	const TCHAR* name, const TCHAR* configname)
+{
+	if (portnum < 0 || portnum >= MAX_JPORTS)
+		return;
+	if (!name || !configname)
+		return;
+
+	auto& preserved = preserved_port_joystick_custom_mappings[portnum];
+	if (preserved.valid && matches_joystick_config(preserved.idc, name, configname))
+		return;
+
+	preserved = {};
+	const int joystick_index = amiberry_get_joystick_index(configname);
+	if (joystick_index < 0 || joystick_index >= num_joystick)
+		return;
+
+	const auto& did = di_joystick[joystick_index];
+	if (name && name[0] && did.name != name)
+		return;
+
+	_tcsncpy(preserved.idc.name, name, MAX_JPORT_NAME - 1);
+	_tcsncpy(preserved.idc.configname, configname, MAX_JPORT_CONFIG - 1);
+	preserved.idc.name[MAX_JPORT_NAME - 1] = 0;
+	preserved.idc.configname[MAX_JPORT_CONFIG - 1] = 0;
+	preserved.mapping = did.mapping;
+	preserved.valid = true;
+}
+
+void amiberry_clear_port_joystick_custom_mapping(const int portnum)
+{
+	if (portnum >= 0 && portnum < MAX_JPORTS)
+		preserved_port_joystick_custom_mappings[portnum] = {};
+}
+
+bool amiberry_get_port_joystick_custom_mapping(const int portnum,
+	const TCHAR* name, const TCHAR* configname, controller_mapping& mapping)
+{
+	if (portnum < 0 || portnum >= MAX_JPORTS)
+		return false;
+
+	const auto& preserved = preserved_port_joystick_custom_mappings[portnum];
+	if (preserved.valid && matches_joystick_config(preserved.idc, name, configname)) {
+		mapping = preserved.mapping;
+		return true;
+	}
+
+	const int joystick_index = amiberry_get_joystick_index(configname);
+	if (joystick_index < 0 || joystick_index >= num_joystick)
+		return false;
+
+	const auto& did = di_joystick[joystick_index];
+	if (name && name[0] && did.name != name)
+		return false;
+
+	mapping = did.mapping;
+	return true;
 }
 
 void amiberry_cache_joystick_custom_mappings()

--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -1547,6 +1547,22 @@ static int init_joystick()
 	return 1;
 }
 
+int amiberry_get_joystick_index(const TCHAR* configname)
+{
+	if (!configname || _tcsncmp(configname, _T("JOY"), 3) != 0)
+		return -1;
+
+	const TCHAR* digits = configname + 3;
+	if (!digits[0])
+		return -1;
+
+	TCHAR* endptr;
+	const long index = _tcstol(digits, &endptr, 10);
+	if (endptr == digits || endptr[0] || index < 0 || index >= MAX_INPUT_DEVICES)
+		return -1;
+	return static_cast<int>(index);
+}
+
 bool load_custom_options(uae_prefs* p, const std::string& option, const TCHAR* value)
 {
 	// Only do this loop if the option starts with "joyport"
@@ -1558,13 +1574,7 @@ bool load_custom_options(uae_prefs* p, const std::string& option, const TCHAR* v
 		{
 			const jport *jp = &p->jports[i];
 
-			// Check if configname contains JOY0, JOY1, JOY2, or JOY3
-			int joy_index = -1;
-			if (jp->idc.configname[0] && strncmp(jp->idc.configname, "JOY", 3) == 0 &&
-				jp->idc.configname[4] == '\0' &&
-				jp->idc.configname[3] >= '0' && jp->idc.configname[3] <= '3') {
-				joy_index = jp->idc.configname[3] - '0';
-				}
+			const int joy_index = amiberry_get_joystick_index(jp->idc.configname);
 			if (joy_index == -1)
 				continue;
 

--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -134,6 +134,15 @@ void copy_custom_mapping_from_cache(const cached_joystick_custom_mapping& source
 	destination.amiberry_custom_axis_none = source.axes;
 	destination.amiberry_custom_axis_hotkey = source.hotkey_axes;
 }
+
+void copy_custom_mapping(const controller_mapping& source,
+	controller_mapping& destination)
+{
+	destination.amiberry_custom_none = source.amiberry_custom_none;
+	destination.amiberry_custom_hotkey = source.amiberry_custom_hotkey;
+	destination.amiberry_custom_axis_none = source.amiberry_custom_axis_none;
+	destination.amiberry_custom_axis_hotkey = source.amiberry_custom_axis_hotkey;
+}
 }
 
 void amiberry_preserve_port_joystick_custom_mapping(const int portnum,
@@ -171,6 +180,11 @@ void amiberry_clear_port_joystick_custom_mapping(const int portnum)
 		preserved_port_joystick_custom_mappings[portnum] = {};
 }
 
+void amiberry_clear_port_joystick_custom_mappings()
+{
+	preserved_port_joystick_custom_mappings = {};
+}
+
 bool amiberry_get_port_joystick_custom_mapping(const int portnum,
 	const TCHAR* name, const TCHAR* configname, controller_mapping& mapping)
 {
@@ -192,6 +206,64 @@ bool amiberry_get_port_joystick_custom_mapping(const int portnum,
 		return false;
 
 	mapping = did.mapping;
+	return true;
+}
+
+void amiberry_set_port_joystick_custom_mapping(const int portnum,
+	const TCHAR* name, const TCHAR* configname, const controller_mapping& mapping)
+{
+	if (portnum < 0 || portnum >= MAX_JPORTS || !name || !configname)
+		return;
+
+	const int joystick_index = amiberry_get_joystick_index(configname);
+	if (joystick_index < 0)
+		return;
+
+	auto& preserved = preserved_port_joystick_custom_mappings[portnum];
+	if (!preserved.valid || !matches_joystick_config(preserved.idc, name, configname)) {
+		preserved = {};
+		_tcsncpy(preserved.idc.name, name, MAX_JPORT_NAME - 1);
+		_tcsncpy(preserved.idc.configname, configname, MAX_JPORT_CONFIG - 1);
+		preserved.idc.name[MAX_JPORT_NAME - 1] = 0;
+		preserved.idc.configname[MAX_JPORT_CONFIG - 1] = 0;
+	}
+	copy_custom_mapping(mapping, preserved.mapping);
+	preserved.valid = true;
+
+	if (joystick_index >= num_joystick)
+		return;
+
+	auto& did = di_joystick[joystick_index];
+	if (name[0] && did.name != name)
+		return;
+	copy_custom_mapping(mapping, did.mapping);
+}
+
+bool amiberry_apply_port_joystick_custom_mapping(const int portnum,
+	const TCHAR* name, const TCHAR* configname)
+{
+	if (portnum < 0 || portnum >= MAX_JPORTS || !name || !configname)
+		return false;
+
+	const auto& preserved = preserved_port_joystick_custom_mappings[portnum];
+	if (!preserved.valid)
+		return false;
+	if (preserved.idc.name[0]) {
+		if (_tcscmp(preserved.idc.name, name))
+			return false;
+	} else if (_tcscmp(preserved.idc.configname, configname)) {
+		return false;
+	}
+
+	const int joystick_index = amiberry_get_joystick_index(configname);
+	if (joystick_index < 0 || joystick_index >= num_joystick)
+		return false;
+
+	auto& did = di_joystick[joystick_index];
+	if (name[0] && did.name != name)
+		return false;
+
+	copy_custom_mapping(preserved.mapping, did.mapping);
 	return true;
 }
 
@@ -1652,7 +1724,9 @@ bool load_custom_options(uae_prefs* p, const std::string& option, const TCHAR* v
 			if (joy_index == -1)
 				continue;
 
-			didata* did = &di_joystick[joy_index];
+			controller_mapping mapping{};
+			amiberry_get_port_joystick_custom_mapping(
+				i, jp->idc.name, jp->idc.configname, mapping);
 
 			for (int m = 0; m < 2; ++m)
 			{
@@ -1662,11 +1736,14 @@ bool load_custom_options(uae_prefs* p, const std::string& option, const TCHAR* v
 					buffer = "joyport" + std::to_string(i) + "_amiberry_custom_" + mode + "_" + SDL_GetGamepadStringForButton(static_cast<SDL_GamepadButton>(n));
 					if (buffer == option)
 					{
-						const auto b = (find_inputevent(value) > -1) ? remap_event_list[find_inputevent(value)] : 0;
+						const int event_index = find_inputevent(value);
+						const auto b = event_index > -1 ? remap_event_list[event_index] : 0;
 						if (m == 0)
-							did->mapping.amiberry_custom_none[n] = b;
+							mapping.amiberry_custom_none[n] = b;
 						else
-							did->mapping.amiberry_custom_hotkey[n] = b;
+							mapping.amiberry_custom_hotkey[n] = b;
+						amiberry_set_port_joystick_custom_mapping(
+							i, jp->idc.name, jp->idc.configname, mapping);
 						return true;
 					}
 				}
@@ -1676,11 +1753,14 @@ bool load_custom_options(uae_prefs* p, const std::string& option, const TCHAR* v
 					buffer = "joyport" + std::to_string(i) + "_amiberry_custom_axis_" + mode + "_" + SDL_GetGamepadStringForAxis(static_cast<SDL_GamepadAxis>(n));
 					if (buffer == option)
 					{
-						const auto b = (find_inputevent(value) > -1) ? remap_event_list[find_inputevent(value)] : 0;
+						const int event_index = find_inputevent(value);
+						const auto b = event_index > -1 ? remap_event_list[event_index] : 0;
 						if (m == 0)
-							did->mapping.amiberry_custom_axis_none[n] = b;
+							mapping.amiberry_custom_axis_none[n] = b;
 						else
-							did->mapping.amiberry_custom_axis_hotkey[n] = b;
+							mapping.amiberry_custom_axis_hotkey[n] = b;
+						amiberry_set_port_joystick_custom_mapping(
+							i, jp->idc.name, jp->idc.configname, mapping);
 						return true;
 					}
 				}

--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -72,8 +72,10 @@ struct cached_joystick_custom_mapping
 struct preserved_port_joystick_custom_mapping
 {
 	struct inputdevconfig idc;
+	amiberry_joystick_identity identity;
 	controller_mapping mapping;
 	bool valid{};
+	bool has_identity{};
 };
 
 std::array<cached_joystick_custom_mapping, MAX_INPUT_DEVICES> cached_joystick_custom_mappings;
@@ -104,6 +106,7 @@ int find_cached_joystick_mapping(const amiberry_joystick_identity& identity,
 {
 	int best_index = -1;
 	int best_score = -1;
+	bool ambiguous = false;
 	for (int i = 0; i < cached_joystick_custom_mapping_count; ++i) {
 		if (used[i])
 			continue;
@@ -112,9 +115,12 @@ int find_cached_joystick_mapping(const amiberry_joystick_identity& identity,
 		if (score > best_score) {
 			best_index = i;
 			best_score = score;
+			ambiguous = false;
+		} else if (score >= 0 && score == best_score) {
+			ambiguous = true;
 		}
 	}
-	return best_index;
+	return ambiguous ? -1 : best_index;
 }
 
 void copy_custom_mapping_to_cache(const controller_mapping& source,
@@ -154,10 +160,6 @@ void amiberry_preserve_port_joystick_custom_mapping(const int portnum,
 		return;
 
 	auto& preserved = preserved_port_joystick_custom_mappings[portnum];
-	if (preserved.valid && matches_joystick_config(preserved.idc, name, configname))
-		return;
-
-	preserved = {};
 	const int joystick_index = amiberry_get_joystick_index(configname);
 	if (joystick_index < 0 || joystick_index >= num_joystick)
 		return;
@@ -166,12 +168,23 @@ void amiberry_preserve_port_joystick_custom_mapping(const int portnum,
 	if (name && name[0] && did.name != name)
 		return;
 
+	if (preserved.valid && matches_joystick_config(preserved.idc, name, configname)) {
+		if (!preserved.has_identity) {
+			preserved.identity = get_joystick_identity(did);
+			preserved.has_identity = true;
+		}
+		return;
+	}
+
+	preserved = {};
 	_tcsncpy(preserved.idc.name, name, MAX_JPORT_NAME - 1);
 	_tcsncpy(preserved.idc.configname, configname, MAX_JPORT_CONFIG - 1);
 	preserved.idc.name[MAX_JPORT_NAME - 1] = 0;
 	preserved.idc.configname[MAX_JPORT_CONFIG - 1] = 0;
+	preserved.identity = get_joystick_identity(did);
 	preserved.mapping = did.mapping;
 	preserved.valid = true;
+	preserved.has_identity = true;
 }
 
 void amiberry_clear_port_joystick_custom_mapping(const int portnum)
@@ -236,7 +249,39 @@ void amiberry_set_port_joystick_custom_mapping(const int portnum,
 	auto& did = di_joystick[joystick_index];
 	if (name[0] && did.name != name)
 		return;
+	if (!preserved.has_identity) {
+		preserved.identity = get_joystick_identity(did);
+		preserved.has_identity = true;
+	}
 	copy_custom_mapping(mapping, did.mapping);
+}
+
+bool amiberry_resolve_port_joystick(const int portnum, int& joystick_index)
+{
+	joystick_index = -1;
+	if (portnum < 0 || portnum >= MAX_JPORTS)
+		return false;
+
+	const auto& preserved = preserved_port_joystick_custom_mappings[portnum];
+	if (!preserved.valid || !preserved.has_identity)
+		return false;
+
+	std::array<bool, MAX_INPUT_DEVICES> used{};
+	for (int i = 0; i < num_joystick; ++i) {
+		const int cache_index = find_cached_joystick_mapping(
+			get_joystick_identity(di_joystick[i]), used);
+		if (cache_index < 0 ||
+			!amiberry_joystick_identity_equal(
+				preserved.identity, cached_joystick_custom_mappings[cache_index].identity)) {
+			continue;
+		}
+		if (joystick_index >= 0) {
+			joystick_index = -1;
+			return true;
+		}
+		joystick_index = i;
+	}
+	return true;
 }
 
 bool amiberry_apply_port_joystick_custom_mapping(const int portnum,
@@ -248,16 +293,20 @@ bool amiberry_apply_port_joystick_custom_mapping(const int portnum,
 	const auto& preserved = preserved_port_joystick_custom_mappings[portnum];
 	if (!preserved.valid)
 		return false;
-	if (preserved.idc.name[0]) {
+	const int joystick_index = amiberry_get_joystick_index(configname);
+	if (joystick_index < 0 || joystick_index >= num_joystick)
+		return false;
+
+	int resolved_joystick = -1;
+	if (amiberry_resolve_port_joystick(portnum, resolved_joystick)) {
+		if (resolved_joystick != joystick_index)
+			return false;
+	} else if (preserved.idc.name[0]) {
 		if (_tcscmp(preserved.idc.name, name))
 			return false;
 	} else if (_tcscmp(preserved.idc.configname, configname)) {
 		return false;
 	}
-
-	const int joystick_index = amiberry_get_joystick_index(configname);
-	if (joystick_index < 0 || joystick_index >= num_joystick)
-		return false;
 
 	auto& did = di_joystick[joystick_index];
 	if (name[0] && did.name != name)

--- a/src/osdep/amiberry_input.h
+++ b/src/osdep/amiberry_input.h
@@ -142,13 +142,18 @@ extern void read_controller_mapping_from_file(controller_mapping& input, const s
 extern int amiberry_get_joystick_index(const TCHAR* configname);
 extern bool load_custom_options(uae_prefs* p, const std::string& option, const TCHAR* value);
 
-// Preserve per-configuration mappings while SDL devices are closed and
-// reopened during hotplug re-enumeration.
+// Keep per-port custom mappings independent of SDL device lifetime, including
+// configurations loaded while their controller is disconnected.
 extern void amiberry_preserve_port_joystick_custom_mapping(int portnum,
 	const TCHAR* name, const TCHAR* configname);
 extern void amiberry_clear_port_joystick_custom_mapping(int portnum);
+extern void amiberry_clear_port_joystick_custom_mappings();
 extern bool amiberry_get_port_joystick_custom_mapping(int portnum,
 	const TCHAR* name, const TCHAR* configname, controller_mapping& mapping);
+extern void amiberry_set_port_joystick_custom_mapping(int portnum,
+	const TCHAR* name, const TCHAR* configname, const controller_mapping& mapping);
+extern bool amiberry_apply_port_joystick_custom_mapping(int portnum,
+	const TCHAR* name, const TCHAR* configname);
 extern void amiberry_cache_joystick_custom_mappings();
 extern void amiberry_restore_joystick_custom_mappings();
 

--- a/src/osdep/amiberry_input.h
+++ b/src/osdep/amiberry_input.h
@@ -152,6 +152,9 @@ extern bool amiberry_get_port_joystick_custom_mapping(int portnum,
 	const TCHAR* name, const TCHAR* configname, controller_mapping& mapping);
 extern void amiberry_set_port_joystick_custom_mapping(int portnum,
 	const TCHAR* name, const TCHAR* configname, const controller_mapping& mapping);
+// Returns true when the port has a physical identity constraint. In that case,
+// joystick_index is the unique matching live device, or -1 if none is safe.
+extern bool amiberry_resolve_port_joystick(int portnum, int& joystick_index);
 extern bool amiberry_apply_port_joystick_custom_mapping(int portnum,
 	const TCHAR* name, const TCHAR* configname);
 extern void amiberry_cache_joystick_custom_mappings();

--- a/src/osdep/amiberry_input.h
+++ b/src/osdep/amiberry_input.h
@@ -139,6 +139,7 @@ extern void read_controller_axis(int id, int axis, int value);
 extern void save_controller_mapping_to_file(const controller_mapping& input, const std::string& filename);
 extern void read_controller_mapping_from_file(controller_mapping& input, const std::string& filename);
 
+extern int amiberry_get_joystick_index(const TCHAR* configname);
 extern bool load_custom_options(uae_prefs* p, const std::string& option, const TCHAR* value);
 
 // Preserve per-configuration mappings while SDL devices are closed and

--- a/src/osdep/amiberry_input.h
+++ b/src/osdep/amiberry_input.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "options.h"
+#include "amiberry_input_identity.h"
 #include <SDL3/SDL.h>
 
 #ifdef AMIBERRY
@@ -54,6 +55,8 @@ struct didata {
 	std::string joystick_name{};
 
 	std::string guid{};
+	std::string serial{};
+	std::string path{};
 	bool is_controller{};
 	SDL_Gamepad* controller{};
 	SDL_Joystick* joystick{};
@@ -137,6 +140,11 @@ extern void save_controller_mapping_to_file(const controller_mapping& input, con
 extern void read_controller_mapping_from_file(controller_mapping& input, const std::string& filename);
 
 extern bool load_custom_options(uae_prefs* p, const std::string& option, const TCHAR* value);
+
+// Preserve per-configuration mappings while SDL devices are closed and
+// reopened during hotplug re-enumeration.
+extern void amiberry_cache_joystick_custom_mappings();
+extern void amiberry_restore_joystick_custom_mappings();
 
 // Multi-mouse support: SDL_MouseID to UAE device index mapping
 extern int get_mouse_index_from_sdl_id(SDL_MouseID which);

--- a/src/osdep/amiberry_input.h
+++ b/src/osdep/amiberry_input.h
@@ -144,6 +144,11 @@ extern bool load_custom_options(uae_prefs* p, const std::string& option, const T
 
 // Preserve per-configuration mappings while SDL devices are closed and
 // reopened during hotplug re-enumeration.
+extern void amiberry_preserve_port_joystick_custom_mapping(int portnum,
+	const TCHAR* name, const TCHAR* configname);
+extern void amiberry_clear_port_joystick_custom_mapping(int portnum);
+extern bool amiberry_get_port_joystick_custom_mapping(int portnum,
+	const TCHAR* name, const TCHAR* configname, controller_mapping& mapping);
 extern void amiberry_cache_joystick_custom_mappings();
 extern void amiberry_restore_joystick_custom_mappings();
 

--- a/src/osdep/amiberry_input_identity.h
+++ b/src/osdep/amiberry_input_identity.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+
+struct amiberry_joystick_identity
+{
+	std::string guid;
+	std::string serial;
+	std::string path;
+	std::string name;
+	bool is_controller{};
+};
+
+// SDL instance IDs change whenever a controller reconnects. Prefer physical
+// identity data when the backend exposes it, with GUID/name as a deterministic
+// fallback for devices that do not report a serial number or stable path.
+inline int amiberry_joystick_identity_score(const amiberry_joystick_identity& previous,
+	const amiberry_joystick_identity& current)
+{
+	if (previous.is_controller != current.is_controller)
+		return -1;
+
+	if (!previous.guid.empty() && !current.guid.empty() && previous.guid != current.guid)
+		return -1;
+
+	if (!previous.serial.empty() && !current.serial.empty())
+		return previous.serial == current.serial ? 400 : -1;
+
+	if (!previous.path.empty() && !current.path.empty() && previous.path == current.path)
+		return 300;
+
+	if (!previous.guid.empty() && previous.guid == current.guid) {
+		if (!previous.name.empty() && previous.name == current.name)
+			return 200;
+		return 100;
+	}
+
+	if (!previous.name.empty() && previous.name == current.name)
+		return 50;
+
+	return -1;
+}

--- a/src/osdep/amiberry_input_identity.h
+++ b/src/osdep/amiberry_input_identity.h
@@ -11,6 +11,16 @@ struct amiberry_joystick_identity
 	bool is_controller{};
 };
 
+inline bool amiberry_joystick_identity_equal(const amiberry_joystick_identity& first,
+	const amiberry_joystick_identity& second)
+{
+	return first.guid == second.guid &&
+		first.serial == second.serial &&
+		first.path == second.path &&
+		first.name == second.name &&
+		first.is_controller == second.is_controller;
+}
+
 // SDL instance IDs change whenever a controller reconnects. Prefer physical
 // identity data when the backend exposes it, with GUID/name as a deterministic
 // fallback for devices that do not report a serial number or stable path.

--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -2121,7 +2121,7 @@ void run_gui()
 			else if (gui_event.type == SDL_EVENT_JOYSTICK_ADDED
 				|| gui_event.type == SDL_EVENT_JOYSTICK_REMOVED) {
 				handle_joy_device_event(gui_event.jdevice.which,
-					gui_event.type == SDL_EVENT_JOYSTICK_REMOVED, &changed_prefs);
+					gui_event.type == SDL_EVENT_JOYSTICK_REMOVED);
 			}
 			else if (gui_event.type == SDL_EVENT_WINDOW_MOVED
 				&& gui_event.window.windowID == SDL_GetWindowID(mon->gui_window)) {

--- a/src/osdep/imgui/input.cpp
+++ b/src/osdep/imgui/input.cpp
@@ -106,6 +106,17 @@ static int get_device_index(const int id)
 	return 0; // Default to <none>
 }
 
+static void set_port_input_device(const int port_idx, const int selected_idx)
+{
+	if (selected_idx < 0 || selected_idx >= static_cast<int>(input_device_options.size()))
+		return;
+
+	changed_prefs.jports[port_idx].id = input_device_options[selected_idx].id;
+	amiberry_clear_port_joystick_custom_mapping(port_idx);
+	inputdevice_forget_unplugged_device(port_idx);
+	inputdevice_validate_jports(&changed_prefs, port_idx, nullptr);
+}
+
 const std::vector<InputDeviceOption>& get_input_device_options()
 {
 	if (input_device_options.empty() || joystick_refresh_needed) {
@@ -178,10 +189,8 @@ void render_panel_input() {
             ImGui::SetNextItemWidth(-ImGui::GetStyle().ItemSpacing.x * 2);
 			int selected_idx = dev_idx;
 			const std::string combo_id = "##Dev" + std::to_string(port_idx);
-			if (InputDeviceCombo(combo_id.c_str(), dev_idx, nullptr, &selected_idx)) {
-				changed_prefs.jports[port_idx].id = input_device_options[selected_idx].id;
-				inputdevice_validate_jports(&changed_prefs, port_idx, nullptr); // Validate change
-			}
+			if (InputDeviceCombo(combo_id.c_str(), dev_idx, nullptr, &selected_idx))
+				set_port_input_device(port_idx, selected_idx);
             ShowHelpMarker("Select the input device to use for this Amiga port. Port 0 is typically for mouse, Port 1 for joystick");
 
             float avail_w = ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 2;
@@ -348,7 +357,7 @@ void render_panel_input() {
 			int selected_idx = dev_idx;
 			const std::string combo_id = "##ParDev" + std::to_string(port_idx);
 			if (InputDeviceCombo(combo_id.c_str(), dev_idx, nullptr, &selected_idx))
-				changed_prefs.jports[port_idx].id = input_device_options[selected_idx].id;
+				set_port_input_device(port_idx, selected_idx);
 
             // Row 2: Autofire | Remap
             float avail_w = ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 2;

--- a/src/osdep/target.h
+++ b/src/osdep/target.h
@@ -70,7 +70,7 @@ extern int mouse_monid;
 extern int minimized;
 extern int monitor_off;
 extern bool joystick_refresh_needed;
-extern void handle_joy_device_event(unsigned int which, bool removed, struct uae_prefs* prefs);
+extern void handle_joy_device_event(unsigned int which, bool removed);
 extern std::string screenshot_filename;
 
 extern void logging_init();

--- a/tests/input_hotplug_identity_test.cpp
+++ b/tests/input_hotplug_identity_test.cpp
@@ -1,0 +1,81 @@
+#include <array>
+#include <iostream>
+
+#include "amiberry_input_identity.h"
+
+static int failures;
+
+static void expect_eq(const int actual, const int expected, const char* message)
+{
+	if (actual != expected) {
+		std::cerr << message << ": expected " << expected << ", got " << actual << '\n';
+		failures++;
+	}
+}
+
+static amiberry_joystick_identity identity(const char* guid, const char* serial,
+	const char* path, const char* name, const bool is_controller = true)
+{
+	return {guid, serial, path, name, is_controller};
+}
+
+template <size_t Count>
+static int best_match(const amiberry_joystick_identity& current,
+	const std::array<amiberry_joystick_identity, Count>& previous)
+{
+	int best_index = -1;
+	int best_score = -1;
+	for (size_t i = 0; i < Count; ++i) {
+		const int score = amiberry_joystick_identity_score(previous[i], current);
+		if (score > best_score) {
+			best_index = static_cast<int>(i);
+			best_score = score;
+		}
+	}
+	return best_index;
+}
+
+int main()
+{
+	const auto original = identity("guid-a", "serial-a", "/dev/input/js0", "Gamepad");
+
+	expect_eq(amiberry_joystick_identity_score(original,
+		identity("guid-a", "serial-a", "/dev/input/js4", "Renamed Gamepad")), 400,
+		"A serial number must survive a changed path and display name");
+	expect_eq(amiberry_joystick_identity_score(original,
+		identity("guid-a", "serial-b", "/dev/input/js0", "Gamepad")), -1,
+		"Different serial numbers must distinguish otherwise identical devices");
+	expect_eq(amiberry_joystick_identity_score(
+		identity("guid-a", "", "/dev/input/by-path/controller-a", "Gamepad"),
+		identity("guid-a", "", "/dev/input/by-path/controller-a", "Gamepad")), 300,
+		"A stable device path must distinguish controllers without serial numbers");
+	expect_eq(amiberry_joystick_identity_score(
+		identity("guid-a", "", "/dev/input/js0", "Gamepad"),
+		identity("guid-a", "", "/dev/input/js1", "Gamepad")), 200,
+		"GUID and name must provide a reconnect fallback when a path changes");
+	expect_eq(amiberry_joystick_identity_score(original,
+		identity("guid-b", "serial-a", "/dev/input/js0", "Gamepad")), -1,
+		"A conflicting GUID must reject a serial collision");
+	expect_eq(amiberry_joystick_identity_score(original,
+		identity("guid-a", "serial-a", "/dev/input/js0", "Gamepad", false)), -1,
+		"Gamepad and raw joystick mappings must not be mixed");
+	expect_eq(amiberry_joystick_identity_score(
+		identity("", "", "", "Legacy Joystick"),
+		identity("", "", "", "Legacy Joystick")), 50,
+		"The friendly name must remain a fallback for legacy backends");
+	expect_eq(amiberry_joystick_identity_score(
+		identity("", "", "", "Joystick A"),
+		identity("", "", "", "Joystick B")), -1,
+		"Devices without a shared identity must not inherit mappings");
+
+	const std::array duplicate_controllers = {
+		identity("shared-guid", "", "/dev/input/by-path/controller-a", "Twin Gamepad"),
+		identity("shared-guid", "", "/dev/input/by-path/controller-b", "Twin Gamepad")
+	};
+	expect_eq(best_match(
+		identity("shared-guid", "", "/dev/input/by-path/controller-b", "Twin Gamepad"),
+		duplicate_controllers), 1,
+		"A reordered duplicate controller must retain the mapping for its physical path");
+
+	return failures == 0 ? 0 : 1;
+}

--- a/tests/input_hotplug_identity_test.cpp
+++ b/tests/input_hotplug_identity_test.cpp
@@ -13,6 +13,14 @@ static void expect_eq(const int actual, const int expected, const char* message)
 	}
 }
 
+static void expect_true(const bool actual, const char* message)
+{
+	if (!actual) {
+		std::cerr << message << '\n';
+		failures++;
+	}
+}
+
 static amiberry_joystick_identity identity(const char* guid, const char* serial,
 	const char* path, const char* name, const bool is_controller = true)
 {
@@ -25,20 +33,30 @@ static int best_match(const amiberry_joystick_identity& current,
 {
 	int best_index = -1;
 	int best_score = -1;
+	bool ambiguous = false;
 	for (size_t i = 0; i < Count; ++i) {
 		const int score = amiberry_joystick_identity_score(previous[i], current);
 		if (score > best_score) {
 			best_index = static_cast<int>(i);
 			best_score = score;
+			ambiguous = false;
+		} else if (score >= 0 && score == best_score) {
+			ambiguous = true;
 		}
 	}
-	return best_index;
+	return ambiguous ? -1 : best_index;
 }
 
 int main()
 {
 	const auto original = identity("guid-a", "serial-a", "/dev/input/js0", "Gamepad");
 
+	expect_true(amiberry_joystick_identity_equal(
+		original, identity("guid-a", "serial-a", "/dev/input/js0", "Gamepad")),
+		"An unchanged physical identity must compare equal");
+	expect_true(!amiberry_joystick_identity_equal(
+		original, identity("guid-a", "serial-a", "/dev/input/js1", "Gamepad")),
+		"A changed physical path must not compare exactly equal");
 	expect_eq(amiberry_joystick_identity_score(original,
 		identity("guid-a", "serial-a", "/dev/input/js4", "Renamed Gamepad")), 400,
 		"A serial number must survive a changed path and display name");
@@ -76,6 +94,15 @@ int main()
 		identity("shared-guid", "", "/dev/input/by-path/controller-b", "Twin Gamepad"),
 		duplicate_controllers), 1,
 		"A reordered duplicate controller must retain the mapping for its physical path");
+
+	const std::array indistinguishable_controllers = {
+		identity("shared-guid", "", "", "Twin Gamepad"),
+		identity("shared-guid", "", "", "Twin Gamepad")
+	};
+	expect_eq(best_match(
+		identity("shared-guid", "", "", "Twin Gamepad"),
+		indistinguishable_controllers), -1,
+		"An ambiguous identical-controller match must be rejected");
 
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/test_input_hotplug.sh
+++ b/tests/test_input_hotplug.sh
@@ -30,6 +30,7 @@ amiberry = Path("src/osdep/amiberry.cpp").read_text()
 amiberry_input = Path("src/osdep/amiberry_input.cpp").read_text()
 cfgfile = Path("src/cfgfile.cpp").read_text()
 inputdevice = Path("src/inputdevice.cpp").read_text()
+input_panel = Path("src/osdep/imgui/input.cpp").read_text()
 
 
 def fail(message: str) -> None:
@@ -84,10 +85,33 @@ if """if (unplugged_ports & (1U << i)) {
 			_tcsncpy(prefs->jports[i].idc.name, jports_name[i], MAX_JPORT_NAME - 1);
 			_tcsncpy(prefs->jports[i].idc.configname, jports_configname[i], MAX_JPORT_CONFIG - 1);""" not in devicechange:
 	fail("Pending preferences must retain the configured device identity while it is unplugged")
-if """const int configured_joystick = amiberry_get_joystick_index(jp->idc.configname);
-		if (configured_joystick >= 0) {
-			_sntprintf(tmp2, sizeof tmp2, _T("joy%d"), configured_joystick);""" not in cfgfile:
-	fail("Configuration saves must prefer the retained joystick identity over a transient fallback")
+save_ports = region_between(
+	cfgfile,
+	"for (i = 0; i < MAX_JPORTS; i++) {",
+	"for (i = 0; i < MAX_JPORTS_CUSTOM; i++) {",
+)
+if "configured_joystick" in save_ports:
+	fail("Saved joyport values must follow the active port selection, not stale identity metadata")
+fixjport = region_between(
+	inputdevice,
+	"static bool fixjport(",
+	"static void inputdevice_get_previous_joy",
+)
+if "if (vv == JPORT_NONE)" in fixjport:
+	fail("Explicitly selecting None must clear the previous device identity")
+port_selection = region_between(
+	input_panel,
+	"static void set_port_input_device(",
+	"const std::vector<InputDeviceOption>& get_input_device_options()",
+)
+if "amiberry_clear_port_joystick_custom_mapping(port_idx);" not in port_selection:
+	fail("Explicit port changes must discard the old controller mapping snapshot")
+if "inputdevice_forget_unplugged_device(port_idx);" not in port_selection:
+	fail("Explicit port changes must cancel pending reconnection of the old controller")
+if "inputdevice_validate_jports(&changed_prefs, port_idx, nullptr);" not in port_selection:
+	fail("Explicit port changes must refresh or clear saved device identity metadata")
+if input_panel.count("set_port_input_device(port_idx, selected_idx);") != 2:
+	fail("Primary and parallel port selectors must share the identity-safe update path")
 if "const int joy_index = amiberry_get_joystick_index(jp->idc.configname);" not in amiberry_input:
 	fail("Custom mapping loads must use the same bounded joystick index parser as saves")
 if """if (!amiberry_get_port_joystick_custom_mapping(

--- a/tests/test_input_hotplug.sh
+++ b/tests/test_input_hotplug.sh
@@ -27,6 +27,7 @@ from pathlib import Path
 import sys
 
 amiberry = Path("src/osdep/amiberry.cpp").read_text()
+amiberry_input = Path("src/osdep/amiberry_input.cpp").read_text()
 cfgfile = Path("src/cfgfile.cpp").read_text()
 inputdevice = Path("src/inputdevice.cpp").read_text()
 
@@ -73,14 +74,21 @@ if "jportscustom[portnum] = -1;" not in devicechange:
 	fail("A reinserted device must clear the custom marker for its port, not its device index")
 if "unplugged_ports |= inputdevice_store_unplugged_port" not in devicechange:
 	fail("Removed controller bindings must be tracked by port")
+if """if (found) {
+				unplugged_ports &= ~(1U << i);
+			}
+			if (!found) {""" not in devicechange:
+	fail("A controller rematched after SDL index compaction must keep its validated identity")
 if """if (unplugged_ports & (1U << i)) {
 			_tcsncpy(prefs->jports[i].idc.name, jports_name[i], MAX_JPORT_NAME - 1);
 			_tcsncpy(prefs->jports[i].idc.configname, jports_configname[i], MAX_JPORT_CONFIG - 1);""" not in devicechange:
 	fail("Pending preferences must retain the configured device identity while it is unplugged")
-if """const int configured_joystick = cfgfile_get_joystick_index(jp);
+if """const int configured_joystick = amiberry_get_joystick_index(jp->idc.configname);
 		if (configured_joystick >= 0) {
 			_sntprintf(tmp2, sizeof tmp2, _T("joy%d"), configured_joystick);""" not in cfgfile:
 	fail("Configuration saves must prefer the retained joystick identity over a transient fallback")
+if "const int joy_index = amiberry_get_joystick_index(jp->idc.configname);" not in amiberry_input:
+	fail("Custom mapping loads must use the same bounded joystick index parser as saves")
 if """if (!changed) {
 		if (acc)
 			inputdevice_acquire (TRUE);

--- a/tests/test_input_hotplug.sh
+++ b/tests/test_input_hotplug.sh
@@ -76,11 +76,19 @@ if "jportscustom[portnum] = -1;" not in devicechange:
 	fail("A reinserted device must clear the custom marker for its port, not its device index")
 if "unplugged_ports |= inputdevice_store_unplugged_port" not in devicechange:
 	fail("Removed controller bindings must be tracked by port")
+if "uae_u32 unplugged_ports = inputdevice_get_unplugged_ports();" not in devicechange:
+	fail("Ports already awaiting reconnection must survive later hotplug passes")
 if """if (found) {
+				if (unplugged_ports & (1U << i))
+					inputdevice_forget_unplugged_device(i);
 				unplugged_ports &= ~(1U << i);
-			}
-			if (!found) {""" not in devicechange:
+			}""" not in devicechange:
 	fail("A controller rematched after SDL index compaction must keep its validated identity")
+if "identity_bound = amiberry_resolve_port_joystick(i, resolved_joystick);" not in devicechange:
+	fail("Port rematching must resolve identity-bound controllers before friendly-name fallback")
+if """if (identity_bound) {
+					inputdevice_store_unplugged_binding(""" not in devicechange:
+	fail("An identity-bound controller with no safe match must remain pending")
 if """if (unplugged_ports & (1U << i)) {
 			_tcsncpy(prefs->jports[i].idc.name, jports_name[i], MAX_JPORT_NAME - 1);
 			_tcsncpy(prefs->jports[i].idc.configname, jports_configname[i], MAX_JPORT_CONFIG - 1);""" not in devicechange:
@@ -130,6 +138,22 @@ if """controller_mapping mapping{};
 	fail("Custom mapping loads must start from the durable per-port representation")
 if "amiberry_set_port_joystick_custom_mapping(" not in amiberry_input:
 	fail("Custom mapping loads must persist without requiring a live SDL device")
+if """struct preserved_port_joystick_custom_mapping
+{
+	struct inputdevconfig idc;
+	amiberry_joystick_identity identity;""" not in amiberry_input:
+	fail("Deferred custom mappings must retain their physical controller identity")
+if "preserved.identity = get_joystick_identity(did);" not in amiberry_input:
+	fail("Live per-port mapping snapshots must capture physical controller identity")
+if "return ambiguous ? -1 : best_index;" not in amiberry_input:
+	fail("Indistinguishable controller identities must not be assigned arbitrarily")
+apply_custom_mapping = region_between(
+	amiberry_input,
+	"bool amiberry_apply_port_joystick_custom_mapping(",
+	"void amiberry_cache_joystick_custom_mappings()",
+)
+if "amiberry_resolve_port_joystick(portnum, resolved_joystick)" not in apply_custom_mapping:
+	fail("Deferred mappings must be applied only to the resolved physical controller")
 custom_loader = region_between(
 	amiberry_input,
 	"bool load_custom_options(",

--- a/tests/test_input_hotplug.sh
+++ b/tests/test_input_hotplug.sh
@@ -95,8 +95,36 @@ if """if (!amiberry_get_port_joystick_custom_mapping(
 	fail("Configuration saves must use a preserved mapping for an unplugged controller")
 if "di_joystick[joy_index]" in cfgfile:
 	fail("Configuration saves must not dereference a stale or compacted joystick slot")
-if "if (found)\n\t\t\tamiberry_clear_port_joystick_custom_mapping(i);" not in devicechange:
-	fail("A successfully rematched port must discard its temporary mapping snapshot")
+apply_mapping = devicechange.find("amiberry_apply_port_joystick_custom_mapping(")
+clear_mapping = devicechange.find("amiberry_clear_port_joystick_custom_mapping(i);")
+validate_port = devicechange.find("inputdevice_validate_jports(prefs, i, fixedports);")
+if not (0 <= apply_mapping < validate_port < clear_mapping):
+	fail("A rematched controller must receive its deferred mapping before the rematch is finalized and the snapshot is cleared")
+if """controller_mapping mapping{};
+			amiberry_get_port_joystick_custom_mapping(
+				i, jp->idc.name, jp->idc.configname, mapping);""" not in amiberry_input:
+	fail("Custom mapping loads must start from the durable per-port representation")
+if "amiberry_set_port_joystick_custom_mapping(" not in amiberry_input:
+	fail("Custom mapping loads must persist without requiring a live SDL device")
+custom_loader = region_between(
+	amiberry_input,
+	"bool load_custom_options(",
+	"static void close_joystick()",
+)
+if "di_joystick[" in custom_loader:
+	fail("Custom mapping loads must not write into an unenumerated SDL device slot")
+if "copy_custom_mapping(preserved.mapping, did.mapping);" not in amiberry_input:
+	fail("Deferred custom mappings must be applied when the configured controller returns")
+cfgload = region_between(
+	cfgfile,
+	"static int cfgfile_load_2",
+	"int cfgfile_load (",
+)
+open_failure = cfgload.find("if (! fh)")
+clear_deferred = cfgload.find("amiberry_clear_port_joystick_custom_mappings();")
+parse_config = cfgload.find("while (cfg_fgets")
+if not (0 <= open_failure < clear_deferred < parse_config):
+	fail("A successfully opened host configuration must discard stale deferred mappings before parsing")
 if """if (!changed) {
 		if (acc)
 			inputdevice_acquire (TRUE);

--- a/tests/test_input_hotplug.sh
+++ b/tests/test_input_hotplug.sh
@@ -27,6 +27,7 @@ from pathlib import Path
 import sys
 
 amiberry = Path("src/osdep/amiberry.cpp").read_text()
+cfgfile = Path("src/cfgfile.cpp").read_text()
 inputdevice = Path("src/inputdevice.cpp").read_text()
 
 
@@ -70,6 +71,16 @@ if not (0 <= cache < close < init < restore < rematch):
 	fail("Custom mappings must bracket SDL joystick re-enumeration before port rematching")
 if "jportscustom[portnum] = -1;" not in devicechange:
 	fail("A reinserted device must clear the custom marker for its port, not its device index")
+if "unplugged_ports |= inputdevice_store_unplugged_port" not in devicechange:
+	fail("Removed controller bindings must be tracked by port")
+if """if (unplugged_ports & (1U << i)) {
+			_tcsncpy(prefs->jports[i].idc.name, jports_name[i], MAX_JPORT_NAME - 1);
+			_tcsncpy(prefs->jports[i].idc.configname, jports_configname[i], MAX_JPORT_CONFIG - 1);""" not in devicechange:
+	fail("Pending preferences must retain the configured device identity while it is unplugged")
+if """const int configured_joystick = cfgfile_get_joystick_index(jp);
+		if (configured_joystick >= 0) {
+			_sntprintf(tmp2, sizeof tmp2, _T("joy%d"), configured_joystick);""" not in cfgfile:
+	fail("Configuration saves must prefer the retained joystick identity over a transient fallback")
 if """if (!changed) {
 		if (acc)
 			inputdevice_acquire (TRUE);

--- a/tests/test_input_hotplug.sh
+++ b/tests/test_input_hotplug.sh
@@ -64,11 +64,12 @@ devicechange = region_between(
 	"#ifdef AMIBERRY\n// Re-enumerate mouse devices",
 )
 cache = devicechange.find("amiberry_cache_joystick_custom_mappings();")
+preserve = devicechange.find("amiberry_preserve_port_joystick_custom_mapping(")
 close = devicechange.find("idev[IDTYPE_JOYSTICK].close();")
 init = devicechange.find("idev[IDTYPE_JOYSTICK].init();")
 restore = devicechange.find("amiberry_restore_joystick_custom_mappings();")
 rematch = devicechange.find("matchdevices_all(prefs);")
-if not (0 <= cache < close < init < restore < rematch):
+if not (0 <= preserve < cache < close < init < restore < rematch):
 	fail("Custom mappings must bracket SDL joystick re-enumeration before port rematching")
 if "jportscustom[portnum] = -1;" not in devicechange:
 	fail("A reinserted device must clear the custom marker for its port, not its device index")
@@ -89,6 +90,13 @@ if """const int configured_joystick = amiberry_get_joystick_index(jp->idc.config
 	fail("Configuration saves must prefer the retained joystick identity over a transient fallback")
 if "const int joy_index = amiberry_get_joystick_index(jp->idc.configname);" not in amiberry_input:
 	fail("Custom mapping loads must use the same bounded joystick index parser as saves")
+if """if (!amiberry_get_port_joystick_custom_mapping(
+			i, jp->idc.name, jp->idc.configname, mapping))""" not in cfgfile:
+	fail("Configuration saves must use a preserved mapping for an unplugged controller")
+if "di_joystick[joy_index]" in cfgfile:
+	fail("Configuration saves must not dereference a stale or compacted joystick slot")
+if "if (found)\n\t\t\tamiberry_clear_port_joystick_custom_mapping(i);" not in devicechange:
+	fail("A successfully rematched port must discard its temporary mapping snapshot")
 if """if (!changed) {
 		if (acc)
 			inputdevice_acquire (TRUE);

--- a/tests/test_input_hotplug.sh
+++ b/tests/test_input_hotplug.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cxx="${CXX:-c++}"
+out="${TMPDIR:-/tmp}/input_hotplug_identity_test.$$"
+trap 'rm -f "$out"' EXIT
+
+"$cxx" -std=c++17 -Wall -Wextra -Werror \
+	-Isrc/osdep \
+	-o "$out" \
+	tests/input_hotplug_identity_test.cpp
+"$out"
+
+if command -v python3 >/dev/null 2>&1; then
+	PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+	PYTHON=python
+elif command -v py >/dev/null 2>&1; then
+	PYTHON="py -3"
+else
+	echo "python3, python, or py is required" >&2
+	exit 1
+fi
+
+$PYTHON - <<'PY'
+from pathlib import Path
+import sys
+
+amiberry = Path("src/osdep/amiberry.cpp").read_text()
+inputdevice = Path("src/inputdevice.cpp").read_text()
+
+
+def fail(message: str) -> None:
+	print(message, file=sys.stderr)
+	sys.exit(1)
+
+
+def region_between(text: str, start_marker: str, end_marker: str) -> str:
+	try:
+		start = text.index(start_marker)
+		end = text.index(end_marker, start)
+	except ValueError as exc:
+		fail(f"Could not find source marker: {exc}")
+	return text[start:end]
+
+
+handler = region_between(
+	amiberry,
+	"void handle_joy_device_event(",
+	"static void handle_controller_button_event",
+)
+if "inputdevice_devicechange(&changed_prefs)" not in handler:
+	fail("Joystick hotplug must synchronize changed_prefs and currprefs")
+if "inputdevice_devicechange(&currprefs)" in handler:
+	fail("Runtime hotplug must not bypass the pending preference state")
+if "import_joysticks()" in handler:
+	fail("Joystick hotplug must not perform a second SDL re-enumeration")
+
+devicechange = region_between(
+	inputdevice,
+	"bool inputdevice_devicechange (struct uae_prefs *prefs)",
+	"#ifdef AMIBERRY\n// Re-enumerate mouse devices",
+)
+cache = devicechange.find("amiberry_cache_joystick_custom_mappings();")
+close = devicechange.find("idev[IDTYPE_JOYSTICK].close();")
+init = devicechange.find("idev[IDTYPE_JOYSTICK].init();")
+restore = devicechange.find("amiberry_restore_joystick_custom_mappings();")
+rematch = devicechange.find("matchdevices_all(prefs);")
+if not (0 <= cache < close < init < restore < rematch):
+	fail("Custom mappings must bracket SDL joystick re-enumeration before port rematching")
+if "jportscustom[portnum] = -1;" not in devicechange:
+	fail("A reinserted device must clear the custom marker for its port, not its device index")
+if """if (!changed) {
+		if (acc)
+			inputdevice_acquire (TRUE);
+		return false;
+	}""" not in devicechange:
+	fail("A no-op re-enumeration must reacquire input before returning")
+PY


### PR DESCRIPTION
## Summary

- route joystick hotplug through the pending preferences and synchronize the live input configuration
- remove the redundant second SDL joystick enumeration
- preserve custom button and axis mappings across reconnects using serial, path, GUID, and name identity matching
- fix input reacquisition on no-op enumeration and use the restored port index when clearing custom port state
- add focused regression coverage for reconnects, reordered devices, and duplicate controllers

## Root cause

Runtime hotplug passed currprefs to inputdevice_devicechange(). The device list was rebuilt and rebound only in the live preferences, while changed_prefs retained the previous selection. The normal preference synchronization could then overwrite the live state while the controller was absent, and reconnecting produced no preference delta that would rebuild the active mapping. Manually reselecting the controller created that missing delta.

The event handler also called import_joysticks() after inputdevice_devicechange() had already closed and reopened the devices, performing an unnecessary second enumeration and discarding in-memory custom mappings.

## Compatibility and performance

Persisted JOY0-style identifiers and the .uae configuration format are unchanged. Re-enumeration is now single-pass, and custom mapping preservation uses a fixed-capacity cache bounded by MAX_INPUT_DEVICES.

## Validation

- bash tests/test_input_hotplug.sh
- cmake --build out/build/windows-debug --parallel
- git diff --check

Physical Bluetooth, 2.4 GHz, and Mayflash sleep/reconnect testing remains the final hardware validation.

Fixes #2221