### PR TITLE
Fix indirect trap callback crash with clipboard sharing

### DIFF
--- a/src/autoconf.cpp
+++ b/src/autoconf.cpp
@@ -34,8 +34,8 @@ uaecptr EXPANSION_bootcode, EXPANSION_nullfunc;
 /* ROM tag area memory access */
 
 uaecptr rtarea_base = RTAREA_DEFAULT;
-uae_sem_t hardware_trap_event[RTAREA_TRAP_DATA_SIZE / RTAREA_TRAP_DATA_SLOT_SIZE];
-uae_sem_t hardware_trap_event2[RTAREA_TRAP_DATA_SIZE / RTAREA_TRAP_DATA_SLOT_SIZE];
+uae_sem_t hardware_trap_event[RTAREA_TRAP_DATA_NUM + RTAREA_TRAP_DATA_SEND_NUM];
+uae_sem_t hardware_trap_event2[RTAREA_TRAP_DATA_NUM + RTAREA_TRAP_DATA_SEND_NUM];
 
 static uaecptr rt_trampoline_ptr, trap_entry;
 static bool rtarea_write_enabled;
@@ -645,7 +645,7 @@ void rtarea_init(void)
 	trap_entry = filesys_get_entry(10);
 	write_log(_T("TRAP_ENTRY = %08x\n"), trap_entry);
 
-	for (int i = 0; i < RTAREA_TRAP_DATA_SIZE / RTAREA_TRAP_DATA_SLOT_SIZE; i++) {
+	for (int i = 0; i < RTAREA_TRAP_DATA_NUM + RTAREA_TRAP_DATA_SEND_NUM; i++) {
 		uae_sem_init(&hardware_trap_event[i], 0, 0);
 		uae_sem_init(&hardware_trap_event2[i], 0, 0);
 	}

--- a/src/traps.cpp
+++ b/src/traps.cpp
@@ -965,7 +965,7 @@ void reset_traps(void)
 			hardware_trap_state[i] = 1;
 			write_comm_pipe_pvoid(&trap_thread_pipe[i], NULL, 1);
 			while (hardware_trap_state[i] > 0) {
-				for (int j = 0; j < RTAREA_TRAP_DATA_SIZE / RTAREA_TRAP_DATA_SLOT_SIZE; j++) {
+				for (int j = 0; j < TRAP_THREADS; j++) {
 					uae_sem_post(&hardware_trap_event[j]);
 					uae_sem_post(&hardware_trap_event2[j]);
 				}
@@ -974,7 +974,7 @@ void reset_traps(void)
 			hardware_trap_kill[i] = htk;
 		}
 	}
-	for (int j = 0; j < RTAREA_TRAP_DATA_SIZE / RTAREA_TRAP_DATA_SLOT_SIZE; j++) {
+	for (int j = 0; j < TRAP_THREADS; j++) {
 		uae_sem_unpost(&hardware_trap_event[j]);
 		uae_sem_unpost(&hardware_trap_event2[j]);
 	}


### PR DESCRIPTION
## Summary

- allocate and initialize trap semaphores for the host-to-Amiga send slot
- include the send slot when waking and resetting indirect trap workers

## Root cause

Clipboard sharing schedules a callback 60 frames after the guest clipboard task starts. With `uaeboard=full+indirect`, that callback uses trap slot 4 for a host-to-Amiga memory read.

The semaphore arrays only contained the four regular trap slots (0-3). Optimized GCC/ELF builds can place the two arrays in reverse order, so indexing slot 4 passed a null semaphore to `SDL_WaitSemaphoreTimeout()` and caused the reported SIGSEGV. The JIT signal handler reported the host crash but was not its source.

## Impact

Indirect UAE-board callbacks, including clipboard signaling, now have a valid semaphore for the dedicated send slot on Linux and other platforms regardless of global variable layout.

Fixes #2222.

## Validation

- full GCC 14 Linux Debug build
- linked ELF inspection: both `hardware_trap_event` arrays are 40 bytes (five pointer slots)
- `./amiberry --jit-selftest`
- llvm-mingw Windows Debug build
- `git diff --check`

The configured CTest project currently exposes no tests.
