### PR TITLE
Fix sidebar section header text color

### DIFF
--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -2560,8 +2560,7 @@ void run_gui()
 						const bool active_in = (last_active_panel >= sidebar_groups[g].first_index &&
 							last_active_panel < g_end);
 						group_collapsed = collapsible && section_collapsed[g] && !has_filter && !active_in;
-						ImVec4 label_col = ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled);
-						label_col.w *= 0.7f;
+						const ImVec4 label_col = ImGui::GetStyleColorVec4(ImGuiCol_Text);
 						std::string upper_label;
 						for (const char* c = sidebar_groups[g].label; *c; ++c)
 							upper_label += static_cast<char>(toupper(static_cast<unsigned char>(*c)));


### PR DESCRIPTION
## Summary

- Render the Expert settings sidebar section headers with the normal theme text color.
- Remove the additional opacity reduction that made the collapse controls appear disabled.

## Root cause

The sidebar group header styling used `ImGuiCol_TextDisabled` and reduced its alpha to 70%. This made the interactive headers and chevrons look unavailable, especially with the light theme shown on KMSDRM.

## Testing

- `cmake --build out/build/windows-debug --parallel`
- `git diff --check`

Fixes #2218
