### PR TITLE
Fix wide-window GUI layout issues

### DIFF
--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -1046,19 +1046,16 @@ bool BeginGroupBox(const char* name, bool collapsible, bool default_open)
 		bool open = storage->GetBool(id, default_open);
 		const char* arrow = open ? ICON_FA_CHEVRON_DOWN : ICON_FA_CHEVRON_RIGHT;
 		std::string toggle_label = std::string(arrow) + " " + name;
-		if (ImGui::Selectable(toggle_label.c_str(), false, 0, ImVec2(0, ImGui::GetTextLineHeightWithSpacing()))) {
+		// Selectable treats zero width as the remaining window width, which lets
+		// a group header's hover highlight spill across sibling columns.
+		const float toggle_width = ImGui::CalcTextSize(toggle_label.c_str()).x
+			+ ImGui::GetStyle().FramePadding.x * 2.0f;
+		if (ImGui::Selectable(toggle_label.c_str(), false, 0,
+			ImVec2(toggle_width, ImGui::GetTextLineHeightWithSpacing()))) {
 			open = !open;
 			storage->SetBool(id, open);
 		}
 		if (!open) {
-			// When collapsed the header Selectable is the group's only/last item.
-			// A Selectable sizes its render/click rect to the full available width
-			// (WorkRect.Max.x), and ImGui::EndGroup() folds the last item's rect
-			// into the group's bounding box. That full-width rect would otherwise
-			// leak into the enclosing layout and push a side-by-side column off
-			// screen (issue #2118). Submit a zero-size item so the collapsed group
-			// reports a sane width based on the header label only.
-			ImGui::Dummy(ImVec2(0.0f, 0.0f));
 			g_groupbox_collapsed = true;
 			return false;
 		}

--- a/src/osdep/imgui/cpu.cpp
+++ b/src/osdep/imgui/cpu.cpp
@@ -608,7 +608,8 @@ void render_panel_cpu() {
         ImGui::Spacing();
         
         // Use table for better organization
-        if (ImGui::BeginTable("JITTable", 2, ImGuiTableFlags_None)) {
+        if (ImGui::BeginTable("JITTable", 2, ImGuiTableFlags_None,
+            ImVec2(right_group_min_width, 0.0f))) {
             ImGui::TableNextRow();
             ImGui::TableNextColumn();
 

--- a/src/osdep/imgui/display.cpp
+++ b/src/osdep/imgui/display.cpp
@@ -275,9 +275,9 @@ void render_panel_display() {
     ImGui::Spacing();
 
     // Checkboxes
-    if (ImGui::BeginTable("ChkTable", 2, ImGuiTableFlags_None)) {
-        ImGui::TableSetupColumn("column1", ImGuiTableColumnFlags_WidthStretch, 1.0f);
-        ImGui::TableSetupColumn("column2", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+    if (ImGui::BeginTable("ChkTable", 2, ImGuiTableFlags_SizingFixedFit)) {
+        ImGui::TableSetupColumn("column1", ImGuiTableColumnFlags_WidthFixed);
+        ImGui::TableSetupColumn("column2", ImGuiTableColumnFlags_WidthFixed);
 
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
@@ -412,10 +412,10 @@ void render_panel_display() {
 
     // Refresh Slider + PAL/NTSC
     // WinUAE: Label "Refresh:" -> Slider -> Dropdown "PAL"
-    if (ImGui::BeginTable("RefreshRowTable", 3, ImGuiTableFlags_None)) {
+    if (ImGui::BeginTable("RefreshRowTable", 3, ImGuiTableFlags_SizingFixedFit)) {
         ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed, BUTTON_WIDTH * 0.7f);
-        ImGui::TableSetupColumn("slider", ImGuiTableColumnFlags_WidthStretch, 1.0f);
-        ImGui::TableSetupColumn("combo", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+        ImGui::TableSetupColumn("slider", ImGuiTableColumnFlags_WidthFixed, BUTTON_WIDTH);
+        ImGui::TableSetupColumn("combo", ImGuiTableColumnFlags_WidthFixed, BUTTON_WIDTH);
 
         ImGui::TableNextRow();
         ImGui::TableNextColumn();

--- a/src/osdep/imgui/expansions.cpp
+++ b/src/osdep/imgui/expansions.cpp
@@ -1065,7 +1065,7 @@ void render_panel_expansions() {
     EndGroupBox("Accelerator Board Settings");
 
     BeginGroupBox("Miscellaneous Expansions");
-    if (ImGui::BeginTable("MiscTable", 2, ImGuiTableFlags_None)) {
+    if (ImGui::BeginTable("MiscTable", 2, ImGuiTableFlags_SizingFixedFit)) {
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
 

--- a/src/osdep/imgui/input.cpp
+++ b/src/osdep/imgui/input.cpp
@@ -4,6 +4,7 @@
 #include "inputdevice.h"
 #include "amiberry_input.h"
 #include "imgui_panels.h"
+#include <algorithm>
 #include <vector>
 #include <string>
 #include <unordered_map>
@@ -504,7 +505,9 @@ void render_panel_input() {
 
     if (BeginGroupBox("Mouse extra settings", true, false)) {
 
-    if (ImGui::BeginTable("MouseExtrasTable", 2, ImGuiTableFlags_None)) {
+    const float mouse_extras_width = std::min(BUTTON_WIDTH * 6.0f, ImGui::GetContentRegionAvail().x);
+    if (ImGui::BeginTable("MouseExtrasTable", 2, ImGuiTableFlags_None,
+        ImVec2(mouse_extras_width, 0.0f))) {
         // Row 1
         ImGui::TableNextRow();
 


### PR DESCRIPTION
## Summary

- constrain collapsible group header hit and highlight rectangles to their rendered labels
- keep compact controls in the CPU, Display, Expansions, and Input panels from stretching across wide windows
- preserve responsive sizing for tables that are intended to fill their panels

## Root cause

Dear ImGui treats a zero-width `Selectable` as spanning the remaining window work rectangle. The custom collapsible group header used that default inside side-by-side layouts, so its hover highlight could spill across sibling columns.

Default table sizing also stretches columns across all available width. That behavior misplaced compact controls in the Advanced JIT settings and several other panels when the GUI window was unusually wide.

## User impact

Collapsible header highlights and compact option groups now stay within their intended layout areas at large window sizes, including high-resolution KMSDRM sessions.

## Validation

- Windows llvm-mingw debug build
- Windows debug executable startup smoke test
- `git diff --check`
- audited all 113 `Selectable` calls and 37 ImGui table layouts

Fixes #2220
