### PR TITLE
Fix physical CD capacity reporting

### DIFF
--- a/src/osdep/blkdev_ioctl.cpp
+++ b/src/osdep/blkdev_ioctl.cpp
@@ -2265,13 +2265,20 @@ static void update_device_info(int unitnum)
 	di->target = 0;
 	di->lun = 0;
 	di->media_inserted = 0;
+	di->cylinders = 0;
+	di->trackspercylinder = 0;
+	di->sectorspertrack = 0;
 	di->bytespersector = 2048;
 	strncpy(di->mediapath, ciw->drvletter, sizeof(ciw->drvletter) - 1);
 	if (fetch_geometry(ciw, unitnum, di)) { // || ioctl_command_toc (unitnum))
 		di->media_inserted = 1;
 	}
 	if (ciw->changed || di->media_inserted) {
-		ioctl_command_toc2(unitnum, &di->toc, true);
+		if (ioctl_command_toc2(unitnum, &di->toc, true)) {
+			di->cylinders = 1;
+			di->trackspercylinder = 1;
+			di->sectorspertrack = di->toc.lastaddress;
+		}
 		ciw->changed = false;
 	}
 	di->removable = ciw->type == DRIVE_CDROM ? 1 : 0;

--- a/src/osdep/blkdev_ioctl.cpp
+++ b/src/osdep/blkdev_ioctl.cpp
@@ -2171,12 +2171,11 @@ static int ioctl_command_toc2(int unitnum, struct cd_toc_head* tocout, bool hide
 
 	// Read the leadout entry to get lastaddress
 	tocentry.cdte_track = CDROM_LEADOUT;
-	tocentry.cdte_format = CDROM_MSF;
+	tocentry.cdte_format = CDROM_LBA;
 	if (ioctl(ciw->fd, CDROMREADTOCENTRY, &tocentry) == -1) {
 		return 0;
 	}
-	th->lastaddress = msf2lsn((tocentry.cdte_addr.msf.minute << 16) | (tocentry.cdte_addr.msf.second << 8) |
-		(tocentry.cdte_addr.msf.frame << 0));
+	th->lastaddress = tocentry.cdte_addr.lba;
 
 	t->adr = 1;
 	t->point = 0xa0;
@@ -2186,14 +2185,13 @@ static int ioctl_command_toc2(int unitnum, struct cd_toc_head* tocout, bool hide
 	th->first_track_offset = 1;
 	for (i = th->first_track; i <= th->last_track; i++) {
 		tocentry.cdte_track = i;
-		tocentry.cdte_format = CDROM_MSF;
+		tocentry.cdte_format = CDROM_LBA;
 		if (ioctl(ciw->fd, CDROMREADTOCENTRY, &tocentry) == -1) {
 			return 0;
 		}
 		t->adr = tocentry.cdte_adr;
 		t->control = tocentry.cdte_ctrl;
-		t->paddress = msf2lsn((tocentry.cdte_addr.msf.minute << 16) | (tocentry.cdte_addr.msf.second << 8) |
-			(tocentry.cdte_addr.msf.frame << 0));
+		t->paddress = tocentry.cdte_addr.lba;
 		t->point = t->track = i;
 		t++;
 	}


### PR DESCRIPTION
## Summary

- clear cached physical-disc geometry whenever device information is refreshed
- derive the logical block count from a successfully read TOC
- report the correct last LBA through emulated `READ CAPACITY(10)`

## Root cause

The non-Windows IOCTL backend detected inserted media and populated the sector size and TOC, but left `cylinders`, `trackspercylinder`, and `sectorspertrack` at zero. The shared SCSI emulation calculates the last LBA from those fields, so physical discs were reported as `0xFFFFFFFF` blocks after unsigned underflow.

This particularly affects filesystems that validate or use the reported medium capacity while mounting data DVDs.

## Impact

Physical optical media now exposes capacity matching the TOC lead-out. Geometry is also cleared before refresh so removed media cannot retain the previous disc's capacity.

This change intentionally does not alter native SCSI passthrough or physical media-change notifications.

## Validation

- configured a fresh Linux Debug build with `USE_IPC_SOCKET=ON`
- compiled the changed Linux IOCTL object
- completed a full Linux build and link with `--no-undefined`
- ran the resulting binary with `--dump-paths`

Addresses #2219