### PR TITLE
Clarify resolution autoswitch and KMSDRM Play mode

### DIFF
--- a/src/osdep/imgui/display.cpp
+++ b/src/osdep/imgui/display.cpp
@@ -406,7 +406,10 @@ void render_panel_display() {
         ImGui::EndCombo();
     }
     AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
-    ShowHelpMarker("Automatically switch resolution based on Amiga display mode. Percentage values control sensitivity threshold");
+    ShowHelpMarker("Automatically adjust Amiberry's internal render resolution and line mode to match the Amiga screen. "
+        "This does not change the host display resolution or refresh rate. Always On follows the highest resolution "
+        "present in each frame. Percentage values require the dominant resolution to cover at least that share of "
+        "the frame; lower percentages switch more readily.");
 
     ImGui::Spacing();
 

--- a/src/osdep/imgui/play.cpp
+++ b/src/osdep/imgui/play.cpp
@@ -9,6 +9,7 @@
 
 #include "file_dialog.h"
 #include "filesys.h"
+#include "amiberry_gfx.h"
 #include "amiberry_rp9.h"
 #include "gui/gui_handling.h"
 #include "imgui_panels.h"
@@ -768,11 +769,21 @@ void render_display_defaults()
 	static const char* scaling_items[] = { "Auto", "Integer", "Smooth" };
 	static const char* shader_items[] = { "None", "CRT", "1084", "Custom" };
 
+	if (kmsdrm_detected)
+		display_defaults.screen_mode = PlayScreenMode::FullWindow;
+
 	int screen_mode = static_cast<int>(display_defaults.screen_mode);
+	if (kmsdrm_detected)
+		ImGui::BeginDisabled();
 	if (render_combo("Screen mode:", &screen_mode, screen_items, IM_ARRAYSIZE(screen_items))) {
 		display_defaults.screen_mode = static_cast<PlayScreenMode>(screen_mode);
 		apply_display_defaults_to_changed_prefs();
 	}
+	if (kmsdrm_detected)
+		ImGui::EndDisabled();
+	ShowHelpMarker(kmsdrm_detected
+		? "KMSDRM always uses the active console display in Full-window mode."
+		: "Run the emulation in a desktop window or a borderless Full-window.");
 
 	int scaling = static_cast<int>(display_defaults.scaling);
 	if (render_combo("Scaling:", &scaling, scaling_items, IM_ARRAYSIZE(scaling_items))) {


### PR DESCRIPTION
## Summary

- clarify that Resolution Autoswitch changes Amiberry's internal render resolution and line mode, not the host display mode or refresh rate
- show Full-window and disable the Play screen-mode selector when KMSDRM is active
- explain the forced KMSDRM mode in the Play tooltip

## Why

KMSDRM always runs against the active console display in Full-window mode, but the Play panel still exposed Windowed and Full-window choices. The Resolution Autoswitch tooltip also did not clearly distinguish Amiga rendering resolution from the host display resolution.

## Validation

- `cmake --build out/build/windows-debug --parallel 12`
- `tests/test_play_setup.sh`
- `git diff --check`

Refs #2178
