### PR TITLE
Fix ZZ9000 combined complement draw modes

### DIFF
--- a/src/zz9000.cpp
+++ b/src/zz9000.cpp
@@ -628,7 +628,7 @@ static void zz_template_rect(zz9000_state *data, uae_u32 source, uae_u32 source_
 			if (draw_mode & 4)
 				set = !set;
 			const int base_mode = draw_mode & 3;
-			if (base_mode == 2) {
+			if (base_mode & COMP) {
 				if (set) {
 					uae_u8 *pixel;
 					if (zz_pixel_address(data, destination, destination_pitch,


### PR DESCRIPTION
## Summary

- detect `COMPLEMENT` as a draw-mode bit in the ZZ9000 template/pattern renderer
- make `JAM2 | COMPLEMENT` match `JAM1 | COMPLEMENT`, including `INVERSVID`

## Root cause

The emulation masked the draw mode to its two low bits but only entered the complement path when the result was exactly `2`. Combined `JAM2 | COMPLEMENT` modes produce `3`, so they incorrectly fell through to pen-based rendering instead of inverting destination pixels under set pattern bits.

## Impact

ZZ9000 `BltPattern()` modes 3 and 7 now follow Picasso96 and ZZ9000 firmware semantics. The shared helper also handles the corresponding `BltTemplate()` combinations consistently for both Zorro II and Zorro III emulation.

## Validation

- Windows debug build: `cmake --build out/build/windows-debug --parallel 12`
- focused classification check across all eight draw modes
- `git diff --check`

The external `p96cts` guest scene was not available for an end-to-end local run.

Fixes #2217