### PR TITLE
Honor runtime controller selections on reconnect

### DIFF
--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -169,6 +169,7 @@ void amiberry_preserve_port_joystick_custom_mapping(const int portnum,
 		return;
 
 	if (preserved.valid && matches_joystick_config(preserved.idc, name, configname)) {
+		preserved.mapping = did.mapping;
 		if (!preserved.has_identity) {
 			preserved.identity = get_joystick_identity(did);
 			preserved.has_identity = true;

--- a/src/osdep/imgui/custom.cpp
+++ b/src/osdep/imgui/custom.cpp
@@ -44,6 +44,14 @@ static int get_mapped_event_index(int event_id)
 	return 0;
 }
 
+static void commit_custom_mapping_change(const int portnum, const didata* did)
+{
+	const auto& port = changed_prefs.jports[portnum];
+	amiberry_set_port_joystick_custom_mapping(
+		portnum, port.idc.name, port.idc.configname, did->mapping);
+	inputdevice_updateconfig(nullptr, &changed_prefs);
+}
+
 void render_panel_custom()
 {
 	ImGui::Indent(4.0f);
@@ -118,7 +126,7 @@ void render_panel_custom()
 	ImGui::SameLine();
 	if (AmigaButton("X")) {
 		did->mapping.hotkey_button = SDL_GAMEPAD_BUTTON_INVALID;
-		inputdevice_updateconfig(nullptr, &changed_prefs);
+		commit_custom_mapping_change(SelectedPort, did);
 	}
 	if (did->mapping.is_retroarch) ImGui::EndDisabled();
 	
@@ -136,7 +144,7 @@ void render_panel_custom()
 			for (int i = 0; i < SDL_GAMEPAD_BUTTON_COUNT; ++i) {
 				if (SDL_GetGamepadButton(did->controller, static_cast<SDL_GamepadButton>(i))) {
 					did->mapping.hotkey_button = i;
-					inputdevice_updateconfig(nullptr, &changed_prefs);
+					commit_custom_mapping_change(SelectedPort, did);
 					ImGui::CloseCurrentPopup();
 					break;
 				}
@@ -146,7 +154,7 @@ void render_panel_custom()
 			for (int i = 0; i < num_buttons; ++i) {
 				if (SDL_GetJoystickButton(did->joystick, i)) {
 					did->mapping.hotkey_button = i;
-					inputdevice_updateconfig(nullptr, &changed_prefs);
+					commit_custom_mapping_change(SelectedPort, did);
 					ImGui::CloseCurrentPopup();
 					break;
 				}
@@ -244,7 +252,7 @@ void render_panel_custom()
 			else if (VectorCombo("##btn", &idx, custom_event_items)) {
 				int new_evt = (idx == 0) ? -1 : remap_event_list[idx - 1];
 				*store_ptr = new_evt;
-				inputdevice_updateconfig(nullptr, &changed_prefs);
+				commit_custom_mapping_change(SelectedPort, did);
 			}
 
 			if (!is_mapped || in_use) ImGui::EndDisabled();
@@ -269,7 +277,7 @@ void render_panel_custom()
 			if (VectorCombo("##axis", &idx, custom_event_items)) {
 				int new_evt = (idx == 0) ? -1 : remap_event_list[idx - 1];
 				*store_ptr = new_evt;
-				inputdevice_updateconfig(nullptr, &changed_prefs);
+				commit_custom_mapping_change(SelectedPort, did);
 			}
 			if (!is_mapped) ImGui::EndDisabled();
 			ImGui::PopID();
@@ -307,7 +315,7 @@ void render_panel_custom()
 			else if (VectorCombo("##btn", &idx, custom_event_items)) {
 				int new_evt = (idx == 0) ? -1 : remap_event_list[idx - 1];
 				*store_ptr = new_evt;
-				inputdevice_updateconfig(nullptr, &changed_prefs);
+				commit_custom_mapping_change(SelectedPort, did);
 			}
 
 			if (!is_mapped || in_use) ImGui::EndDisabled();
@@ -332,7 +340,7 @@ void render_panel_custom()
 			if (VectorCombo("##axis", &idx, custom_event_items)) {
 				int new_evt = (idx == 0) ? -1 : remap_event_list[idx - 1];
 				*store_ptr = new_evt;
-				inputdevice_updateconfig(nullptr, &changed_prefs);
+				commit_custom_mapping_change(SelectedPort, did);
 			}
 			if (!is_mapped) ImGui::EndDisabled();
 			ImGui::PopID();

--- a/src/osdep/imgui/input.cpp
+++ b/src/osdep/imgui/input.cpp
@@ -116,6 +116,11 @@ static void set_port_input_device(const int port_idx, const int selected_idx)
 	amiberry_clear_port_joystick_custom_mapping(port_idx);
 	inputdevice_forget_unplugged_device(port_idx);
 	inputdevice_validate_jports(&changed_prefs, port_idx, nullptr);
+	const auto& selected_port = changed_prefs.jports[port_idx];
+	if (selected_port.id >= JSEM_JOYS && selected_port.id < JSEM_MICE) {
+		amiberry_preserve_port_joystick_custom_mapping(
+			port_idx, selected_port.idc.name, selected_port.idc.configname);
+	}
 }
 
 const std::vector<InputDeviceOption>& get_input_device_options()

--- a/tests/test_input_hotplug.sh
+++ b/tests/test_input_hotplug.sh
@@ -112,12 +112,18 @@ port_selection = region_between(
 	"static void set_port_input_device(",
 	"const std::vector<InputDeviceOption>& get_input_device_options()",
 )
-if "amiberry_clear_port_joystick_custom_mapping(port_idx);" not in port_selection:
+clear_selected = port_selection.find("amiberry_clear_port_joystick_custom_mapping(port_idx);")
+forget_selected = port_selection.find("inputdevice_forget_unplugged_device(port_idx);")
+validate_selected = port_selection.find("inputdevice_validate_jports(&changed_prefs, port_idx, nullptr);")
+preserve_selected = port_selection.find("amiberry_preserve_port_joystick_custom_mapping(")
+if clear_selected < 0:
 	fail("Explicit port changes must discard the old controller mapping snapshot")
-if "inputdevice_forget_unplugged_device(port_idx);" not in port_selection:
+if forget_selected < 0:
 	fail("Explicit port changes must cancel pending reconnection of the old controller")
-if "inputdevice_validate_jports(&changed_prefs, port_idx, nullptr);" not in port_selection:
+if validate_selected < 0:
 	fail("Explicit port changes must refresh or clear saved device identity metadata")
+if not (clear_selected < forget_selected < validate_selected < preserve_selected):
+	fail("An explicit joystick choice must replace the old reconnect target with its validated physical identity")
 if input_panel.count("set_port_input_device(port_idx, selected_idx);") != 2:
 	fail("Primary and parallel port selectors must share the identity-safe update path")
 if "const int joy_index = amiberry_get_joystick_index(jp->idc.configname);" not in amiberry_input:

--- a/tests/test_input_hotplug.sh
+++ b/tests/test_input_hotplug.sh
@@ -31,6 +31,7 @@ amiberry_input = Path("src/osdep/amiberry_input.cpp").read_text()
 cfgfile = Path("src/cfgfile.cpp").read_text()
 inputdevice = Path("src/inputdevice.cpp").read_text()
 input_panel = Path("src/osdep/imgui/input.cpp").read_text()
+custom_panel = Path("src/osdep/imgui/custom.cpp").read_text()
 
 
 def fail(message: str) -> None:
@@ -126,6 +127,25 @@ if not (clear_selected < forget_selected < validate_selected < preserve_selected
 	fail("An explicit joystick choice must replace the old reconnect target with its validated physical identity")
 if input_panel.count("set_port_input_device(port_idx, selected_idx);") != 2:
 	fail("Primary and parallel port selectors must share the identity-safe update path")
+mapping_commit = region_between(
+	custom_panel,
+	"static void commit_custom_mapping_change(",
+	"void render_panel_custom()",
+)
+snapshot_update = mapping_commit.find("amiberry_set_port_joystick_custom_mapping(")
+runtime_update = mapping_commit.find("inputdevice_updateconfig(nullptr, &changed_prefs);")
+if not (0 <= snapshot_update < runtime_update):
+	fail("Custom mapping edits must update the per-port snapshot before rebuilding live input")
+if custom_panel.count("commit_custom_mapping_change(SelectedPort, did);") != 7:
+	fail("Every Custom-panel mapping mutation must refresh the selected port snapshot")
+preserve_mapping = region_between(
+	amiberry_input,
+	"void amiberry_preserve_port_joystick_custom_mapping(",
+	"void amiberry_clear_port_joystick_custom_mapping(",
+)
+if """if (preserved.valid && matches_joystick_config(preserved.idc, name, configname)) {
+		preserved.mapping = did.mapping;""" not in preserve_mapping:
+	fail("Hotplug preservation must refresh an existing snapshot from the live mapping")
 if "const int joy_index = amiberry_get_joystick_index(jp->idc.configname);" not in amiberry_input:
 	fail("Custom mapping loads must use the same bounded joystick index parser as saves")
 if """if (!amiberry_get_port_joystick_custom_mapping(


### PR DESCRIPTION
## Summary
- capture the mapping and physical identity of a controller immediately when it is selected in the Input panel
- replace the controller loaded from the configuration as the runtime reconnect target
- add regression coverage for the selection handoff ordering

## Testing
- `bash tests/test_input_hotplug.sh`
- `cmake --build out\build\windows-debug --parallel`

Follow-up to the runtime-selection feedback in #2221.