### PR TITLE
Fix KMSDRM GUI resume page-flip handoff

### DIFF
--- a/src/osdep/amiberry_platform_internal_host.h
+++ b/src/osdep/amiberry_platform_internal_host.h
@@ -30,6 +30,18 @@ static inline bool osdep_platform_init_sdl()
 		return false;
 	}
 
+	// KMSDRM's default triple-buffer path returns from SDL_GL_SwapWindow()
+	// with a DRM page flip still pending. The GUI and emulation share the same
+	// window/context, so keep presentation fully drained across that handoff.
+	// KMSDRM reads this hint when the first window is created, after video init.
+	const char* video_driver = SDL_GetCurrentVideoDriver();
+	if (video_driver && SDL_strcasecmp(video_driver, "kmsdrm") == 0) {
+		if (SDL_SetHintWithPriority(SDL_HINT_VIDEO_DOUBLE_BUFFER, "1", SDL_HINT_OVERRIDE))
+			write_log("KMSDRM: enabled double-buffered presentation for safe GUI transitions\n");
+		else
+			write_log("KMSDRM: failed to enable double-buffered presentation: %s\n", SDL_GetError());
+	}
+
 	// Enable native IME for international text input
 	SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "1");
 


### PR DESCRIPTION
## Summary

- enable SDL's double-buffered presentation path when KMSDRM is the active video driver
- ensure DRM page flips are drained before the shared GUI/emulation window changes owners
- log whether the KMSDRM safety hint was applied

## Root cause

The earlier swap-interval fix prevented asynchronous KMSDRM flips, but it did not remove the pending flip at the GUI-to-emulation handoff.

In SDL 3.2.10's default triple-buffered KMSDRM path, `SDL_GL_SwapWindow()` waits for the previous page flip, queues the next one, and returns while that new flip is still pending. Amiberry uses the same window and OpenGL context for ImGui and emulation under KMSDRM. Resuming emulation can therefore enter SDL's unbounded page-flip wait with state carried over from the final GUI frame, freezing presentation and main-thread input processing.

`SDL_HINT_VIDEO_DOUBLE_BUFFER` makes SDL wait for each submitted flip before returning. SDL 3.2.x applies this in the legacy KMSDRM swap path, while SDL 3.4.x uses it to select the blocking double-buffered atomic path.

Fixes #2179

## Validation

- `git diff --check`
- `cmake --build out/build/windows-debug --parallel 12`
- `wsl -e bash -lc "cd /mnt/d/Github/amiberry && cmake --build out/build/issue-2219-linux --parallel 12"`

Runtime verification on Raspberry Pi KMSDRM hardware remains pending.
