### PR TITLE
Fix KMSDRM full-speed GUI handoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ docs/superpowers
 .omg
 .claude/settings.local.json
 .compound-engineering/*.local.yaml
+docs/plans

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -2503,6 +2503,15 @@ void drawing_init(void)
 // of std::atomic<float>, with enough precision for a ~1 Hz match tolerance.
 static std::atomic<uint32_t> hw_vsync_cached_monitor_hz_x1000{0};
 
+// Published by the active renderer only after it has successfully configured
+// a presentation mode that blocks for vblank.
+static std::atomic<bool> hw_vsync_cached_presentation_blocking{false};
+
+void amiberry_hw_vsync_pacing_set_blocking(const bool blocking)
+{
+	hw_vsync_cached_presentation_blocking.store(blocking, std::memory_order_relaxed);
+}
+
 // Invoked on the SDL main thread in response to display / window events
 // (window migrated to another display, display mode changed) and once at
 // graphics_init() time. Re-probes SDL and caches the active display's
@@ -2534,8 +2543,8 @@ void amiberry_hw_vsync_pacing_invalidate(void)
 // vulkan_renderer.cpp), so hardware pacing is disabled there unconditionally.
 //
 // This runs on the emulator thread (via isvsync_chipset() → framewait()).
-// It does NOT call any SDL video APIs: it only reads the cached monitor Hz
-// published by amiberry_hw_vsync_pacing_invalidate() on the main thread.
+// It does NOT call any SDL video APIs: it only reads the cached monitor Hz and
+// blocking-presentation capability published by the presentation thread.
 static bool amiberry_hw_vsync_pacing_ok(void)
 {
 #ifdef USE_VULKAN
@@ -2547,6 +2556,8 @@ static bool amiberry_hw_vsync_pacing_ok(void)
 	if (kmsdrm_detected)
 		return false;
 #endif
+	if (!hw_vsync_cached_presentation_blocking.load(std::memory_order_relaxed))
+		return false;
 	if (vblank_hz <= 0.0f)
 		return false;
 	const uint32_t hz_x1000 = hw_vsync_cached_monitor_hz_x1000.load(std::memory_order_relaxed);
@@ -2560,6 +2571,7 @@ static bool amiberry_hw_vsync_pacing_ok(void)
 // Libretro stub: declaration is visible via xwin.h's AMIBERRY block, so
 // provide an empty body here so callers link without the full pacing logic.
 void amiberry_hw_vsync_pacing_invalidate(void) {}
+void amiberry_hw_vsync_pacing_set_blocking(const bool) {}
 #endif
 
 int isvsync_chipset(void)

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -2541,12 +2541,6 @@ static bool amiberry_hw_vsync_pacing_ok(void)
 #ifdef USE_VULKAN
 	return false;
 #else
-	// KMSDRM is forced to full-window mode and cannot switch the host refresh
-	// to follow chipset changes. It also cannot reliably disable swap blocking.
-	// Keep emulation on software timing instead of changing pacing paths when
-	// the Amiga and console refresh rates happen to match.
-	if (kmsdrm_detected)
-		return false;
 	if (vblank_hz <= 0.0f)
 		return false;
 	const uint32_t hz_x1000 = hw_vsync_cached_monitor_hz_x1000.load(std::memory_order_relaxed);
@@ -2565,7 +2559,18 @@ void amiberry_hw_vsync_pacing_invalidate(void) {}
 int isvsync_chipset(void)
 {
 	struct amigadisplay *ad = &adisplays[0];
-	if (ad->picasso_on || currprefs.gfx_apmode[0].gfx_vsync <= 0)
+	if (ad->picasso_on)
+		return 0;
+#ifdef AMIBERRY
+#ifndef LIBRETRO
+	// KMSDRM always uses swap interval 1 and double-buffered presentation, so
+	// a matched console refresh provides hardware pacing even when VSync is
+	// disabled in the emulation settings.
+	if (kmsdrm_detected && amiberry_hw_vsync_pacing_ok())
+		return 1;
+#endif
+#endif
+	if (currprefs.gfx_apmode[0].gfx_vsync <= 0)
 		return 0;
 #ifdef AMIBERRY
 #ifndef LIBRETRO

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -2550,12 +2550,6 @@ static bool amiberry_hw_vsync_pacing_ok(void)
 #ifdef USE_VULKAN
 	return false;
 #else
-#ifndef USE_OPENGL
-	// SDL_RenderPresent() does not guarantee blocking presentation. Keep
-	// KMSDRM SDL-renderer builds on software timing even at matched refresh.
-	if (kmsdrm_detected)
-		return false;
-#endif
 	if (!hw_vsync_cached_presentation_blocking.load(std::memory_order_relaxed))
 		return false;
 	if (vblank_hz <= 0.0f)
@@ -2580,10 +2574,9 @@ int isvsync_chipset(void)
 	if (ad->picasso_on)
 		return 0;
 #if defined(AMIBERRY) && !defined(LIBRETRO) && defined(USE_OPENGL) && !defined(USE_VULKAN)
-	// KMSDRM OpenGL/GLES always uses swap interval 1 and double-buffered
-	// presentation, so a matched console refresh provides hardware pacing even
-	// when VSync is disabled in the emulation settings. This exception must stay
-	// on the blocking OpenGL path; SDL_RenderPresent() has no such guarantee.
+	// KMSDRM OpenGL/GLES publishes blocking presentation only on the SDL 3.4+
+	// interval-1 path. A matching console refresh can therefore provide
+	// hardware pacing even when VSync is disabled in the emulation settings.
 	if (kmsdrm_detected && amiberry_hw_vsync_pacing_ok())
 		return 1;
 #endif

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -2541,6 +2541,12 @@ static bool amiberry_hw_vsync_pacing_ok(void)
 #ifdef USE_VULKAN
 	return false;
 #else
+#ifndef USE_OPENGL
+	// SDL_RenderPresent() does not guarantee blocking presentation. Keep
+	// KMSDRM SDL-renderer builds on software timing even at matched refresh.
+	if (kmsdrm_detected)
+		return false;
+#endif
 	if (vblank_hz <= 0.0f)
 		return false;
 	const uint32_t hz_x1000 = hw_vsync_cached_monitor_hz_x1000.load(std::memory_order_relaxed);
@@ -2561,14 +2567,13 @@ int isvsync_chipset(void)
 	struct amigadisplay *ad = &adisplays[0];
 	if (ad->picasso_on)
 		return 0;
-#ifdef AMIBERRY
-#ifndef LIBRETRO
-	// KMSDRM always uses swap interval 1 and double-buffered presentation, so
-	// a matched console refresh provides hardware pacing even when VSync is
-	// disabled in the emulation settings.
+#if defined(AMIBERRY) && !defined(LIBRETRO) && defined(USE_OPENGL) && !defined(USE_VULKAN)
+	// KMSDRM OpenGL/GLES always uses swap interval 1 and double-buffered
+	// presentation, so a matched console refresh provides hardware pacing even
+	// when VSync is disabled in the emulation settings. This exception must stay
+	// on the blocking OpenGL path; SDL_RenderPresent() has no such guarantee.
 	if (kmsdrm_detected && amiberry_hw_vsync_pacing_ok())
 		return 1;
-#endif
 #endif
 	if (currprefs.gfx_apmode[0].gfx_vsync <= 0)
 		return 0;

--- a/src/include/xwin.h
+++ b/src/include/xwin.h
@@ -59,6 +59,10 @@ extern float amiberry_get_refreshrate_for_display_id(uint32_t display_id);
 // Forces the hardware VSync pacing cache to re-probe on the next call. Called
 // from the SDL event loop on display mode / window-display changes.
 extern void amiberry_hw_vsync_pacing_invalidate(void);
+
+// Publishes whether the active renderer has successfully configured blocking
+// presentation. Called on the presentation thread and read by frame pacing.
+extern void amiberry_hw_vsync_pacing_set_blocking(bool blocking);
 #endif
 
 extern void flush_line(struct vidbuffer*, int);

--- a/src/osdep/amiberry_platform_internal_host.h
+++ b/src/osdep/amiberry_platform_internal_host.h
@@ -30,6 +30,18 @@ static inline bool osdep_platform_init_sdl()
 		return false;
 	}
 
+	// KMSDRM's default triple-buffer path returns from SDL_GL_SwapWindow()
+	// with a DRM page flip still pending. The GUI and emulation share the same
+	// window/context, so keep presentation fully drained across that handoff.
+	// KMSDRM reads this hint when the first window is created, after video init.
+	const char* video_driver = SDL_GetCurrentVideoDriver();
+	if (video_driver && SDL_strcasecmp(video_driver, "kmsdrm") == 0) {
+		if (SDL_SetHintWithPriority(SDL_HINT_VIDEO_DOUBLE_BUFFER, "1", SDL_HINT_OVERRIDE))
+			write_log("KMSDRM: enabled double-buffered presentation for safe GUI transitions\n");
+		else
+			write_log("KMSDRM: failed to enable double-buffered presentation: %s\n", SDL_GetError());
+	}
+
 	// Enable native IME for international text input
 	SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "1");
 

--- a/src/osdep/amiberry_platform_internal_host.h
+++ b/src/osdep/amiberry_platform_internal_host.h
@@ -30,18 +30,6 @@ static inline bool osdep_platform_init_sdl()
 		return false;
 	}
 
-	// KMSDRM's default triple-buffer path returns from SDL_GL_SwapWindow()
-	// with a DRM page flip still pending. The GUI and emulation share the same
-	// window/context, so keep presentation fully drained across that handoff.
-	// KMSDRM reads this hint when the first window is created, after video init.
-	const char* video_driver = SDL_GetCurrentVideoDriver();
-	if (video_driver && SDL_strcasecmp(video_driver, "kmsdrm") == 0) {
-		if (SDL_SetHintWithPriority(SDL_HINT_VIDEO_DOUBLE_BUFFER, "1", SDL_HINT_OVERRIDE))
-			write_log("KMSDRM: enabled double-buffered presentation for safe GUI transitions\n");
-		else
-			write_log("KMSDRM: failed to enable double-buffered presentation: %s\n", SDL_GetError());
-	}
-
 	// Enable native IME for international text input
 	SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "1");
 

--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -2973,36 +2973,38 @@ void run_gui()
 
 		// Rendering
 		ImGui::Render();
+		if (gui_running || !kmsdrm_detected) {
 #ifdef USE_VULKAN
-		if (gui_use_vulkan) {
-			auto* vk = get_vulkan_renderer();
-			if (vk) {
-				vk->render_gui_frame(ImGui::GetDrawData());
-			}
-		} else
+			if (gui_use_vulkan) {
+				auto* vk = get_vulkan_renderer();
+				if (vk) {
+					vk->render_gui_frame(ImGui::GetDrawData());
+				}
+			} else
 #endif
 #ifdef USE_OPENGL
-		if (gui_use_opengl) {
-			const ImGuiIO& gl_io = ImGui::GetIO();
-			glViewport(0, 0,
-				(int)(gl_io.DisplaySize.x * gl_io.DisplayFramebufferScale.x),
-				(int)(gl_io.DisplaySize.y * gl_io.DisplayFramebufferScale.y));
-			glClearColor(0.45f, 0.55f, 0.60f, 1.00f);
-			glClear(GL_COLOR_BUFFER_BIT);
-			ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-			SDL_GL_SwapWindow(mon->gui_window);
-		} else
+			if (gui_use_opengl) {
+				const ImGuiIO& gl_io = ImGui::GetIO();
+				glViewport(0, 0,
+					(int)(gl_io.DisplaySize.x * gl_io.DisplayFramebufferScale.x),
+					(int)(gl_io.DisplaySize.y * gl_io.DisplayFramebufferScale.y));
+				glClearColor(0.45f, 0.55f, 0.60f, 1.00f);
+				glClear(GL_COLOR_BUFFER_BIT);
+				ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+				SDL_GL_SwapWindow(mon->gui_window);
+			} else
 #endif
-		{
-			const ImGuiIO& render_io = ImGui::GetIO();
-			const float render_scale_x = kmsdrm_detected ? 1.0f : render_io.DisplayFramebufferScale.x;
-			const float render_scale_y = kmsdrm_detected ? 1.0f : render_io.DisplayFramebufferScale.y;
-			SDL_SetRenderScale(mon->gui_renderer, render_scale_x, render_scale_y);
-			SDL_SetRenderDrawColor(mon->gui_renderer, static_cast<uint8_t>(0.45f * 255), static_cast<uint8_t>(0.55f * 255),
-							   static_cast<uint8_t>(0.60f * 255), static_cast<uint8_t>(1.00f * 255));
-			SDL_RenderClear(mon->gui_renderer);
-			ImGui_ImplSDLRenderer3_RenderDrawData(ImGui::GetDrawData(), mon->gui_renderer);
-			SDL_RenderPresent(mon->gui_renderer);
+			{
+				const ImGuiIO& render_io = ImGui::GetIO();
+				const float render_scale_x = kmsdrm_detected ? 1.0f : render_io.DisplayFramebufferScale.x;
+				const float render_scale_y = kmsdrm_detected ? 1.0f : render_io.DisplayFramebufferScale.y;
+				SDL_SetRenderScale(mon->gui_renderer, render_scale_x, render_scale_y);
+				SDL_SetRenderDrawColor(mon->gui_renderer, static_cast<uint8_t>(0.45f * 255), static_cast<uint8_t>(0.55f * 255),
+								   static_cast<uint8_t>(0.60f * 255), static_cast<uint8_t>(1.00f * 255));
+				SDL_RenderClear(mon->gui_renderer);
+				ImGui_ImplSDLRenderer3_RenderDrawData(ImGui::GetDrawData(), mon->gui_renderer);
+				SDL_RenderPresent(mon->gui_renderer);
+			}
 		}
 	}
 

--- a/src/osdep/imgui/display.cpp
+++ b/src/osdep/imgui/display.cpp
@@ -78,7 +78,7 @@ void render_panel_display() {
     if (kmsdrm) {
         ImGui::TextDisabled("KMSDRM uses the active console display mode");
         ImGui::SameLine();
-        ShowHelpMarker("Host resolution and refresh rate are controlled by the console configuration. Amiberry uses console Full-window mode with software emulation pacing and vblank-paced presentation.");
+        ShowHelpMarker("Host resolution and refresh rate are controlled by the console configuration. Amiberry uses console Full-window mode; blocking OpenGL/GLES with matching console and emulated refresh uses hardware/vblank pacing, otherwise software timing is used.");
         ImGui::Spacing();
     }
 
@@ -199,7 +199,7 @@ void render_panel_display() {
     if (kmsdrm) ImGui::EndDisabled();
     AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
     ShowHelpMarker(kmsdrm
-        ? "KMSDRM uses software emulation timing and vblank-paced presentation; VSync off, refresh switching, and Adaptive/VRR modes are not available"
+        ? "Blocking OpenGL/GLES with matching console and emulated refresh uses hardware/vblank pacing; otherwise KMSDRM uses software timing. VSync controls, refresh switching, and Adaptive/VRR modes are not available"
         : "VSync mode: Standard waits for vertical blank, 50/60Hz enforces refresh rate, Adaptive uses VRR (FreeSync/G-SYNC) with late-swap tearing fallback");
 
     ImGui::Spacing();

--- a/src/osdep/imgui/display.cpp
+++ b/src/osdep/imgui/display.cpp
@@ -199,7 +199,7 @@ void render_panel_display() {
     if (kmsdrm) ImGui::EndDisabled();
     AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
     ShowHelpMarker(kmsdrm
-        ? "Blocking OpenGL/GLES with matching console and emulated refresh uses hardware/vblank pacing; otherwise KMSDRM uses software timing. VSync controls, refresh switching, and Adaptive/VRR modes are not available"
+        ? "Legacy KMSDRM uses software timing with drained presentation; blocking presentation is used for pacing only when console and emulated refresh match. VSync controls, refresh switching, and Adaptive/VRR modes are not available"
         : "VSync mode: Standard waits for vertical blank, 50/60Hz enforces refresh rate, Adaptive uses VRR (FreeSync/G-SYNC) with late-swap tearing fallback");
 
     ImGui::Spacing();
@@ -268,7 +268,7 @@ void render_panel_display() {
     if (kmsdrm) ImGui::EndDisabled();
     AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
     ShowHelpMarker(kmsdrm
-        ? "KMSDRM uses software emulation timing and vblank-paced presentation"
+        ? "KMSDRM presentation timing depends on the SDL driver path; RTG remains software-paced"
         : "VSync mode for RTG display");
     if (!rtg_enabled) ImGui::EndDisabled();
 

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -398,14 +398,14 @@ void OpenGLRenderer::update_vsync(int monid)
 		}
 	}
 
-	// KMSDRM only accepts intervals 0 and 1, cannot reliably provide
-	// unsynchronised swaps, and has no Adaptive/VRR presentation mode. Its
-	// legacy path maps interval 0 to asynchronous DRM page flips, while atomic
-	// paths may remain vblank-paced regardless. Avoid the async path: a pending
-	// flip can otherwise leave SDL_GL_SwapWindow() waiting indefinitely across
-	// the shared-window GUI handoff. Emulation pacing is handled separately.
+	// KMSDRM has no Adaptive/VRR presentation mode. SDL 3.2.x maps interval 0
+	// to an asynchronous DRM page flip; combined with the double-buffer hint,
+	// SDL immediately drains that flip without waiting for vblank. SDL 3.4+
+	// changed its double-buffer path to a blocking atomic commit, so retain
+	// interval 1 there and let matched-refresh hardware pacing account for it.
+	// Mismatched-refresh atomic presentation needs a separate scheduler.
 	if (kmsdrm_detected) {
-		interval = 1;
+		interval = SDL_GetVersion() < SDL_VERSIONNUM(3, 4, 0) ? 0 : 1;
 	}
 
 	if (m_vsync.current_interval != interval) {

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -102,6 +102,7 @@ static void resolve_gl_pixel_format(uint32_t sdl_pixel_format, GLenum& fmt, GLen
 bool OpenGLRenderer::init_context(SDL_Window* window)
 {
 	write_log("DEBUG: Initializing OpenGL Context...\n");
+	amiberry_hw_vsync_pacing_set_blocking(false);
 
 	m_gl_context = SDL_GL_CreateContext(window);
 	if (!m_gl_context) {
@@ -153,6 +154,7 @@ bool OpenGLRenderer::init_context(SDL_Window* window)
 
 void OpenGLRenderer::destroy_context()
 {
+	amiberry_hw_vsync_pacing_set_blocking(false);
 	if (m_gl_context != nullptr)
 	{
 		SDL_GL_DestroyContext(m_gl_context);
@@ -361,7 +363,10 @@ void OpenGLRenderer::set_scaling(int monid, const uae_prefs* p, int w, int h)
 
 void OpenGLRenderer::update_vsync(int monid)
 {
-	if (!AMonitors[monid].amiga_window) return;
+	if (!AMonitors[monid].amiga_window) {
+		amiberry_hw_vsync_pacing_set_blocking(false);
+		return;
+	}
 
 	const AmigaMonitor* mon = &AMonitors[monid];
 	const auto idx = mon->screen_is_picasso ? APMODE_RTG : APMODE_NATIVE;
@@ -405,6 +410,10 @@ void OpenGLRenderer::update_vsync(int monid)
 
 	if (m_vsync.current_interval != interval) {
 		const int requested_interval = interval;
+		// Do not retain a stale blocking capability while changing the active
+		// presentation policy. Publish true only after a positive interval is
+		// applied successfully.
+		amiberry_hw_vsync_pacing_set_blocking(false);
 		if (interval == ADAPTIVE_SWAP_INTERVAL) {
 			if (!SDL_GL_SetSwapInterval(ADAPTIVE_SWAP_INTERVAL)) {
 				const std::string adaptive_error = SDL_GetError();
@@ -419,6 +428,7 @@ void OpenGLRenderer::update_vsync(int monid)
 				write_log("OpenGL VSync: Adaptive VSync enabled\n");
 			}
 		} else if (SDL_GL_SetSwapInterval(interval)) {
+			amiberry_hw_vsync_pacing_set_blocking(interval > 0);
 			write_log("OpenGL VSync: Mode %d, Interval set to %d\n", vsync_mode, interval);
 		} else {
 			write_log("OpenGL VSync: Failed to set interval %d: %s (will not retry)\n", interval, SDL_GetError());
@@ -1285,6 +1295,7 @@ void OpenGLRenderer::restore_emulation_context(SDL_Window* window)
 		SDL_GL_MakeCurrent(window, m_gl_context);
 		reset_state();
 		m_vsync.current_interval = INVALID_SWAP_INTERVAL;
+		amiberry_hw_vsync_pacing_set_blocking(false);
 	}
 }
 

--- a/tests/test_kmsdrm_gui_handoff.sh
+++ b/tests/test_kmsdrm_gui_handoff.sh
@@ -142,13 +142,15 @@ fi
 if ! awk '
 	/void OpenGLRenderer::update_vsync\(int monid\)/ { in_update_vsync = 1 }
 	in_update_vsync && /if \(kmsdrm_detected\) \{/ { in_kmsdrm_policy = 1 }
-	in_kmsdrm_policy && /interval = 1;/ { interval_one = 1 }
+	in_kmsdrm_policy && /interval = SDL_GetVersion\(\) < SDL_VERSIONNUM\(3, 4, 0\) \? 0 : 1;/ {
+		versioned_interval = 1
+	}
 	in_kmsdrm_policy && /^	}/ {
-		exit interval_one ? 0 : 1
+		exit versioned_interval ? 0 : 1
 	}
 	END { if (!in_update_vsync) exit 1 }
 ' "$opengl_renderer_file"; then
-	echo "KMSDRM must continue to force OpenGL swap interval 1" >&2
+	echo "KMSDRM must use interval 0 for SDL 3.2.x and retain interval 1 for SDL 3.4+" >&2
 	exit 1
 fi
 
@@ -202,25 +204,6 @@ if ! awk '
 	END { if (!in_update_vsync) exit 1 }
 ' "$opengl_renderer_file"; then
 	echo "OpenGL pacing capability must be false for failure/nonblocking/adaptive requests and true only after a positive interval succeeds" >&2
-	exit 1
-fi
-
-if ! awk '
-	/static bool amiberry_hw_vsync_pacing_ok\(void\)/ { in_pacing_policy = 1 }
-	in_pacing_policy && /#ifndef USE_OPENGL/ { in_sdl_only_policy = 1 }
-	in_sdl_only_policy && /if \(kmsdrm_detected\)/ {
-		kmsdrm_sdl_only = 1
-		next
-	}
-	kmsdrm_sdl_only && /return false;/ {
-		sdl_software_pacing = 1
-		next
-	}
-	in_sdl_only_policy && /#endif/ { exit sdl_software_pacing ? 0 : 1 }
-	in_pacing_policy && /^}/ { exit 1 }
-	END { if (!in_pacing_policy) exit 1 }
-' "$drawing_file"; then
-	echo "SDL-only KMSDRM builds must stay on software pacing" >&2
 	exit 1
 fi
 
@@ -299,10 +282,10 @@ for lifecycle_function in init_context destroy_context; do
 	fi
 done
 
-if ! grep -F -q 'Blocking OpenGL/GLES with matching console and emulated refresh uses hardware/vblank pacing' "$display_panel_file" ||
-	! grep -F -q 'otherwise KMSDRM uses software timing' "$display_panel_file" ||
+if ! grep -F -q 'Legacy KMSDRM uses software timing with drained presentation' "$display_panel_file" ||
+	! grep -F -q 'blocking presentation is used for pacing only when console and emulated refresh match' "$display_panel_file" ||
 	! grep -F -q 'VSync controls, refresh switching, and Adaptive/VRR modes are not available' "$display_panel_file"; then
-	echo "KMSDRM help must describe matched-refresh hardware pacing, software fallback, and unavailable controls" >&2
+	echo "KMSDRM help must describe legacy software pacing, matched-refresh hardware pacing, and unavailable controls" >&2
 	exit 1
 fi
 

--- a/tests/test_kmsdrm_gui_handoff.sh
+++ b/tests/test_kmsdrm_gui_handoff.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file="src/osdep/gui/main_window.cpp"
+platform_init_file="src/osdep/amiberry_platform_internal_host.h"
+gfx_window_file="src/osdep/gfx_window.cpp"
+opengl_renderer_file="src/osdep/opengl_renderer.cpp"
+drawing_file="src/drawing.cpp"
+gui_lifecycle_file="src/osdep/amiberry_gui.cpp"
+handoff_guard='if (gui_running || !kmsdrm_detected) {'
+
+handoff_guard_count=$(grep -F -c "$handoff_guard" "$source_file" || true)
+if [ "$handoff_guard_count" -ne 1 ]; then
+	echo "GUI backend dispatch must use one late KMSDRM handoff guard" >&2
+	exit 1
+fi
+
+if ! awk '
+	/void run_gui\(\)/ { in_run_gui = 1 }
+	in_run_gui && /\/\/ Rendering/ { in_render_boundary = 1 }
+	in_render_boundary && /ImGui::Render\(\);/ {
+		imgui_rendered = 1
+		next
+	}
+	in_render_boundary && /if \(gui_running \|\| !kmsdrm_detected\) \{/ {
+		if (!imgui_rendered || guard_seen)
+			exit 1
+		guard_seen = 1
+		guard_depth = depth
+	}
+	in_render_boundary {
+		line = $0
+		opens = gsub(/\{/, "", line)
+		line = $0
+		closes = gsub(/\}/, "", line)
+
+		if (/vk->render_gui_frame\(ImGui::GetDrawData\(\)\)/ ||
+			/glViewport\(0, 0,/ ||
+			/glClearColor\(0.45f, 0.55f, 0.60f, 1.00f\)/ ||
+			/glClear\(GL_COLOR_BUFFER_BIT\)/ ||
+			/ImGui_ImplOpenGL3_RenderDrawData\(ImGui::GetDrawData\(\)\)/ ||
+			/SDL_GL_SwapWindow\(mon->gui_window\)/ ||
+			/SDL_SetRenderScale\(mon->gui_renderer, render_scale_x, render_scale_y\)/ ||
+			/SDL_SetRenderDrawColor\(mon->gui_renderer,/ ||
+			/SDL_RenderClear\(mon->gui_renderer\)/ ||
+			/ImGui_ImplSDLRenderer3_RenderDrawData\(ImGui::GetDrawData\(\), mon->gui_renderer\)/ ||
+			/SDL_RenderPresent\(mon->gui_renderer\)/) {
+			if (!guard_seen || guard_closed || depth <= guard_depth)
+				exit 1
+			backend_dispatches++
+		}
+
+		depth += opens - closes
+		if (guard_seen && !guard_closed && depth == guard_depth)
+			guard_closed = 1
+	}
+	in_run_gui && /amiberry_gui_halt\(\);/ {
+		exit imgui_rendered && guard_seen && guard_closed && backend_dispatches == 11 ? 0 : 1
+	}
+	END {
+		if (!in_run_gui)
+			exit 1
+	}
+' "$source_file"; then
+	echo "ImGui frame completion must remain unconditional and the late guard must enclose every GUI backend dispatch" >&2
+	exit 1
+fi
+
+if ! awk '
+	/void run_gui\(\)/ { in_run_gui = 1 }
+	in_run_gui && /if \(gui_running \|\| !kmsdrm_detected\) \{/ { guard_seen = 1 }
+	in_run_gui && /gui_running = false;/ {
+		exit_routes++
+		if (guard_seen)
+			exit 1
+	}
+	in_run_gui && /amiberry_gui_halt\(\);/ {
+		exit exit_routes > 0 && guard_seen ? 0 : 1
+	}
+' "$source_file"; then
+	echo "GUI exit routes must converge on the single guard after all exit decisions" >&2
+	exit 1
+fi
+
+if ! awk '
+	/void gui_restart\(\)/ { in_restart = 1 }
+	in_restart && /gui_running = false;/ { restart_clears_gui = 1 }
+	in_restart && /^}/ { exit restart_clears_gui ? 0 : 1 }
+	END { if (!in_restart) exit 1 }
+' "$source_file"; then
+	echo "External GUI restart must continue to converge through gui_running" >&2
+	exit 1
+fi
+
+dispatch_eligible()
+{
+	local gui_is_running=$1
+	local kmsdrm_is_active=$2
+
+	if (( gui_is_running || ! kmsdrm_is_active )); then
+		echo 1
+	else
+		echo 0
+	fi
+}
+
+if [ "$(dispatch_eligible 0 1)" -ne 0 ]; then
+	echo "Terminal KMSDRM frames must skip GUI backend dispatch" >&2
+	exit 1
+fi
+
+if [ "$(dispatch_eligible 1 1)" -ne 1 ]; then
+	echo "Active KMSDRM GUI frames must remain eligible for backend dispatch" >&2
+	exit 1
+fi
+
+if [ "$(dispatch_eligible 0 0)" -ne 1 ]; then
+	echo "Non-KMSDRM terminal GUI frames must remain eligible for backend dispatch" >&2
+	exit 1
+fi
+
+if grep -E -q 'SDL_(SetHint|SetHintWithPriority)\([^;]*SDL_HINT_VIDEO_DOUBLE_BUFFER' "$platform_init_file"; then
+	echo "Amiberry must not force SDL_HINT_VIDEO_DOUBLE_BUFFER" >&2
+	exit 1
+fi
+
+if ! awk '
+	/void OpenGLRenderer::update_vsync\(int monid\)/ { in_update_vsync = 1 }
+	in_update_vsync && /if \(kmsdrm_detected\) \{/ { in_kmsdrm_policy = 1 }
+	in_kmsdrm_policy && /interval = 1;/ { interval_one = 1 }
+	in_kmsdrm_policy && /^	}/ {
+		exit interval_one ? 0 : 1
+	}
+	END { if (!in_update_vsync) exit 1 }
+' "$opengl_renderer_file"; then
+	echo "KMSDRM must continue to force OpenGL swap interval 1" >&2
+	exit 1
+fi
+
+if ! awk '
+	/static bool amiberry_hw_vsync_pacing_ok\(void\)/ { in_pacing_policy = 1 }
+	in_pacing_policy && /if \(kmsdrm_detected\)/ {
+		kmsdrm_policy = 1
+		next
+	}
+	kmsdrm_policy && /return false;/ { exit 0 }
+	in_pacing_policy && /^}/ { exit 1 }
+	END { if (!in_pacing_policy) exit 1 }
+' "$drawing_file"; then
+	echo "KMSDRM must continue to use software emulation pacing" >&2
+	exit 1
+fi
+
+if ! grep -F -q 'success &= SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);' "$gfx_window_file"; then
+	echo "The OpenGL context must continue to request double buffering" >&2
+	exit 1
+fi
+
+if ! awk '
+	/void amiberry_gui_halt\(\)/ { in_gui_halt = 1 }
+	in_gui_halt && /gl_renderer->restore_emulation_context\(mon->amiga_window\);/ {
+		context_restored = 1
+	}
+	in_gui_halt && /^}/ { exit context_restored ? 0 : 1 }
+	END { if (!in_gui_halt) exit 1 }
+' "$source_file"; then
+	echo "GUI teardown must continue to restore the emulation context" >&2
+	exit 1
+fi
+
+if ! awk '
+	/void OpenGLRenderer::restore_emulation_context\(SDL_Window\* window\)/ { in_restore = 1 }
+	in_restore && /SDL_GL_MakeCurrent\(window, m_gl_context\);/ { context_current = 1 }
+	in_restore && /m_vsync.current_interval = INVALID_SWAP_INTERVAL;/ { interval_invalidated = 1 }
+	in_restore && /^}/ { exit context_current && interval_invalidated ? 0 : 1 }
+	END { if (!in_restore) exit 1 }
+' "$opengl_renderer_file"; then
+	echo "OpenGL context restoration must continue to make the emulation context current and refresh its swap interval" >&2
+	exit 1
+fi
+
+if ! awk '
+	/void gui_display\(int shortcut\)/ { in_gui_display = 1 }
+	in_gui_display && /if \(no_wm_detected && amiga_surface != nullptr\)/ {
+		in_shared_window_refresh = 1
+		next
+	}
+	in_shared_window_refresh && /target_graphics_buffer_update\(mon->monitor_id, true\);/ {
+		forced_refresh = 1
+	}
+	in_shared_window_refresh && /^	}/ { exit forced_refresh ? 0 : 1 }
+	in_gui_display && /^}/ { exit 1 }
+	END { if (!in_gui_display) exit 1 }
+' "$gui_lifecycle_file"; then
+	echo "Shared-window GUI resume must continue to force a graphics-buffer refresh" >&2
+	exit 1
+fi

--- a/tests/test_kmsdrm_gui_handoff.sh
+++ b/tests/test_kmsdrm_gui_handoff.sh
@@ -6,6 +6,8 @@ platform_init_file="src/osdep/amiberry_platform_internal_host.h"
 gfx_window_file="src/osdep/gfx_window.cpp"
 opengl_renderer_file="src/osdep/opengl_renderer.cpp"
 drawing_file="src/drawing.cpp"
+xwin_file="src/include/xwin.h"
+display_panel_file="src/osdep/imgui/display.cpp"
 gui_lifecycle_file="src/osdep/amiberry_gui.cpp"
 handoff_guard='if (gui_running || !kmsdrm_detected) {'
 
@@ -150,6 +152,59 @@ if ! awk '
 	exit 1
 fi
 
+if ! grep -F -q 'static std::atomic<bool> hw_vsync_cached_presentation_blocking{false};' "$drawing_file" ||
+	! grep -F -q 'hw_vsync_cached_presentation_blocking.store(blocking, std::memory_order_relaxed);' "$drawing_file" ||
+	! grep -F -q 'extern void amiberry_hw_vsync_pacing_set_blocking(bool blocking);' "$xwin_file" ||
+	! grep -F -q 'void amiberry_hw_vsync_pacing_set_blocking(const bool) {}' "$drawing_file"; then
+	echo "Hardware pacing must expose an atomic blocking-presentation capability with a Libretro stub" >&2
+	exit 1
+fi
+
+if ! awk '
+	/static bool amiberry_hw_vsync_pacing_ok\(void\)/ { in_pacing_policy = 1 }
+	in_pacing_policy && /if \(!hw_vsync_cached_presentation_blocking.load\(std::memory_order_relaxed\)\)/ {
+		blocking_gate = 1
+		next
+	}
+	blocking_gate && /return false;/ { exit 0 }
+	in_pacing_policy && /^}/ { exit 1 }
+	END { if (!in_pacing_policy) exit 1 }
+' "$drawing_file"; then
+	echo "Hardware pacing must require the cached blocking-presentation capability" >&2
+	exit 1
+fi
+
+if ! awk '
+	/void OpenGLRenderer::update_vsync\(int monid\)/ { in_update_vsync = 1 }
+	in_update_vsync && /if \(m_vsync.current_interval != interval\) \{/ { changing_interval = 1 }
+	changing_interval && /amiberry_hw_vsync_pacing_set_blocking\(false\);/ {
+		cleared_before_attempt = 1
+		next
+	}
+	changing_interval && /if \(interval == ADAPTIVE_SWAP_INTERVAL\)/ {
+		if (!cleared_before_attempt)
+			exit 1
+		adaptive_request = 1
+		next
+	}
+	changing_interval && /else if \(SDL_GL_SetSwapInterval\(interval\)\)/ {
+		nonadaptive_success = 1
+		next
+	}
+	nonadaptive_success && /amiberry_hw_vsync_pacing_set_blocking\(interval > 0\);/ {
+		positive_success_published = 1
+		next
+	}
+	in_update_vsync && /m_vsync.current_interval = requested_interval;/ {
+		exit cleared_before_attempt && adaptive_request && positive_success_published ? 0 : 1
+	}
+	in_update_vsync && /^}/ { exit 1 }
+	END { if (!in_update_vsync) exit 1 }
+' "$opengl_renderer_file"; then
+	echo "OpenGL pacing capability must be false for failure/nonblocking/adaptive requests and true only after a positive interval succeeds" >&2
+	exit 1
+fi
+
 if ! awk '
 	/static bool amiberry_hw_vsync_pacing_ok\(void\)/ { in_pacing_policy = 1 }
 	in_pacing_policy && /#ifndef USE_OPENGL/ { in_sdl_only_policy = 1 }
@@ -224,10 +279,30 @@ if ! awk '
 	/void OpenGLRenderer::restore_emulation_context\(SDL_Window\* window\)/ { in_restore = 1 }
 	in_restore && /SDL_GL_MakeCurrent\(window, m_gl_context\);/ { context_current = 1 }
 	in_restore && /m_vsync.current_interval = INVALID_SWAP_INTERVAL;/ { interval_invalidated = 1 }
-	in_restore && /^}/ { exit context_current && interval_invalidated ? 0 : 1 }
+	in_restore && /amiberry_hw_vsync_pacing_set_blocking\(false\);/ { blocking_cleared = 1 }
+	in_restore && /^}/ { exit context_current && interval_invalidated && blocking_cleared ? 0 : 1 }
 	END { if (!in_restore) exit 1 }
 ' "$opengl_renderer_file"; then
-	echo "OpenGL context restoration must continue to make the emulation context current and refresh its swap interval" >&2
+	echo "OpenGL context restoration must make the context current and invalidate both swap interval and blocking capability" >&2
+	exit 1
+fi
+
+for lifecycle_function in init_context destroy_context; do
+	if ! awk -v function_name="$lifecycle_function" '
+		$0 ~ "OpenGLRenderer::" function_name "\\(" { in_lifecycle = 1 }
+		in_lifecycle && /amiberry_hw_vsync_pacing_set_blocking\(false\);/ { exit 0 }
+		in_lifecycle && /^}/ { exit 1 }
+		END { if (!in_lifecycle) exit 1 }
+	' "$opengl_renderer_file"; then
+		echo "OpenGL $lifecycle_function must clear the blocking-presentation capability" >&2
+		exit 1
+	fi
+done
+
+if ! grep -F -q 'Blocking OpenGL/GLES with matching console and emulated refresh uses hardware/vblank pacing' "$display_panel_file" ||
+	! grep -F -q 'otherwise KMSDRM uses software timing' "$display_panel_file" ||
+	! grep -F -q 'VSync controls, refresh switching, and Adaptive/VRR modes are not available' "$display_panel_file"; then
+	echo "KMSDRM help must describe matched-refresh hardware pacing, software fallback, and unavailable controls" >&2
 	exit 1
 fi
 

--- a/tests/test_kmsdrm_gui_handoff.sh
+++ b/tests/test_kmsdrm_gui_handoff.sh
@@ -150,20 +150,35 @@ if ! awk '
 	exit 1
 fi
 
-if awk '
+if ! awk '
 	/static bool amiberry_hw_vsync_pacing_ok\(void\)/ { in_pacing_policy = 1 }
-	in_pacing_policy && /if \(kmsdrm_detected\)/ { kmsdrm_branch = 1 }
-	kmsdrm_branch && /return false;/ { exit 0 }
+	in_pacing_policy && /#ifndef USE_OPENGL/ { in_sdl_only_policy = 1 }
+	in_sdl_only_policy && /if \(kmsdrm_detected\)/ {
+		kmsdrm_sdl_only = 1
+		next
+	}
+	kmsdrm_sdl_only && /return false;/ {
+		sdl_software_pacing = 1
+		next
+	}
+	in_sdl_only_policy && /#endif/ { exit sdl_software_pacing ? 0 : 1 }
 	in_pacing_policy && /^}/ { exit 1 }
 	END { if (!in_pacing_policy) exit 1 }
 ' "$drawing_file"; then
-	echo "Matched-refresh KMSDRM must not be excluded from hardware pacing" >&2
+	echo "SDL-only KMSDRM builds must stay on software pacing" >&2
 	exit 1
 fi
 
 if ! awk '
 	/int isvsync_chipset\(void\)/ { in_chipset_policy = 1 }
+	in_chipset_policy && /#if defined\(AMIBERRY\) && !defined\(LIBRETRO\) && defined\(USE_OPENGL\) && !defined\(USE_VULKAN\)/ {
+		in_blocking_gl_policy = 1
+		gl_guard_seen = 1
+		next
+	}
 	in_chipset_policy && /if \(kmsdrm_detected && amiberry_hw_vsync_pacing_ok\(\)\)/ {
+		if (!in_blocking_gl_policy)
+			exit 1
 		kmsdrm_match = 1
 		next
 	}
@@ -171,13 +186,20 @@ if ! awk '
 		kmsdrm_hardware_pacing = 1
 		next
 	}
+	in_blocking_gl_policy && /#endif/ {
+		if (!kmsdrm_hardware_pacing)
+			exit 1
+		in_blocking_gl_policy = 0
+		gl_guard_closed = 1
+		next
+	}
 	in_chipset_policy && /if \(currprefs.gfx_apmode\[0\]\.gfx_vsync <= 0\)/ {
-		exit kmsdrm_hardware_pacing ? 0 : 1
+		exit gl_guard_seen && gl_guard_closed ? 0 : 1
 	}
 	in_chipset_policy && /^}/ { exit 1 }
 	END { if (!in_chipset_policy) exit 1 }
 ' "$drawing_file"; then
-	echo "Matched-refresh KMSDRM must select hardware pacing before the user VSync early return" >&2
+	echo "Matched-refresh KMSDRM hardware pacing must be limited to OpenGL/GLES before the user VSync early return" >&2
 	exit 1
 fi
 

--- a/tests/test_kmsdrm_gui_handoff.sh
+++ b/tests/test_kmsdrm_gui_handoff.sh
@@ -119,8 +119,21 @@ if [ "$(dispatch_eligible 0 0)" -ne 1 ]; then
 	exit 1
 fi
 
-if grep -E -q 'SDL_(SetHint|SetHintWithPriority)\([^;]*SDL_HINT_VIDEO_DOUBLE_BUFFER' "$platform_init_file"; then
-	echo "Amiberry must not force SDL_HINT_VIDEO_DOUBLE_BUFFER" >&2
+if ! awk '
+	/static inline bool osdep_platform_init_sdl\(\)/ { in_init = 1 }
+	in_init && /SDL_GetCurrentVideoDriver\(\)/ { driver_queried = 1 }
+	in_init && /SDL_strcasecmp\(video_driver, "kmsdrm"\) == 0/ {
+		if (!driver_queried)
+			exit 1
+		in_kmsdrm_policy = 1
+	}
+	in_kmsdrm_policy && /SDL_SetHintWithPriority\(SDL_HINT_VIDEO_DOUBLE_BUFFER, "1", SDL_HINT_OVERRIDE\)/ {
+		double_buffer_forced = 1
+	}
+	in_init && /return true;/ { exit double_buffer_forced ? 0 : 1 }
+	END { if (!in_init) exit 1 }
+' "$platform_init_file"; then
+	echo "KMSDRM must force double-buffered presentation so submitted page flips drain before handoff" >&2
 	exit 1
 fi
 
@@ -137,17 +150,34 @@ if ! awk '
 	exit 1
 fi
 
-if ! awk '
+if awk '
 	/static bool amiberry_hw_vsync_pacing_ok\(void\)/ { in_pacing_policy = 1 }
-	in_pacing_policy && /if \(kmsdrm_detected\)/ {
-		kmsdrm_policy = 1
-		next
-	}
-	kmsdrm_policy && /return false;/ { exit 0 }
+	in_pacing_policy && /if \(kmsdrm_detected\)/ { kmsdrm_branch = 1 }
+	kmsdrm_branch && /return false;/ { exit 0 }
 	in_pacing_policy && /^}/ { exit 1 }
 	END { if (!in_pacing_policy) exit 1 }
 ' "$drawing_file"; then
-	echo "KMSDRM must continue to use software emulation pacing" >&2
+	echo "Matched-refresh KMSDRM must not be excluded from hardware pacing" >&2
+	exit 1
+fi
+
+if ! awk '
+	/int isvsync_chipset\(void\)/ { in_chipset_policy = 1 }
+	in_chipset_policy && /if \(kmsdrm_detected && amiberry_hw_vsync_pacing_ok\(\)\)/ {
+		kmsdrm_match = 1
+		next
+	}
+	kmsdrm_match && /return 1;/ {
+		kmsdrm_hardware_pacing = 1
+		next
+	}
+	in_chipset_policy && /if \(currprefs.gfx_apmode\[0\]\.gfx_vsync <= 0\)/ {
+		exit kmsdrm_hardware_pacing ? 0 : 1
+	}
+	in_chipset_policy && /^}/ { exit 1 }
+	END { if (!in_chipset_policy) exit 1 }
+' "$drawing_file"; then
+	echo "Matched-refresh KMSDRM must select hardware pacing before the user VSync early return" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary

On Raspberry Pi 4 with SDL 3.2.10 and KMSDRM, PAL games on a 59 Hz console mode fell to about 30 FPS: Amiberry first software-paced the frame to 50 Hz, then blocked for another display vblank during presentation. This PR restores the expected 50 FPS while retaining reliable GUI/emulation handoff by using SDL 3.2's interval-0 asynchronous flip with the existing immediate page-flip drain.

SDL 3.4+ retains its existing blocking presentation policy; mismatched-refresh atomic scheduling remains follow-up work for the broader KMSDRM optimization phase. The PR also prevents a redundant terminal GUI frame from being submitted after a KMSDRM exit decision and keeps hardware pacing gated on a confirmed blocking presentation path.

Related: #2179

## Performance context

| Raspberry Pi 4 PAL observation | FPS | Presentation time |
| --- | ---: | ---: |
| Before forced double-buffer draining | 49.2-49.9 | 0.80-1.66 ms |
| SDL 3.2.10 interval 1 plus software pacing | 29.7-30.6 | 16.18-19.59 ms |
| This PR: SDL 3.2.10 interval 0 plus immediate drain | 49.1-49.9 (49.63 average) | 2.40-3.74 ms |

## Validation

- `bash -n tests/test_kmsdrm_gui_handoff.sh`
- `bash tests/test_kmsdrm_gui_handoff.sh`
- WSL Debian Debug/OpenGL build
- WSL Debian Release/GLES build
- WSL Debian Release/SDL-renderer-only build (`USE_OPENGL=OFF`)
- Raspberry Pi 4, Raspberry Pi OS 64-bit Trixie, KMSDRM, SDL 3.2.10: Battle Squadron held the expected 50 FPS; the log confirmed interval 0 and 2.40-3.74 ms presentation
- Repeated F12 GUI/resume round-trips completed without issues on Raspberry Pi 4
- Focused correctness, project-standards, testing, and performance review; the SDL 3.4+ fallback finding was resolved by preserving the existing drained path
- All GitHub Actions build and analysis targets passed

Local planning artifacts remain ignored and are not part of the PR.
