### PR TITLE
perf(rpi4): restore SDL 3.2 KMSDRM throughput

### DIFF
--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -121,6 +121,7 @@ static int draw_line_next_line, draw_line_wclks;
 static uae_u32 rga_denise_cycle_line = 1;
 static struct pipeline_reg preg;
 static struct pipeline_func pfunc[MAX_PIPELINE_REG];
+static int pfunc_active_count;
 static uae_u16 prev_strobe;
 static bool vb_fast;
 static uae_u32 custom_state_flags;
@@ -164,6 +165,7 @@ static void pipelined_custom_write(evfunc2 func, uae_u16 v, uae_u16 cck)
 			p->func = func;
 			p->v = v;
 			p->cck = cck;
+			pfunc_active_count++;
 			return;
 		}
 	}
@@ -171,6 +173,9 @@ static void pipelined_custom_write(evfunc2 func, uae_u16 v, uae_u16 cck)
 }
 static void handle_pipelined_custom_write(bool now)
 {
+	if (!pfunc_active_count) {
+		return;
+	}
 	for (int i = 0 ; i < MAX_PIPELINE_REG; i++) {
 		struct pipeline_func *p = &pfunc[i];
 		if (p->func) {
@@ -178,6 +183,7 @@ static void handle_pipelined_custom_write(bool now)
 			if (!p->cck || now) {
 				auto f = p->func;
 				p->func = NULL;
+				pfunc_active_count--;
 				f(p->v);
 			}
 		}
@@ -6661,6 +6667,7 @@ void custom_reset(bool hardreset, bool keyboardreset)
 		struct pipeline_func *p = &pfunc[i];
 		memset(p, 0, sizeof(struct pipeline_func));
 	}
+	pfunc_active_count = 0;
 	rga_denise_cycle = 0;
 	rga_denise_cycle_start = 0;
 	rga_denise_cycle_count_end = 0;

--- a/src/osdep/amiberry_platform_internal_host.h
+++ b/src/osdep/amiberry_platform_internal_host.h
@@ -30,16 +30,20 @@ static inline bool osdep_platform_init_sdl()
 		return false;
 	}
 
-	// KMSDRM's default triple-buffer path returns from SDL_GL_SwapWindow()
-	// with a DRM page flip still pending. The GUI and emulation share the same
-	// window/context, so keep presentation fully drained across that handoff.
-	// KMSDRM reads this hint when the first window is created, after video init.
+	// SDL 3.2.x KMSDRM's default triple-buffer path leaves interval-0 page flips
+	// asynchronous, avoiding the immediate drain imposed by the double-buffer
+	// hint. Keep that lower-latency path; the shared-window terminal guard avoids
+	// submitting another GUI flip after the exit decision.
+	// SDL 3.4+ uses the hint for its existing blocking atomic presentation path.
 	const char* video_driver = SDL_GetCurrentVideoDriver();
 	if (video_driver && SDL_strcasecmp(video_driver, "kmsdrm") == 0) {
-		if (SDL_SetHintWithPriority(SDL_HINT_VIDEO_DOUBLE_BUFFER, "1", SDL_HINT_OVERRIDE))
-			write_log("KMSDRM: enabled double-buffered presentation for safe GUI transitions\n");
-		else
+		if (SDL_GetVersion() < SDL_VERSIONNUM(3, 4, 0)) {
+			write_log("KMSDRM: using SDL 3.2.x default triple-buffered presentation\n");
+		} else if (SDL_SetHintWithPriority(SDL_HINT_VIDEO_DOUBLE_BUFFER, "1", SDL_HINT_OVERRIDE)) {
+			write_log("KMSDRM: enabled double-buffered blocking atomic presentation\n");
+		} else {
 			write_log("KMSDRM: failed to enable double-buffered presentation: %s\n", SDL_GetError());
+		}
 	}
 
 	// Enable native IME for international text input

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -399,10 +399,10 @@ void OpenGLRenderer::update_vsync(int monid)
 	}
 
 	// KMSDRM has no Adaptive/VRR presentation mode. SDL 3.2.x maps interval 0
-	// to an asynchronous DRM page flip; combined with the double-buffer hint,
-	// SDL immediately drains that flip without waiting for vblank. SDL 3.4+
-	// changed its double-buffer path to a blocking atomic commit, so retain
-	// interval 1 there and let matched-refresh hardware pacing account for it.
+	// to an asynchronous DRM page flip and retains its default triple-buffered
+	// path, with software timing pacing the emulator. SDL 3.4+ retains the
+	// double-buffered blocking atomic path, so use interval 1 there and let
+	// matched-refresh hardware pacing account for it.
 	// Mismatched-refresh atomic presentation needs a separate scheduler.
 	if (kmsdrm_detected) {
 		interval = SDL_GetVersion() < SDL_VERSIONNUM(3, 4, 0) ? 0 : 1;

--- a/tests/test_kmsdrm_gui_handoff.sh
+++ b/tests/test_kmsdrm_gui_handoff.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 source_file="src/osdep/gui/main_window.cpp"
+platform_init_file="src/osdep/amiberry_platform_internal_host.h"
 gfx_window_file="src/osdep/gfx_window.cpp"
 opengl_renderer_file="src/osdep/opengl_renderer.cpp"
 drawing_file="src/drawing.cpp"
@@ -121,12 +122,50 @@ if [ "$(dispatch_eligible 0 0)" -ne 1 ]; then
 fi
 
 if ! awk '
+	/static inline bool osdep_platform_init_sdl\(\)/ { in_init = 1 }
+	in_init && /SDL_GetCurrentVideoDriver\(\)/ { driver_queried = 1 }
+	in_init && /SDL_strcasecmp\(video_driver, "kmsdrm"\) == 0/ {
+		if (!driver_queried)
+			exit 1
+		in_kmsdrm_policy = 1
+	}
+	in_kmsdrm_policy && /^[[:space:]]*if \(SDL_GetVersion\(\) < SDL_VERSIONNUM\(3, 4, 0\)\) \{/ {
+		in_sdl32_policy = 1
+		next
+	}
+	in_sdl32_policy && /using SDL 3.2.x default triple-buffered presentation/ {
+		sdl32_default_triple_buffer = 1
+		next
+	}
+	in_sdl32_policy && /^[[:space:]]*} else if \(SDL_SetHintWithPriority\(SDL_HINT_VIDEO_DOUBLE_BUFFER, "1", SDL_HINT_OVERRIDE\)\) \{/ {
+		if (!sdl32_default_triple_buffer)
+			exit 1
+		sdl34_double_buffer_hint = 1
+		in_sdl32_policy = 0
+		next
+	}
+	in_kmsdrm_policy && /SDL_SetHintWithPriority\(SDL_HINT_VIDEO_DOUBLE_BUFFER/ { exit 1 }
+	in_init && /return true;/ {
+		exit sdl32_default_triple_buffer && sdl34_double_buffer_hint ? 0 : 1
+	}
+	END { if (!in_init) exit 1 }
+' "$platform_init_file"; then
+	echo "KMSDRM must keep SDL 3.2.x on the default triple-buffered path and enable the double-buffer hint only for SDL 3.4+" >&2
+	exit 1
+fi
+
+if ! awk '
 	/void OpenGLRenderer::update_vsync\(int monid\)/ { in_update_vsync = 1 }
-	in_update_vsync && /if \(kmsdrm_detected\) \{/ { exit 0 }
-	in_update_vsync && /^}/ { exit 1 }
+	in_update_vsync && /if \(kmsdrm_detected\) \{/ { in_kmsdrm_policy = 1 }
+	in_kmsdrm_policy && /interval = SDL_GetVersion\(\) < SDL_VERSIONNUM\(3, 4, 0\) \? 0 : 1;/ {
+		versioned_interval = 1
+	}
+	in_kmsdrm_policy && /^	}/ {
+		exit versioned_interval ? 0 : 1
+	}
 	END { if (!in_update_vsync) exit 1 }
 ' "$opengl_renderer_file"; then
-	echo "OpenGL VSync must retain an explicit KMSDRM presentation policy" >&2
+	echo "OpenGL KMSDRM must use interval 0 for SDL 3.2.x and interval 1 for SDL 3.4+" >&2
 	exit 1
 fi
 

--- a/tests/test_kmsdrm_gui_handoff.sh
+++ b/tests/test_kmsdrm_gui_handoff.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 source_file="src/osdep/gui/main_window.cpp"
-platform_init_file="src/osdep/amiberry_platform_internal_host.h"
 gfx_window_file="src/osdep/gfx_window.cpp"
 opengl_renderer_file="src/osdep/opengl_renderer.cpp"
 drawing_file="src/drawing.cpp"
@@ -122,37 +121,26 @@ if [ "$(dispatch_eligible 0 0)" -ne 1 ]; then
 fi
 
 if ! awk '
-	/static inline bool osdep_platform_init_sdl\(\)/ { in_init = 1 }
-	in_init && /SDL_GetCurrentVideoDriver\(\)/ { driver_queried = 1 }
-	in_init && /SDL_strcasecmp\(video_driver, "kmsdrm"\) == 0/ {
-		if (!driver_queried)
-			exit 1
-		in_kmsdrm_policy = 1
-	}
-	in_kmsdrm_policy && /SDL_SetHintWithPriority\(SDL_HINT_VIDEO_DOUBLE_BUFFER, "1", SDL_HINT_OVERRIDE\)/ {
-		double_buffer_forced = 1
-	}
-	in_init && /return true;/ { exit double_buffer_forced ? 0 : 1 }
-	END { if (!in_init) exit 1 }
-' "$platform_init_file"; then
-	echo "KMSDRM must force double-buffered presentation so submitted page flips drain before handoff" >&2
+	/void OpenGLRenderer::update_vsync\(int monid\)/ { in_update_vsync = 1 }
+	in_update_vsync && /if \(kmsdrm_detected\) \{/ { exit 0 }
+	in_update_vsync && /^}/ { exit 1 }
+	END { if (!in_update_vsync) exit 1 }
+' "$opengl_renderer_file"; then
+	echo "OpenGL VSync must retain an explicit KMSDRM presentation policy" >&2
 	exit 1
 fi
 
-if ! awk '
-	/void OpenGLRenderer::update_vsync\(int monid\)/ { in_update_vsync = 1 }
-	in_update_vsync && /if \(kmsdrm_detected\) \{/ { in_kmsdrm_policy = 1 }
-	in_kmsdrm_policy && /interval = SDL_GetVersion\(\) < SDL_VERSIONNUM\(3, 4, 0\) \? 0 : 1;/ {
-		versioned_interval = 1
-	}
-	in_kmsdrm_policy && /^	}/ {
-		exit versioned_interval ? 0 : 1
-	}
-	END { if (!in_update_vsync) exit 1 }
-' "$opengl_renderer_file"; then
-	echo "KMSDRM must use interval 0 for SDL 3.2.x and retain interval 1 for SDL 3.4+" >&2
-	exit 1
-fi
+for lifecycle_function in prepare_gui_sharing restore_emulation_context; do
+	if ! awk -v function_name="$lifecycle_function" '
+		$0 ~ "OpenGLRenderer::" function_name "\\(" { in_lifecycle = 1; function_seen = 1 }
+		in_lifecycle && /(glFinish|SDL_SyncWindow|SDL_GL_SwapWindow|drmHandleEvent|SDL_Delay)/ { exit 1 }
+		in_lifecycle && /^}/ { exit 0 }
+		END { if (!function_seen) exit 1 }
+	' "$opengl_renderer_file"; then
+		echo "OpenGL $lifecycle_function must not add a guessed or competing presentation-completion barrier" >&2
+		exit 1
+	fi
+done
 
 if ! grep -F -q 'static std::atomic<bool> hw_vsync_cached_presentation_blocking{false};' "$drawing_file" ||
 	! grep -F -q 'hw_vsync_cached_presentation_blocking.store(blocking, std::memory_order_relaxed);' "$drawing_file" ||
@@ -282,7 +270,7 @@ for lifecycle_function in init_context destroy_context; do
 	fi
 done
 
-if ! grep -F -q 'Legacy KMSDRM uses software timing with drained presentation' "$display_panel_file" ||
+if ! grep -F -q 'Legacy KMSDRM uses software timing' "$display_panel_file" ||
 	! grep -F -q 'blocking presentation is used for pacing only when console and emulated refresh match' "$display_panel_file" ||
 	! grep -F -q 'VSync controls, refresh switching, and Adaptive/VRR modes are not available' "$display_panel_file"; then
 	echo "KMSDRM help must describe legacy software pacing, matched-refresh hardware pacing, and unavailable controls" >&2


### PR DESCRIPTION
## Summary

Raspberry Pi 4 console users on Debian Trixie's SDL 3.2.10 no longer pay for an immediate KMSDRM page-flip drain on every frame. Battle Squadron recovers from the reported 30 FPS regression to full-speed PAL, while the more demanding Jim Power A1200 title sequence also gains measurable CPU-side headroom without reducing emulation accuracy.

SDL 3.2 keeps its lower-latency triple-buffered, interval-0 path; SDL 3.4+ retains the existing blocking atomic policy. The shared-window terminal guard remains responsible for safe GUI handoff. The exact-cycle hot loop now also skips its delayed custom-register callback scan when no callback is pending, while preserving callback order, delay, overflow, restore, and reset behavior.

## Performance

| RPi4 workload | Before | After | Result |
|---|---:|---:|---|
| Battle Squadron, PAL | 30 FPS | 50 FPS | Full speed restored |
| Jim Power A1200, full-session mean | 36.95 FPS / 2.35 ms present | 38.63 FPS / 0.92 ms present | +4.5% FPS; -61% presentation time |
| Jim Power A1200, paired native title run | 35.175 FPS / 27.541 ms emulation | 36.513 FPS / 26.499 ms emulation | +3.80% FPS; -3.79% emulation time |
| Jim Power A1200, exact release title run | - | 39.088 FPS / 24.666 ms emulation | Improvement survives the production toolchain |

The Jim Power stress target remains 50 FPS; this PR closes the measured presentation regression and retains the best safe CPU-side improvement found within the four-experiment optimization budget.

## Validation

- Raspberry Pi 4 revision 1.1, Raspberry Pi OS 64-bit Trixie, KMSDRM console, system SDL 3.2.10
- Exact Debian Trixie aarch64 release build with `midwan/amiberry-debian-aarch64:trixie`
- Eight stable Jim Power title-screen measurement windows at 1.5 GHz with no active throttling
- 52 consecutive F12 GUI-to-emulation round-trips and clean shutdown on the cumulative presentation path
- `bash tests/test_kmsdrm_gui_handoff.sh`
- Structured correctness, project-standards, testing, and performance review; no code findings

Residual coverage note: delayed BPLCON0 and blitter-write callback timing/order does not yet have a focused lifecycle harness; the counter paths were reviewed against all insertion, execution, restore, overflow, re-entrant, and reset sites.
