### PR TITLE
ci: add GitLab CI for the libretro buildbot (Linux x64 + aarch64)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@
 # Core definitions
 .core-defs:
   variables:
+    GIT_SUBMODULE_STRATEGY: recursive
     MAKEFILE_PATH: libretro
     CORENAME: amiberry
     platform: unix

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,52 @@
+# DESCRIPTION: GitLab CI/CD for libRetro (NOT FOR GitLab-proper)
+
+##############################################################################
+################################# BOILERPLATE ################################
+##############################################################################
+
+# Core definitions
+.core-defs:
+  variables:
+    MAKEFILE_PATH: libretro
+    CORENAME: amiberry
+    platform: unix
+    # Amiberry is C++17 and uses <filesystem>, so both Linux jobs need a
+    # newer compiler than the one the images default to.
+    CC: gcc-12
+    CXX: g++-12
+
+# Inclusion templates, required for the build to work
+include:
+  ################################## DESKTOPS ################################
+  # Linux 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-x64.yml'
+
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
+# Stages for building
+stages:
+  - build-prepare
+  - build-shared
+  - build-static
+
+##############################################################################
+#################################### STAGES ##################################
+##############################################################################
+
+################################### DESKTOPS #################################
+# Linux 64-bit
+libretro-build-linux-x64:
+  extends:
+    - .libretro-linux-x64-make-default
+    - .core-defs
+  # The default x64 image is xenial-gcc9; gcc-12 lives in the backports one.
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:backports
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
+    - .core-defs


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a `.gitlab-ci.yml` with `libretro-build-linux-x64` and `libretro-build-linux-aarch64` jobs, so the libretro core can be built by the libretro buildbot.
- No source files are touched.

@midwan

### Why

Amiberry has a `.info` file and a recipe in libretro-super, but no core is published on the libretro buildbot for **any** platform — `nightly/linux/x86_64/` (218 cores) and `nightly/linux/aarch64/` (165 cores) both lack it, because the repository has no `.gitlab-ci.yml` and the recipe is not enabled in `build-config.sh`. Adding the CI file is the piece that lives on your side.

Both jobs pin `gcc-12` (`CC`/`CXX` in `.core-defs`), because the core is C++17 and uses `<filesystem>`: the default x64 image is `xenial-gcc9`, so the x64 job also overrides the image to `libretro-build-amd64-ubuntu:backports`, which is where gcc-12 lives. The aarch64 job deliberately does **not** override the image — the `:backports` tag exists only for the amd64 image, while `libretro-build-aarch64-ubuntu` publishes just `:latest`/`:main` and already installs gcc-12 from `ppa:ubuntu-toolchain-r/test` in its main Dockerfile. Mirroring the override there would kill the job in `prepare_executor` with `failed to resolve reference ...:backports: not found`.

I kept this to the two Linux targets your own `build-libretro` matrix already covers on Linux. Windows/macOS jobs can follow if you want them; I have no way to test those here.

### Verified on real aarch64 hardware

Built natively (not cross-compiled) on a Snapdragon 7c / SC7180 machine running postmarketOS, GCC 15.2, `make platform=unix -j3` in `libretro/`:

* **no source changes needed at all** — 211 objects, zero errors, 17 min 30 s
* `amiberry_libretro.so`, ELF 64-bit LSB shared object, ARM aarch64, 34 MB

Then run for real:

* **libretro harness**, 600 frames: 752×576 PAL, 48.86 fps against the core's own 50.08 Hz target = **97.7 % of realtime**, exit 0
* **RetroArch**, 2500 frames: the AROS Kickstart replacement boots and renders its animation at a steady **50.00 FPS**, exit 0

Since `roms/aros-rom.bin` and `roms/aros-ext.bin` ship in the repository, this needs no copyrighted Kickstart to reproduce.

### One thing I ran into (not part of this PR)

`libretro/libretro.cpp` passes the ROM directory as `-s rom_path=<frontend system dir>`, but Amiberry's config parser rejects that key:

```
Command line parameters: amiberry -G -s rom_path=/tmp ...
unknown config entry: 'rom_path=/tmp'
```

So the setting is dropped and the AROS files have to sit in `<AMIBERRY_HOME_DIR>/ROMs` (i.e. the frontend's *save* directory) instead of the frontend's system directory, which is where a libretro user would normally put them. My first RetroArch run was a black screen for exactly this reason. Happy to open a separate issue for it, or a PR if you tell me which of the two paths you consider correct.

### What I could not test

The GitLab pipeline itself: a GitHub PR does not trigger it, and there is currently **no amiberry project on git.libretro.com at all**, so even after this is merged the buildbot will not pick the core up until libretro registers a mirror for the repository. I am happy to file that request with libretro (libretro-super) once this lands — just say the word.
