### PR TITLE
Fix libretro ROM lookup in the frontend system directory

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -3937,6 +3937,7 @@ static void core_entry(void)
 	std::string deferred_rp9_kickstart;
 
 	std::vector<std::string> deferred_rp9_options;
+	std::vector<std::string> deferred_whdload_rom_paths;
 	auto push_s_option = [&safe_strdup, &deferred_rp9_options, is_rp9](const std::string& value) {
 		if (is_rp9) {
 			deferred_rp9_options.emplace_back(value);
@@ -4091,6 +4092,10 @@ static void core_entry(void)
 			// RP9 defers this preference until after autoload, but main's RP9 source
 			// pre-scan registers ROMs from the directory before manifest validation.
 			push_s_option(rom_path);
+			// WHDLoad can rebuild preferences from a per-game config or hardware
+			// preset, so reapply ROM directories after autoload as well.
+			if (is_whdload)
+				deferred_whdload_rom_paths.emplace_back(rom_path);
 		};
 
 		// Libretro reserves system_dir for BIOS/firmware. Keep it in the ROM
@@ -4183,6 +4188,12 @@ static void core_entry(void)
 			}
 		} else {
 			safe_strdup(game_path);
+		}
+	}
+	if (is_whdload) {
+		for (const auto& option : deferred_whdload_rom_paths) {
+			safe_strdup("-s");
+			safe_strdup(option.c_str());
 		}
 	}
 	if (is_rp9) {

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -4083,10 +4083,23 @@ static void core_entry(void)
 		}
 		if (rom_path_value.empty())
 			rom_path_value = !system_dir.empty() ? system_dir : save_dir;
-		const std::string rom_path = "rom_path=" + rom_path_value;
-		// RP9 defers this preference until after autoload, but main's RP9 source
-		// pre-scan registers ROMs from the directory before manifest validation.
-		push_s_option(rom_path);
+
+		const auto push_rom_path = [&](const std::string& path) {
+			if (path.empty())
+				return;
+			const std::string rom_path = "amiberry.rom_path=" + path;
+			// RP9 defers this preference until after autoload, but main's RP9 source
+			// pre-scan registers ROMs from the directory before manifest validation.
+			push_s_option(rom_path);
+		};
+
+		// Libretro reserves system_dir for BIOS/firmware. Keep it in the ROM
+		// multipath even when a legacy Kickstarts directory was detected elsewhere,
+		// so replacement ROMs stored at the standard frontend location remain visible.
+		const std::string primary_rom_path = !system_dir.empty() ? system_dir : save_dir;
+		push_rom_path(primary_rom_path);
+		if (rom_path_value != primary_rom_path)
+			push_rom_path(rom_path_value);
 	}
 
 	{

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1878,22 +1878,45 @@ static bool load_extendedkickstart (const TCHAR *romextfile, int type)
 #ifndef AMIBERRY
 extern unsigned char arosrom[];
 extern unsigned int arosrom_len;
+#else
+static std::string find_kickstart_replacement_directory()
+{
+	const auto find_replacement = [](const TCHAR* directory) {
+		if (directory == nullptr || directory[0] == '\0')
+			return std::string();
+
+		std::string candidate(directory);
+		fix_trailing(candidate);
+		if (zfile_exists((candidate + "aros-ext.bin").c_str())
+			&& zfile_exists((candidate + "aros-rom.bin").c_str()))
+			return candidate;
+		return std::string();
+	};
+
+	for (const auto& directory : currprefs.path_rom.path) {
+		if (auto candidate = find_replacement(directory); !candidate.empty())
+			return candidate;
+	}
+
+	const auto default_rom_path = get_rom_path();
+	return find_replacement(default_rom_path.c_str());
+}
 #endif
 extern int seriallog;
 static bool load_kickstart_replacement(void)
 {
 #ifdef AMIBERRY
 	int arosrom_len;
-	char path[MAX_DPATH];
-	get_rom_path(path, MAX_DPATH);
-	strcat(path, "aros-ext.bin");
-	auto* arosrom = zfile_load_file(path, &arosrom_len);
-	if (arosrom == nullptr)
-	{
-		gui_message("Could not find the 'aros-ext.bin' file in the ROMs directory!");
+	const auto aros_directory = find_kickstart_replacement_directory();
+	if (aros_directory.empty()) {
+		gui_message("Could not find the 'aros-ext.bin' and 'aros-rom.bin' files in the configured ROM directories!");
 		return false;
 	}
-	struct zfile* f = zfile_fopen_data(path, arosrom_len, arosrom);
+	auto path = aros_directory + "aros-ext.bin";
+	auto* arosrom = zfile_load_file(path.c_str(), &arosrom_len);
+	if (arosrom == nullptr)
+		return false;
+	struct zfile* f = zfile_fopen_data(path.c_str(), arosrom_len, arosrom);
 	if (!f)
 	{
 		xfree(arosrom);
@@ -1918,15 +1941,11 @@ static bool load_kickstart_replacement(void)
 #ifdef AMIBERRY
 	zfile_fclose(f);
 	xfree(arosrom);
-	get_rom_path(path, MAX_DPATH);
-	strcat(path, "aros-rom.bin");
-	arosrom = zfile_load_file(path, &arosrom_len);
+	path = aros_directory + "aros-rom.bin";
+	arosrom = zfile_load_file(path.c_str(), &arosrom_len);
 	if (arosrom == nullptr)
-	{
-		gui_message("Could not find the 'aros-rom.bin' file in the ROMs directory!");
 		return false;
-	}
-	f = zfile_fopen_data(path, arosrom_len, arosrom);
+	f = zfile_fopen_data(path.c_str(), arosrom_len, arosrom);
 	if (!f)
 	{
 		xfree(arosrom);

--- a/tests/test_libretro_rom_path.sh
+++ b/tests/test_libretro_rom_path.sh
@@ -21,6 +21,19 @@ if ! grep -F -q 'const std::string primary_rom_path = !system_dir.empty() ? syst
 	exit 1
 fi
 
+if ! grep -F -q 'deferred_whdload_rom_paths.emplace_back(rom_path);' "$libretro_source"; then
+	echo "Libretro must retain ROM directories for reapplication after WHDLoad autoload" >&2
+	exit 1
+fi
+
+autoload_line=$(grep -n -F 'safe_strdup("--autoload");' "$libretro_source" | head -1 | cut -d: -f1)
+whdload_rom_reapply_line=$(grep -n -F 'for (const auto& option : deferred_whdload_rom_paths)' "$libretro_source" | head -1 | cut -d: -f1)
+if [ -z "$autoload_line" ] || [ -z "$whdload_rom_reapply_line" ] ||
+	[ "$whdload_rom_reapply_line" -le "$autoload_line" ]; then
+	echo "Libretro must reapply ROM directories after WHDLoad autoload resets preferences" >&2
+	exit 1
+fi
+
 if ! awk '
 	/static std::string find_kickstart_replacement_directory\(\)/ { in_helper = 1 }
 	in_helper && /currprefs\.path_rom\.path/ { checks_multipath = 1 }

--- a/tests/test_libretro_rom_path.sh
+++ b/tests/test_libretro_rom_path.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+libretro_source="libretro/libretro.cpp"
+memory_source="src/memory.cpp"
+
+if ! grep -F -q 'const std::string rom_path = "amiberry.rom_path=" + path;' "$libretro_source"; then
+	echo "Libretro ROM directories must use the target-qualified config option" >&2
+	exit 1
+fi
+
+if grep -F -q 'const std::string rom_path = "rom_path="' "$libretro_source"; then
+	echo "Libretro must not emit the unrecognized bare rom_path config option" >&2
+	exit 1
+fi
+
+if ! grep -F -q 'const std::string primary_rom_path = !system_dir.empty() ? system_dir : save_dir;' "$libretro_source" ||
+	! grep -F -q 'push_rom_path(primary_rom_path);' "$libretro_source" ||
+	! grep -F -q 'if (rom_path_value != primary_rom_path)' "$libretro_source"; then
+	echo "Libretro must keep the frontend system directory and legacy Kickstarts directory in the ROM multipath" >&2
+	exit 1
+fi
+
+if ! awk '
+	/static std::string find_kickstart_replacement_directory\(\)/ { in_helper = 1 }
+	in_helper && /currprefs\.path_rom\.path/ { checks_multipath = 1 }
+	in_helper && /aros-ext\.bin/ { checks_ext = 1 }
+	in_helper && /aros-rom\.bin/ { checks_main = 1 }
+	in_helper && /^}/ { exit }
+	END { exit checks_multipath && checks_ext && checks_main ? 0 : 1 }
+' "$memory_source"; then
+	echo "The AROS replacement loader must search every configured ROM directory for both ROM files" >&2
+	exit 1
+fi


### PR DESCRIPTION
Fixes: N/A.

Changes proposed in this pull request:
- Allow the AROS replacement ROM to boot when `aros-rom.bin` and `aros-ext.bin` are stored in the libretro frontend's system directory; users no longer need duplicate files under the save directory.
- Keep the frontend system directory and existing legacy `Kickstarts` locations in Amiberry's ROM multipath.
- Require both AROS ROM halves to resolve from the same configured ROM directory.

Related: #2239

## Validation

- Built the x86_64 standalone libretro core from a clean tree with `--no-undefined`.
- Ran the core in RetroArch with both AROS files only in `system_directory` and the save-side `ROMs` path deliberately unavailable; both Kickstart halves mapped successfully, with no missing-AROS or unknown-`rom_path` error.
- Passed `tests/test_libretro_rom_path.sh` and `tests/test_rp9_rom_override_order.sh`.
- `tools/check_libretro_contract.py` remains blocked by a pre-existing assertion on master for the old two-argument `whdload_auto_prefs` signature.

@midwan
