### PR TITLE
ci: add remaining libretro buildbot targets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,9 @@
     GIT_SUBMODULE_STRATEGY: recursive
     MAKEFILE_PATH: libretro
     CORENAME: amiberry
+
+.linux-defs:
+  variables:
     platform: unix
     # Amiberry is C++17 and uses <filesystem>, so both Linux jobs need a
     # newer compiler than the one the images default to.
@@ -19,6 +22,10 @@
 # Inclusion templates, required for the build to work
 include:
   ################################## DESKTOPS ################################
+  # Windows 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-x64-mingw.yml'
+
   # Linux 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
@@ -26,6 +33,10 @@ include:
   # Linux ARM 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-aarch64.yml'
+
+  # macOS ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-arm64.yml'
 
 # Stages for building
 stages:
@@ -38,11 +49,21 @@ stages:
 ##############################################################################
 
 ################################### DESKTOPS #################################
+# Windows 64-bit
+libretro-build-windows-x64:
+  extends:
+    - .libretro-windows-x64-mingw-make-default
+    - .core-defs
+  variables:
+    # The template defaults to win64, but Amiberry's Makefile uses win.
+    platform: win
+
 # Linux 64-bit
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
     - .core-defs
+    - .linux-defs
   # The default x64 image is xenial-gcc9; gcc-12 lives in the backports one.
   image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:backports
 
@@ -51,3 +72,12 @@ libretro-build-linux-aarch64:
   extends:
     - .libretro-linux-aarch64-make-default
     - .core-defs
+    - .linux-defs
+
+# macOS ARM 64-bit
+libretro-build-osx-arm64:
+  extends:
+    - .libretro-osx-arm64-make-default
+    - .core-defs
+  variables:
+    ARCH: arm64


### PR DESCRIPTION
## Summary

The libretro buildbot now covers the same four desktop targets as Amiberry's GitHub Actions matrix: Linux x86_64, Linux aarch64, Windows x86_64, and macOS arm64.

Linux's GCC 12 overrides are isolated from the common variables so they cannot replace the Windows or macOS toolchains. The Windows job also overrides the buildbot template's `win64` platform value with the exact `win` value expected by Amiberry's Makefile.

Related: #2239

## Testing

- Parsed `.gitlab-ci.yml` successfully as YAML.
- Resolved the current imported buildbot templates and verified each job's final platform, architecture, compiler, Makefile path, and core name.
- Verified exact target parity with the `build-libretro` GitHub Actions matrix.
- Ran `git diff --check`.

The external GitLab runner images and artifact publication could not be exercised locally.

## Post-Deploy Monitoring & Validation

No additional production monitoring is required because this change only expands libretro buildbot coverage.

- Validation window: the first buildbot pipeline after merge.
- Owner: Amiberry maintainer reviewing the pipeline.
- Healthy signal: all four desktop jobs run and publish the expected `.so`, `.dll`, or `.dylib` artifact.
- Failure signal: a target is missing, a job fails, or an artifact has the wrong platform or architecture.
- Mitigation trigger: revert this commit if the new jobs disrupt the buildbot pipeline; otherwise correct the affected job or template override in a follow-up.
