### PR TITLE
feat(android): improve emulator setup reliability

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -268,4 +268,38 @@ tasks.register('copyAssets', Copy) {
     }
 }
 
-preBuild.dependsOn copyAssets
+def verifySdlJavaShimVersion = tasks.register('verifySdlJavaShimVersion') {
+    group = 'verification'
+    description = 'Verifies that the checked-in SDL Java shim matches the native SDL release pin'
+
+    def dependenciesFile = rootProject.file('../cmake/Dependencies.cmake')
+    def sdlActivityFile = file('src/main/java/org/libsdl/app/SDLActivity.java')
+    inputs.files(dependenciesFile, sdlActivityFile)
+
+    doLast {
+        def dependencies = dependenciesFile.getText('UTF-8')
+        def nativeVersionMatcher = dependencies =~ /(?s)FetchContent_Declare\(\s*sdl3\b.*?GIT_TAG\s+release-(\d+)\.(\d+)\.(\d+)/
+        if (!nativeVersionMatcher.find()) {
+            throw new GradleException("Could not parse the native SDL release pin from ${dependenciesFile}")
+        }
+        def expectedVersion = (1..3).collect { nativeVersionMatcher.group(it).toInteger() }
+
+        def sdlActivity = sdlActivityFile.getText('UTF-8')
+        def javaVersion = ['MAJOR', 'MINOR', 'MICRO'].collect { component ->
+            def matcher = sdlActivity =~ /SDL_${component}_VERSION\s*=\s*(\d+)\s*;/
+            if (!matcher.find()) {
+                throw new GradleException("Could not parse SDL_${component}_VERSION from ${sdlActivityFile}")
+            }
+            matcher.group(1).toInteger()
+        }
+
+        if (javaVersion != expectedVersion) {
+            throw new GradleException(
+                    "SDL Java shim ${javaVersion.join('.')} does not match native SDL ${expectedVersion.join('.')}. " +
+                            'Port the matching android-project Java sources before building the APK.'
+            )
+        }
+    }
+}
+
+preBuild.dependsOn copyAssets, verifySdlJavaShimVersion

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/FileManager.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/FileManager.kt
@@ -2,6 +2,7 @@ package com.blitterstudio.amiberry.data
 
 import android.content.Context
 import android.net.Uri
+import android.provider.DocumentsContract
 import android.provider.OpenableColumns
 import android.util.Log
 import com.blitterstudio.amiberry.data.model.AmigaFile
@@ -9,6 +10,7 @@ import com.blitterstudio.amiberry.data.model.FileCategory
 import com.blitterstudio.amiberry.data.model.StoragePaths
 import java.io.File
 import java.io.IOException
+import java.util.ArrayDeque
 import java.util.zip.CRC32
 
 object FileManager {
@@ -41,6 +43,27 @@ object FileManager {
 		data class Failed(override val safeName: String) : ImportResult
 	}
 
+	internal data class DocumentTreeChild(
+		val documentId: String,
+		val mimeType: String,
+		val displayName: String?
+	)
+
+	internal data class DocumentTreeDocument(
+		val documentId: String,
+		val displayName: String?
+	)
+
+	internal data class DocumentTreeFailure(
+		val documentId: String,
+		val cause: Exception?
+	)
+
+	internal data class DocumentTreeTraversal(
+		val documents: List<DocumentTreeDocument>,
+		val failures: List<DocumentTreeFailure>
+	)
+
 	fun getAppStoragePath(context: Context): String {
 		return context.getExternalFilesDir(null)?.absolutePath ?: ""
 	}
@@ -62,11 +85,48 @@ object FileManager {
 	}
 
 	fun importFileWithResult(context: Context, uri: Uri, category: FileCategory): ImportResult {
-		val candidate = importCandidateForCategory(getFileName(context, uri), category)
+		return importFileWithResult(context, uri, category, getFileName(context, uri))
+	}
+
+	private fun importFileWithResult(
+		context: Context,
+		uri: Uri,
+		category: FileCategory,
+		displayName: String?
+	): ImportResult {
+		val candidate = importCandidateForCategory(displayName, category)
 		return when (candidate) {
 			is ImportCandidate.Importable -> copyImportFile(context, uri, category, candidate.safeName)
 			is ImportCandidate.Unsupported -> ImportResult.Unsupported(candidate.safeName, candidate.extension)
 		}
+	}
+
+	/**
+	 * Import every supported file below a Storage Access Framework directory tree.
+	 * Subdirectories are traversed so users can select a ROM collection root once.
+	 */
+	fun importFolderWithResults(
+		context: Context,
+		treeUri: Uri,
+		category: FileCategory
+	): List<ImportResult> {
+		val traversal = documentsInTree(context, treeUri)
+		val results = traversal.documents.mapTo(mutableListOf()) { document ->
+			val uri = try {
+				DocumentsContract.buildDocumentUriUsingTree(treeUri, document.documentId)
+			} catch (e: IllegalArgumentException) {
+				Log.w(TAG, "Failed to build document URI: ${document.documentId}", e)
+				return@mapTo ImportResult.Failed(
+					safeImportFileName(document.displayName ?: document.documentId)
+				)
+			}
+			val displayName = document.displayName
+				?.takeIf { it.isNotBlank() }
+				?: document.documentId.substringAfterLast('/').substringAfterLast(':')
+			importFileWithResult(context, uri, category, displayName)
+		}
+		results += traversal.failures.map { ImportResult.Failed(FOLDER_IMPORT_FAILURE_NAME) }
+		return results
 	}
 
 	private fun copyImportFile(
@@ -244,7 +304,13 @@ object FileManager {
 
 	private fun getFileName(context: Context, uri: Uri): String? {
 		// Try ContentResolver query first (works for most SAF URIs)
-		context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+		context.contentResolver.query(
+			uri,
+			arrayOf(OpenableColumns.DISPLAY_NAME),
+			null,
+			null,
+			null
+		)?.use { cursor ->
 			val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
 			if (nameIndex >= 0 && cursor.moveToFirst()) {
 				val name = cursor.getString(nameIndex)
@@ -253,6 +319,108 @@ object FileManager {
 		}
 		// Fallback: extract from URI path
 		return uri.lastPathSegment?.substringAfterLast('/')
+	}
+
+	private fun documentsInTree(context: Context, treeUri: Uri): DocumentTreeTraversal {
+		val resolver = context.contentResolver
+
+		val rootDocumentId = try {
+			DocumentsContract.getTreeDocumentId(treeUri)
+		} catch (e: IllegalArgumentException) {
+			Log.e(TAG, "Invalid document tree URI: $treeUri", e)
+			return DocumentTreeTraversal(
+				documents = emptyList(),
+				failures = listOf(DocumentTreeFailure(FOLDER_IMPORT_FAILURE_NAME, e))
+			)
+		}
+
+		val traversal = traverseDocumentTree(rootDocumentId) { documentId ->
+			val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, documentId)
+			val cursor = resolver.query(
+				childrenUri,
+				arrayOf(
+					DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+					DocumentsContract.Document.COLUMN_MIME_TYPE,
+					DocumentsContract.Document.COLUMN_DISPLAY_NAME
+				),
+				null,
+				null,
+				null
+			) ?: return@traverseDocumentTree null
+
+			cursor.use {
+				val idColumn = it.getColumnIndexOrThrow(
+					DocumentsContract.Document.COLUMN_DOCUMENT_ID
+				)
+				val mimeTypeColumn = it.getColumnIndexOrThrow(
+					DocumentsContract.Document.COLUMN_MIME_TYPE
+				)
+				val displayNameColumn = it.getColumnIndex(
+					DocumentsContract.Document.COLUMN_DISPLAY_NAME
+				)
+				buildList {
+					while (it.moveToNext()) {
+						add(
+							DocumentTreeChild(
+								documentId = it.getString(idColumn),
+								mimeType = it.getString(mimeTypeColumn),
+								displayName = if (displayNameColumn >= 0) {
+									it.getString(displayNameColumn)
+								} else {
+									null
+								}
+							)
+						)
+					}
+				}
+			}
+		}
+
+		traversal.failures.forEach { failure ->
+			if (failure.cause == null) {
+				Log.w(TAG, "Document provider returned no cursor for directory: ${failure.documentId}")
+			} else {
+				Log.w(TAG, "Failed to list document tree directory: ${failure.documentId}", failure.cause)
+			}
+		}
+		return traversal
+	}
+
+	internal fun traverseDocumentTree(
+		rootDocumentId: String,
+		queryChildren: (String) -> List<DocumentTreeChild>?
+	): DocumentTreeTraversal {
+		val pendingDirectories = ArrayDeque<String>()
+		val visitedDirectories = mutableSetOf<String>()
+		val documents = mutableListOf<DocumentTreeDocument>()
+		val failures = mutableListOf<DocumentTreeFailure>()
+		pendingDirectories.add(rootDocumentId)
+
+		while (pendingDirectories.isNotEmpty()) {
+			val documentId = pendingDirectories.removeFirst()
+			if (!visitedDirectories.add(documentId)) continue
+
+			val children = try {
+				queryChildren(documentId)
+			} catch (e: Exception) {
+				failures += DocumentTreeFailure(documentId, e)
+				continue
+			}
+			if (children == null) {
+				failures += DocumentTreeFailure(documentId, null)
+				continue
+			}
+
+			children.forEach { child ->
+				if (child.mimeType == DocumentsContract.Document.MIME_TYPE_DIR) {
+					pendingDirectories.add(child.documentId)
+				} else {
+					documents += DocumentTreeDocument(child.documentId, child.displayName)
+				}
+			}
+		}
+
+		return DocumentTreeTraversal(documents, failures)
 	}
 
 	private fun calculateCrc32(file: File): Long? {
@@ -274,6 +442,7 @@ object FileManager {
 	}
 
 	private val SAFE_FILENAME_CHARS = setOf(' ', '.', '_', '-', '(', ')', '+')
+	private const val FOLDER_IMPORT_FAILURE_NAME = "folder"
 
 	private fun importTargetName(baseName: String, extension: String, counter: Int): String =
 		if (extension.isBlank()) "${baseName}_$counter" else "${baseName}_$counter.$extension"

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ImportBatchFeedback.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ImportBatchFeedback.kt
@@ -17,6 +17,7 @@ object ImportBatchFeedback {
 		val total = results.size
 
 		return when {
+			total == 0 -> Message(R.string.msg_import_folder_no_supported_files, emptyList())
 			imported == total -> Message(R.string.msg_imported_multiple, listOf(imported, total))
 			imported == 0 -> Message(R.string.msg_imported_none, listOf(unsupported, failed))
 			else -> Message(R.string.msg_imported_multiple_with_failures, listOf(imported, total, unsupported, failed))

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/SettingsIntentPresets.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/SettingsIntentPresets.kt
@@ -52,4 +52,7 @@ object SettingsIntentPresets {
 			)
 		}
 	}
+
+	fun matches(settings: EmulatorSettings, preset: SettingsIntentPreset): Boolean =
+		apply(settings, preset) == settings
 }

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/FileManagerScreen.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/FileManagerScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -92,6 +94,7 @@ fun FileManagerScreen(viewModel: FileManagerViewModel = viewModel()) {
 	val scope = rememberCoroutineScope()
 	val snackbarHostState = remember { SnackbarHostState() }
 	var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+	var showRomImportMenu by remember { mutableStateOf(false) }
 
 	val tabs = listOf(
 		TabInfo(FileCategory.ROMS, stringResource(R.string.file_manager_tab_roms), Icons.Default.Memory),
@@ -145,6 +148,20 @@ fun FileManagerScreen(viewModel: FileManagerViewModel = viewModel()) {
 			viewModel.importFiles(uris, currentCategory)
 		}
 	}
+	val romFolderPickerLauncher = rememberLauncherForActivityResult(
+		contract = ActivityResultContracts.OpenDocumentTree()
+	) { uri ->
+		if (uri != null && !showProgress) {
+			viewModel.importFolder(uri, FileCategory.ROMS)
+		}
+	}
+	val openImportPicker = {
+		if (currentCategory == FileCategory.ROMS) {
+			showRomImportMenu = true
+		} else {
+			filePickerLauncher.launch(FilePickerFilters.mimeTypesFor(currentCategory))
+		}
+	}
 
 	LaunchedEffect(importResult) {
 		importResult?.let { msg ->
@@ -172,32 +189,55 @@ fun FileManagerScreen(viewModel: FileManagerViewModel = viewModel()) {
 			)
 		},
 		floatingActionButton = {
-			ExtendedFloatingActionButton(
-				onClick = {
-					if (showProgress) {
-						return@ExtendedFloatingActionButton
-					}
-					filePickerLauncher.launch(FilePickerFilters.mimeTypesFor(currentCategory))
-				},
-				modifier = Modifier.semantics { if (showProgress) disabled() },
-				icon = {
-					if (isImporting) {
-						CircularProgressIndicator(
-							modifier = Modifier.size(18.dp),
-							strokeWidth = 2.dp
+			Box {
+				ExtendedFloatingActionButton(
+					onClick = {
+						if (showProgress) {
+							return@ExtendedFloatingActionButton
+						}
+						openImportPicker()
+					},
+					modifier = Modifier.semantics { if (showProgress) disabled() },
+					icon = {
+						if (isImporting) {
+							CircularProgressIndicator(
+								modifier = Modifier.size(18.dp),
+								strokeWidth = 2.dp
+							)
+						} else {
+							Icon(Icons.Default.Add, contentDescription = null)
+						}
+					},
+					text = {
+						Text(
+							stringResource(
+								if (isImporting) R.string.action_importing else R.string.action_import
+							)
 						)
-					} else {
-						Icon(Icons.Default.Add, contentDescription = null)
 					}
-				},
-				text = {
-					Text(
-						stringResource(
-							if (isImporting) R.string.action_importing else R.string.action_import
-						)
+				)
+				DropdownMenu(
+					expanded = showRomImportMenu,
+					onDismissRequest = { showRomImportMenu = false }
+				) {
+					DropdownMenuItem(
+						text = { Text(stringResource(R.string.action_import_rom_files)) },
+						leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
+						onClick = {
+							showRomImportMenu = false
+							filePickerLauncher.launch(FilePickerFilters.mimeTypesFor(FileCategory.ROMS))
+						}
+					)
+					DropdownMenuItem(
+						text = { Text(stringResource(R.string.action_import_rom_folder)) },
+						leadingIcon = { Icon(Icons.Default.FolderOpen, contentDescription = null) },
+						onClick = {
+							showRomImportMenu = false
+							romFolderPickerLauncher.launch(null)
+						}
 					)
 				}
-			)
+			}
 		}
 	) { innerPadding ->
 		Column(
@@ -351,7 +391,7 @@ fun FileManagerScreen(viewModel: FileManagerViewModel = viewModel()) {
 								if (searchHasNoResults) {
 									searchQuery = ""
 								} else {
-									filePickerLauncher.launch(FilePickerFilters.mimeTypesFor(currentCategory))
+									openImportPicker()
 								}
 							},
 							enabled = searchHasNoResults || !showProgress

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsScreen.kt
@@ -308,6 +308,7 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel(LocalContext.current
 			}
 
 			SettingsPresetSelector(
+				selectedPreset = viewModel.selectedIntentPreset,
 				onPresetSelected = { preset -> viewModel.applyIntentPreset(preset) }
 			)
 
@@ -452,6 +453,7 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel(LocalContext.current
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SettingsPresetSelector(
+	selectedPreset: SettingsIntentPreset?,
 	onPresetSelected: (SettingsIntentPreset) -> Unit
 ) {
 	var expanded by remember { mutableStateOf(false) }
@@ -467,7 +469,8 @@ private fun SettingsPresetSelector(
 				onExpandedChange = { expanded = it }
 			) {
 				OutlinedTextField(
-					value = stringResource(R.string.settings_preset_select),
+					value = selectedPreset?.let { stringResource(it.titleRes()) }
+						?: stringResource(R.string.settings_preset_select),
 					onValueChange = {},
 					readOnly = true,
 					label = { Text(stringResource(R.string.settings_presets_title)) },

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/FileManagerViewModel.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/FileManagerViewModel.kt
@@ -52,6 +52,21 @@ class FileManagerViewModel(application: Application) : AndroidViewModel(applicat
 
 	fun importFiles(uris: List<Uri>, category: FileCategory) {
 		if (uris.isEmpty()) return
+		startImport(category) { app ->
+			uris.map { uri -> FileManager.importFileWithResult(app, uri, category) }
+		}
+	}
+
+	fun importFolder(treeUri: Uri, category: FileCategory) {
+		startImport(category) { app ->
+			FileManager.importFolderWithResults(app, treeUri, category)
+		}
+	}
+
+	private fun startImport(
+		category: FileCategory,
+		importer: (Application) -> List<FileManager.ImportResult>
+	) {
 		if (_isImporting.value) {
 			return
 		}
@@ -59,22 +74,11 @@ class FileManagerViewModel(application: Application) : AndroidViewModel(applicat
 		viewModelScope.launch(Dispatchers.IO) {
 			try {
 				val app = getApplication<Application>()
-				var successCount = 0
-				val totalCount = uris.size
-				var firstResult: FileManager.ImportResult? = null
-				val results = mutableListOf<FileManager.ImportResult>()
+				val results = importer(app)
+				val successCount = results.count { it is FileManager.ImportResult.Imported }
 
-				for (uri in uris) {
-					val result = FileManager.importFileWithResult(app, uri, category)
-					results += result
-					if (firstResult == null) firstResult = result
-					if (result is FileManager.ImportResult.Imported) {
-						successCount++
-					}
-				}
-
-				_importResult.value = if (totalCount == 1) {
-					val message = ImportFeedback.fromImportResult(firstResult ?: FileManager.ImportResult.Failed("file"))
+				_importResult.value = if (results.size == 1) {
+					val message = ImportFeedback.fromImportResult(results.first())
 					app.getString(message.stringRes, message.argument)
 				} else {
 					val message = ImportBatchFeedback.messageFor(results)

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
@@ -43,6 +43,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 	var adjustmentNotices by mutableStateOf<List<SettingsAdjustmentNotice>>(emptyList())
 		private set
 
+	var selectedIntentPreset by mutableStateOf<SettingsIntentPreset?>(null)
+		private set
+
 	var currentUnknownLines by mutableStateOf<List<String>>(emptyList())
 		private set
 
@@ -115,6 +118,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 	}
 
 	fun applyModel(model: AmigaModel) {
+		selectedIntentPreset = null
 		val selectedRoms = ModelRomAvailability.selectRomsForModel(model, availableRoms.value)
 		val previousSettings = settings
 		val newSettings = EmulatorSettings.fromModel(model).copy(
@@ -132,6 +136,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 	}
 
 	fun loadConfig(parsed: ConfigParser.ParsedConfig, name: String, path: String) {
+		selectedIntentPreset = null
 		applyConstrainedSettings(
 			appPreferences.applyRememberedAndroidControls(parsed.settings, parsed.explicitKeys),
 			publishNotices = true
@@ -208,6 +213,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
 	/** Revert in-memory edits back to the last saved/loaded values of the open config. */
 	fun discardChanges() {
+		selectedIntentPreset = null
 		settings = baselineSettings
 		currentUnknownLines = baselineUnknownLines
 		clearAdjustmentNotices()
@@ -245,6 +251,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 			SettingsIntentPresets.apply(settings, preset),
 			publishNotices = true
 		)
+		selectedIntentPreset = preset.takeIf { SettingsIntentPresets.matches(settings, it) }
 		appPreferences.saveAndroidControls(settings)
 		saveLastSession()
 	}
@@ -265,6 +272,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 				)
 			} ?: return@launch
 
+			selectedIntentPreset = null
 			applyConstrainedSettings(detectedSettings, publishNotices = true)
 			appPreferences.saveAndroidControls(settings)
 			saveLastSession()
@@ -296,6 +304,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 	private fun applyConstrainedSettings(requested: EmulatorSettings, publishNotices: Boolean) {
 		val constrained = applyConstraints(requested)
 		settings = constrained
+		selectedIntentPreset = selectedIntentPreset?.takeIf {
+			SettingsIntentPresets.matches(constrained, it)
+		}
 		if (publishNotices) {
 			adjustmentNotices = SettingsAdjustmentNotices.fromAdjustment(requested, constrained)
 		}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -149,6 +149,8 @@
     <string name="setup_required_title">ROM Setup Required</string>
     <string name="setup_required_message">An Amiga Kickstart ROM is required to start the emulator. Please import a valid ROM file.</string>
     <string name="action_import_rom">Import ROM</string>
+    <string name="action_import_rom_files">Import ROM files</string>
+    <string name="action_import_rom_folder">Import ROM folder</string>
     <string name="file_manager_import_category">Import %1$s</string>
     <string name="configurations_empty_cta">Create Initial Configuration</string>
     <string name="quick_start_amiga_model">Amiga Model</string>
@@ -188,6 +190,7 @@
     <string name="msg_imported_multiple">Imported %1$d of %2$d files</string>
     <string name="msg_imported_multiple_with_failures">Imported %1$d of %2$d files (%3$d unsupported, %4$d failed)</string>
     <string name="msg_imported_none">No files imported (%1$d unsupported, %2$d failed)</string>
+    <string name="msg_import_folder_no_supported_files">No supported files found in the selected folder</string>
     <string name="msg_import_failed">Import failed</string>
     <string name="msg_intent_imported_config_as">Imported config as %1$s</string>
     <string name="msg_intent_imported_file">Imported %1$s</string>

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/DocumentTreeTraversalTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/DocumentTreeTraversalTest.kt
@@ -1,0 +1,110 @@
+package com.blitterstudio.amiberry.data
+
+import android.provider.DocumentsContract
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DocumentTreeTraversalTest {
+
+	@Test
+	fun `traversal preserves projected names across nested directories`() {
+		val queries = mutableListOf<String>()
+		val children = mapOf(
+			"root" to listOf(
+				directory("nested", "Kickstarts"),
+				file("kick13", "Kickstart 1.3.rom"),
+				file("notes", "notes.txt")
+			),
+			"nested" to listOf(
+				file("kick31", "Kickstart 3.1.rom")
+			)
+		)
+
+		val result = FileManager.traverseDocumentTree("root") { documentId ->
+			queries += documentId
+			children[documentId]
+		}
+
+		assertEquals(listOf("root", "nested"), queries)
+		assertEquals(
+			listOf(
+				FileManager.DocumentTreeDocument("kick13", "Kickstart 1.3.rom"),
+				FileManager.DocumentTreeDocument("notes", "notes.txt"),
+				FileManager.DocumentTreeDocument("kick31", "Kickstart 3.1.rom")
+			),
+			result.documents
+		)
+		assertTrue(result.failures.isEmpty())
+	}
+
+	@Test
+	fun `null root cursor is preserved as a traversal failure`() {
+		val result = FileManager.traverseDocumentTree("root") { null }
+
+		assertTrue(result.documents.isEmpty())
+		assertEquals(1, result.failures.size)
+		assertEquals("root", result.failures.single().documentId)
+		assertNull(result.failures.single().cause)
+	}
+
+	@Test
+	fun `nested query failure keeps discovered files and reports partial traversal`() {
+		val failure = IllegalStateException("provider unavailable")
+		val result = FileManager.traverseDocumentTree("root") { documentId ->
+			when (documentId) {
+				"root" -> listOf(
+					directory("nested", "Nested"),
+					file("kick13", "Kickstart 1.3.rom")
+				)
+				"nested" -> throw failure
+				else -> emptyList()
+			}
+		}
+
+		assertEquals(
+			listOf(FileManager.DocumentTreeDocument("kick13", "Kickstart 1.3.rom")),
+			result.documents
+		)
+		assertEquals(1, result.failures.size)
+		assertEquals("nested", result.failures.single().documentId)
+		assertEquals(failure, result.failures.single().cause)
+	}
+
+	@Test
+	fun `duplicate directory IDs are queried once`() {
+		var nestedQueries = 0
+		val result = FileManager.traverseDocumentTree("root") { documentId ->
+			when (documentId) {
+				"root" -> listOf(
+					directory("nested", "Nested"),
+					directory("nested", "Nested")
+				)
+				"nested" -> {
+					nestedQueries++
+					listOf(file("kick31", "Kickstart 3.1.rom"))
+				}
+				else -> emptyList()
+			}
+		}
+
+		assertEquals(1, nestedQueries)
+		assertEquals(1, result.documents.size)
+		assertTrue(result.failures.isEmpty())
+	}
+
+	private fun directory(documentId: String, displayName: String) =
+		FileManager.DocumentTreeChild(
+			documentId = documentId,
+			mimeType = DocumentsContract.Document.MIME_TYPE_DIR,
+			displayName = displayName
+		)
+
+	private fun file(documentId: String, displayName: String) =
+		FileManager.DocumentTreeChild(
+			documentId = documentId,
+			mimeType = "application/octet-stream",
+			displayName = displayName
+		)
+}

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ImportBatchFeedbackTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ImportBatchFeedbackTest.kt
@@ -7,6 +7,14 @@ import org.junit.Test
 class ImportBatchFeedbackTest {
 
 	@Test
+	fun `empty folder reports that no supported files were found`() {
+		val message = ImportBatchFeedback.messageFor(emptyList())
+
+		assertEquals(R.string.msg_import_folder_no_supported_files, message.stringRes)
+		assertEquals(emptyList<Int>(), message.args)
+	}
+
+	@Test
 	fun `all imported batch uses existing imported multiple message`() {
 		val message = ImportBatchFeedback.messageFor(
 			listOf(

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/SettingsIntentPresetsTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/SettingsIntentPresetsTest.kt
@@ -11,6 +11,22 @@ import org.junit.Test
 class SettingsIntentPresetsTest {
 
 	@Test
+	fun `preset match remains true until one of its settings changes`() {
+		val settings = SettingsIntentPresets.apply(
+			EmulatorSettings(),
+			SettingsIntentPreset.Balanced
+		)
+
+		assertTrue(SettingsIntentPresets.matches(settings, SettingsIntentPreset.Balanced))
+		assertFalse(
+			SettingsIntentPresets.matches(
+				settings.copy(cpuSpeed = "max"),
+				SettingsIntentPreset.Balanced
+			)
+		)
+	}
+
+	@Test
 	fun `pixel perfect preset enables integer scaling pair`() {
 		val settings = SettingsIntentPresets.apply(
 			EmulatorSettings(scalingMethod = -1, gfxAutoresolution = 0),

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/FileManagerScreenArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/FileManagerScreenArchitectureTest.kt
@@ -26,6 +26,22 @@ class FileManagerScreenArchitectureTest {
 	}
 
 	@Test
+	fun `ROM import offers both file and recursive folder pickers`() {
+		val screen = source()
+
+		assertTrue(
+			"ROM users should be able to select a directory tree once.",
+			screen.contains("ActivityResultContracts.OpenDocumentTree()")
+		)
+		assertTrue(
+			"The selected ROM tree should be imported through the view model.",
+			screen.contains("viewModel.importFolder(uri, FileCategory.ROMS)")
+		)
+		assertTrue(screen.contains("R.string.action_import_rom_files"))
+		assertTrue(screen.contains("R.string.action_import_rom_folder"))
+	}
+
+	@Test
 	fun `file manager does not mutate search state during composition`() {
 		val screen = source()
 

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/SDLJavaShimSignatureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/SDLJavaShimSignatureTest.kt
@@ -32,6 +32,14 @@ class SDLJavaShimSignatureTest {
 	}
 
 	@Test
+	fun androidApkBuildVerifiesSdlJavaShimVersion() {
+		val buildScript = File("build.gradle").readText()
+
+		assertEquals(true, buildScript.contains("verifySdlJavaShimVersion"))
+		assertEquals(true, buildScript.contains("preBuild.dependsOn copyAssets, verifySdlJavaShimVersion"))
+	}
+
+	@Test
 	fun registeredNativeMethodsMatchSdlRegistrationTables() {
 		assertNativeMethods(
 			SDLActivity::class.java,

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsScreenSaveArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/SettingsScreenSaveArchitectureTest.kt
@@ -52,7 +52,9 @@ class SettingsScreenSaveArchitectureTest {
 	fun `settings screen exposes dependency feedback and intent presets`() {
 		assertTrue(source.contains("SettingsAdjustmentBanner("))
 		assertTrue(source.contains("SettingsPresetSelector("))
+		assertTrue(source.contains("selectedPreset = viewModel.selectedIntentPreset"))
 		assertTrue(source.contains("viewModel.applyIntentPreset"))
+		assertTrue(source.contains("selectedPreset?.let { stringResource(it.titleRes()) }"))
 	}
 
 	@Test

--- a/docs/solutions/design-patterns/reliable-recursive-android-saf-rom-folder-imports.md
+++ b/docs/solutions/design-patterns/reliable-recursive-android-saf-rom-folder-imports.md
@@ -1,0 +1,116 @@
+---
+title: "Reliable Recursive Android SAF ROM Folder Imports"
+date: 2026-07-30
+category: design-patterns
+module: "Android file management"
+problem_type: design_pattern
+component: service_object
+severity: medium
+applies_when:
+  - "Importing a user-selected file collection through an Android DocumentsProvider tree"
+  - "Traversing nested SAF directories that may fail after returning partial results"
+  - "Using provider metadata to validate and sanitize local filenames"
+tags:
+  - "android"
+  - "storage-access-framework"
+  - "documents-provider"
+  - "document-tree"
+  - "rom-import"
+  - "recursive-traversal"
+  - "partial-failure"
+  - "filename-sanitization"
+---
+
+# Reliable Recursive Android SAF ROM Folder Imports
+
+## Context
+
+Android ROM import needs to support selecting either individual Kickstart files or one directory containing a nested ROM collection. The directory flow starts with `OpenDocumentTree` and passes the selected tree URI into the ROM importer (`android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/FileManagerScreen.kt:151` and `android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/FileManagerViewModel.kt:60`).
+
+Storage Access Framework trees are not ordinary filesystem directories. The importer is designed and tested to tolerate null query results, enumeration exceptions, repeated directory IDs, and display names that differ from document IDs. A reliable importer must preserve those distinctions instead of treating every missing query result as an empty directory.
+
+An early implementation correctly discovered nested documents, but it logged and discarded directory-query failures. That made an unreadable root look empty and made an unreadable nested directory look like a completely successful partial scan. It also queried each leaf again for a display name already available in the child-directory cursor.
+
+## Guidance
+
+### Return documents and traversal failures together
+
+Model tree enumeration as a result containing both discovered documents and failed directories. Amiberry uses `DocumentTreeTraversal` for this boundary (`android/app/src/main/java/com/blitterstudio/amiberry/data/FileManager.kt:62`).
+
+The traversal preserves a thrown query exception or null cursor before continuing:
+
+```kotlin
+val children = try {
+	queryChildren(documentId)
+} catch (e: Exception) {
+	failures += DocumentTreeFailure(documentId, e)
+	continue
+}
+if (children == null) {
+	failures += DocumentTreeFailure(documentId, null)
+	continue
+}
+```
+
+This logic lives in `traverseDocumentTree()` (`android/app/src/main/java/com/blitterstudio/amiberry/data/FileManager.kt:389`). Documents discovered before a nested failure remain importable, while the failure remains available to the feedback layer.
+
+### Project all downstream metadata in the directory query
+
+Request the document ID, MIME type, and `COLUMN_DISPLAY_NAME` together (`android/app/src/main/java/com/blitterstudio/amiberry/data/FileManager.kt:337`). Carry the display name with the document ID instead of resolving it through another provider query for each leaf.
+
+The folder importer passes the projected name directly into the import path (`android/app/src/main/java/com/blitterstudio/amiberry/data/FileManager.kt:108`). It falls back to the final part of the document ID only when the provider returns a blank name. Individual-file imports can still query `OpenableColumns.DISPLAY_NAME`; the folder path avoids that repeated work.
+
+### Deduplicate directory IDs
+
+Use a queue for pending directories and a visited-ID set for cycle protection. Amiberry skips an ID after its first query (`android/app/src/main/java/com/blitterstudio/amiberry/data/FileManager.kt:394` and `android/app/src/main/java/com/blitterstudio/amiberry/data/FileManager.kt:401`).
+
+Do not assume a provider tree has strict filesystem semantics. Deduplicating IDs prevents repeated queries and guarantees termination if a provider exposes cycles.
+
+### Convert enumeration failures into typed import outcomes
+
+Do not stop at logging. Convert every traversal failure into `ImportResult.Failed` before returning the batch (`android/app/src/main/java/com/blitterstudio/amiberry/data/FileManager.kt:128`).
+
+The feedback layer can then distinguish:
+
+- A genuinely empty tree: no results, reported as no supported files.
+- An unreadable tree: one or more failed results.
+- A partially readable tree: imported or unsupported files plus failed results.
+
+These branches are derived from typed result counts in `ImportBatchFeedback` (`android/app/src/main/java/com/blitterstudio/amiberry/data/ImportBatchFeedback.kt:20`).
+
+### Sanitize provider-controlled names before copying
+
+Treat a provider display name as untrusted input. Normalize it to a leaf name, replace unsafe characters, strip unsafe edge characters, and validate the sanitized extension against the selected file category (`android/app/src/main/java/com/blitterstudio/amiberry/data/FileManager.kt:235` and `android/app/src/main/java/com/blitterstudio/amiberry/data/FileManager.kt:260`).
+
+Keep name handling at the import boundary. Tree enumeration should preserve provider metadata without deciding whether a file is valid for the destination category.
+
+## Why This Matters
+
+A recursive import is correct only when it preserves the difference between "the directory was empty" and "the directory could not be enumerated." Logging a provider failure without returning it changes user-visible semantics: an incomplete scan can appear successful.
+
+Carrying the projected display name also removes an N+1-style metadata lookup without coupling cursor traversal to file copying. Enumeration owns provider metadata, copying owns streams and destination files, and the traversal result is the explicit boundary between them.
+
+Typed outcomes let the existing UI report empty, failed, partial, and successful imports without inferring state from exceptions or log messages.
+
+## When to Apply
+
+- A user selects an Android directory through `OpenDocumentTree`.
+- Files may exist below multiple levels of provider-backed directories.
+- Partial results are useful even if one nested query fails.
+- Provider metadata is needed for filtering, display, or destination naming.
+- The provider may expose duplicate IDs or non-filesystem tree behavior.
+
+## Examples
+
+The traversal regression suite keeps four cases together in `android/app/src/test/java/com/blitterstudio/amiberry/data/DocumentTreeTraversalTest.kt`:
+
+- Nested traversal preserves projected names (`:12`).
+- A null root cursor becomes a failure rather than an empty tree (`:43`).
+- A nested exception keeps previously discovered files and reports partial traversal (`:53`).
+- Duplicate directory IDs are queried once (`:76`).
+
+This session recorded successful runs of the full `:app:testDebugUnitTest` suite, `:app:lintDebug`, and `:app:assembleDebug` for `arm64-v8a` and `x86_64`, plus `git diff --check`. The session did not include a physical-device folder-picker test; device verification should cover an empty folder, nested ROMs, unsupported files, duplicate filenames, and access loss during traversal.
+
+## Related
+
+No existing solution document covered Android SAF tree import when this learning was captured.


### PR DESCRIPTION
## Summary

Android setup is more reliable from ROM selection through emulator launch:

- Users can select a folder once to import supported Kickstart ROMs recursively, with empty, unsupported, failed, and partially successful scans reported distinctly.
- The settings preset control keeps showing the selected preset while the effective settings still match it, and returns to the prompt when later changes diverge.
- Android builds now verify that the checked-in SDL Java shim matches the native SDL release pin, preventing another C/Java version mismatch from reaching an APK.

## Validation

- `:app:testDebugUnitTest`
- `:app:lintDebug`
- `:app:assembleDebug` for `arm64-v8a` and `x86_64`
- `git diff --check`

The folder picker was not exercised on a physical Android device in this session.

## New concepts

### Failure-preserving document-tree traversal

An Android Storage Access Framework tree can yield useful files before one nested directory becomes unreadable. The traversal therefore returns discovered documents and enumeration failures together instead of failing the whole import or silently treating the unreadable branch as empty.

```kotlin
// Preserve usable ROMs while keeping incomplete enumeration visible to the UI.
DocumentTreeTraversal(documents = documents, failures = failures)
```

Each traversal failure becomes a typed import failure, so feedback can distinguish an empty folder from an unreadable or partially readable one. This pattern is useful when partial success has value; it should not be used for operations that must remain transactional.
