### PR TITLE
fix: preserve scaling geometry through filters

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -8,6 +8,16 @@ An Amiberry host-display mode where emulation and the settings GUI reuse one nat
 
 Only one owner presents through the shared window at a time. A transition between the GUI and emulation must restore the next owner's display state and complete any presentation work that cannot safely cross the ownership boundary.
 
+### Presentation rectangle
+
+The host-display region where the emulated frame is finally drawn after aspect correction, scaling, centering, and any active bezel constraint have been resolved.
+
+The presentation rectangle may be smaller than the full drawable area, or may extend beyond it when an unbounded centered mode preserves a requested source size.
+
+### Bezel hole
+
+The transparent screen region inside a custom bezel that can replace the full drawable area as the bounded region for emulated-frame presentation.
+
 ## Touch input
 
 ### Captured joystick gesture

--- a/docs/solutions/performance-issues/presentation-geometry-predicate-ordering.md
+++ b/docs/solutions/performance-issues/presentation-geometry-predicate-ordering.md
@@ -1,0 +1,85 @@
+---
+title: Reducing presentation-geometry helper cost with measured predicate ordering
+date: 2026-07-31
+category: performance-issues
+module: frame presentation geometry
+problem_type: performance_issue
+component: tooling
+symptoms:
+  - The presentation-geometry microbenchmark measured a 2.322099 ns/scenario seven-run median before predicate reordering.
+  - Bounded fallback validated the area and aspect before checking whether an already-fitting presentation needed fallback.
+root_cause: logic_error
+resolution_type: code_fix
+severity: low
+tags: [presentation-geometry, microbenchmark, predicate-ordering, rendering-performance, benchmark-validation]
+---
+
+# Reducing presentation-geometry helper cost with measured predicate ordering
+
+## Problem
+
+[Issue #2246](https://github.com/BlitterStudio/amiberry/issues/2246) reported that enabling a filter could replace the presentation geometry selected by integer scaling. [PR #2250](https://github.com/BlitterStudio/amiberry/pull/2250) makes the selected presentation rectangle authoritative through the filter path. The follow-on task was to reduce the cost of the resulting geometry helpers without changing sizing or positioning.
+
+`amiberry_gfx_final_presentation_rect()` normalizes invalid presentation dimensions, optionally fits an oversized presentation into a valid bounded area, and centers the result (`src/osdep/amiberry_gfx_geometry.h:32`). Because this helper controls visible geometry, a performance change was acceptable only when the focused tests, expected rectangles, and result checksum stayed unchanged.
+
+## Symptoms
+
+The synthetic eight-case benchmark measured a baseline median of **2.322099 ns per scenario** over seven invocations of 100,000,000 iterations. The samples ranged from 2.312088 to 2.336175 ns, with a standard deviation of 0.007615 ns.
+
+The checked-in benchmark emits one timed sample per invocation. It performs a fixed warm-up, times one `run_scenarios()` call, and emits JSON with the timing, gates, checksum, and scenario count (`tests/gfx_geometry_benchmark.cpp:83`). The optimization workflow supplied the seven-run repetition and median aggregation.
+
+The benchmark rotates through exactly eight fixed presentation cases with `& 7` (`tests/gfx_geometry_benchmark.cpp:21`, `tests/gfx_geometry_benchmark.cpp:65`). Three cases enable bounded fallback: one already fits and benefits from the early-false oversize check, while two are oversized. Invalid bounded inputs are covered by focused tests rather than the timed mix. This is useful for stable commit-to-commit comparison, but it is not a production profile of Amiberry sessions.
+
+## What Didn't Work
+
+Three plausible changes were measured and reverted:
+
+| Attempt | Median | Result |
+|---------|--------|--------|
+| Pass the 16-byte rectangle inputs by value | 2.355136 ns | Slower than the 2.322099 ns baseline and noisier. This run did not demonstrate a benefit over the inlined `const` references. |
+| Combine coverage comparisons eagerly for branchless evaluation | 3.322754 ns | Much slower. It forced all edge calculations and widened arithmetic instead of retaining short-circuit evaluation. |
+| Add a zero-origin coverage fast path | 2.369229 ns | Slower than the current best and too noisy for a strong causal claim. The result was consistent with extra dispatch offsetting the two avoided additions. |
+
+All three variants still passed the output gates and retained checksum 4260610592. Correctness gates therefore prevented regressions, but measurement was still required to choose a performance change.
+
+## Solution
+
+Keep the change small: after `use_bounded_fallback`, test whether the presentation is oversized before validating the bounded area's width, height, and aspect (`src/osdep/amiberry_gfx_geometry.h:40`).
+
+```cpp
+if (use_bounded_fallback
+	&& (width > available_area.w || height > available_area.h)
+	&& available_area.w > 0 && available_area.h > 0
+	&& fallback_aspect > 0.0f) {
+	// Fit the oversized presentation into the bounded area.
+}
+```
+
+For a bounded presentation that already fits, the oversize expression is false and short-circuits the remaining three validity comparisons. The benchmark includes this path as well as oversized fallback paths (`tests/gfx_geometry_benchmark.cpp:26`).
+
+The reordered predicate reduced the seven-run median to **2.193232 ns per scenario**, an improvement of **0.128867 ns or 5.55%** for that sample set. The seven samples ranged from 2.180707 to 2.220078 ns, with a standard deviation of 0.013738 ns. Expected rectangles, the focused tests, and checksum 4260610592 remained unchanged.
+
+A later single-run validation measured 2.281184 ns per scenario. It remained faster than the baseline median, but the difference from the accepted median shows environmental drift. Baseline and candidate runs were serial rather than interleaved, so the 5.55% result should not be treated as universally reproducible.
+
+The benchmark entry point compiles and runs the focused regression test before building the optimized benchmark with warnings treated as errors (`tests/benchmark_gfx_geometry.sh:15`). Review also added focused cases proving that zero-width, negative-height, and non-positive-aspect bounded inputs keep the requested presentation size (`tests/gfx_geometry_test.cpp:193`).
+
+## Why This Works
+
+The conjunction's meaning is unchanged. Bounded fitting still requires bounded mode, an oversized presentation, positive available dimensions, and a positive fallback aspect (`src/osdep/amiberry_gfx_geometry.h:40`). These operands are side-effect-free comparisons, so reordering them changes only where evaluation can stop.
+
+When every predicate passes, the same aspect-fit helper computes the bounded dimensions. Otherwise, the same normalized dimensions are centered (`src/osdep/amiberry_gfx_geometry.h:44`, `src/osdep/amiberry_gfx_geometry.h:48`). Reference rectangles are checked before timing, and each timed run emits a checksum for external comparison (`tests/gfx_geometry_benchmark.cpp:47`, `tests/gfx_geometry_benchmark.cpp:63`). The checksum is an aggregate regression signal for this fixed input set, not proof of equivalence for every possible rectangle.
+
+## Prevention
+
+- Preserve the fixed eight-case cycle when comparing commits. Changing the scenario mix changes the meaning of the primary metric.
+- Treat the cycle as a synthetic microbenchmark, not as evidence of production workload frequency.
+- Repeat the one-sample harness externally and compare medians. Retain the raw samples and spread with the optimization decision. When practical, alternate baseline and candidate runs under pinned CPU-frequency conditions to reduce drift.
+- Keep focused tests and reference-output checks coupled to performance measurements, and retain the emitted checksum for external comparison (`tests/benchmark_gfx_geometry.sh:15`, `tests/gfx_geometry_benchmark.cpp:47`).
+- Retain invalid-input tests whenever predicate order changes; they protect guards that may move later in a short-circuit expression (`tests/gfx_geometry_test.cpp:193`).
+- Measure compiler-oriented ideas. By-value inputs, eager branchless evaluation, and common-case specialization all appeared plausible but regressed this workload.
+
+## Related Issues
+
+- [Issue #2246](https://github.com/BlitterStudio/amiberry/issues/2246) is the filter and overlay scaling report that motivated the presentation-geometry work.
+- [PR #2250](https://github.com/BlitterStudio/amiberry/pull/2250) contains the functional fix. It was open and unmerged as of 2026-07-31.
+- [Issue #1862](https://github.com/BlitterStudio/amiberry/issues/1862) provides earlier integer-scaling correctness context.

--- a/src/osdep/amiberry_gfx_geometry.h
+++ b/src/osdep/amiberry_gfx_geometry.h
@@ -37,9 +37,10 @@ static inline AmiberryGfxRect amiberry_gfx_final_presentation_rect(
 	int width = presentation_width > 0 ? presentation_width : 1;
 	int height = presentation_height > 0 ? presentation_height : 1;
 
-	if (use_bounded_fallback && available_area.w > 0 && available_area.h > 0
-		&& fallback_aspect > 0.0f
-		&& (width > available_area.w || height > available_area.h)) {
+	if (use_bounded_fallback
+		&& (width > available_area.w || height > available_area.h)
+		&& available_area.w > 0 && available_area.h > 0
+		&& fallback_aspect > 0.0f) {
 		amiberry_gfx_aspect_fit_dimensions(
 			available_area.w, available_area.h, fallback_aspect, width, height);
 	}

--- a/src/osdep/amiberry_gfx_geometry.h
+++ b/src/osdep/amiberry_gfx_geometry.h
@@ -1,6 +1,57 @@
 #ifndef AMIBERRY_GFX_GEOMETRY_H
 #define AMIBERRY_GFX_GEOMETRY_H
 
+struct AmiberryGfxRect
+{
+	int x;
+	int y;
+	int w;
+	int h;
+};
+
+static inline void amiberry_gfx_aspect_fit_dimensions(
+	const int available_width, const int available_height,
+	const float target_aspect, int& width, int& height)
+{
+	if (available_width <= 0 || available_height <= 0 || target_aspect <= 0.0f) {
+		width = 1;
+		height = 1;
+		return;
+	}
+
+	width = available_width;
+	height = static_cast<int>(available_width / target_aspect);
+	if (height > available_height) {
+		height = available_height;
+		width = static_cast<int>(available_height * target_aspect);
+	}
+	if (width < 1) width = 1;
+	if (height < 1) height = 1;
+}
+
+static inline AmiberryGfxRect amiberry_gfx_final_presentation_rect(
+	const AmiberryGfxRect& available_area, const int presentation_width,
+	const int presentation_height, const float fallback_aspect,
+	const bool use_bounded_fallback)
+{
+	int width = presentation_width > 0 ? presentation_width : 1;
+	int height = presentation_height > 0 ? presentation_height : 1;
+
+	if (use_bounded_fallback && available_area.w > 0 && available_area.h > 0
+		&& fallback_aspect > 0.0f
+		&& (width > available_area.w || height > available_area.h)) {
+		amiberry_gfx_aspect_fit_dimensions(
+			available_area.w, available_area.h, fallback_aspect, width, height);
+	}
+
+	return {
+		available_area.x + (available_area.w - width) / 2,
+		available_area.y + (available_area.h - height) / 2,
+		width,
+		height
+	};
+}
+
 static inline void amiberry_gfx_auto_crop_presentation_dimensions(
 	int source_width, int source_height, bool is_ntsc, bool correct_aspect,
 	bool integer_scaling, int output_width, int output_height,
@@ -66,14 +117,8 @@ static inline void amiberry_gfx_correct_aspect_integer_dimensions(
 
 	// Start with a bounded aspect-correct fit. If even 1x integer scaling does
 	// not fit, retain this fractional fallback instead of clipping the viewport.
-	dest_width = render_width;
-	dest_height = static_cast<int>(render_width / target_aspect);
-	if (dest_height > render_height) {
-		dest_height = render_height;
-		dest_width = static_cast<int>(render_height * target_aspect);
-	}
-	if (dest_width < 1) dest_width = 1;
-	if (dest_height < 1) dest_height = 1;
+	amiberry_gfx_aspect_fit_dimensions(
+		render_width, render_height, target_aspect, dest_width, dest_height);
 
 	const int vertical_scale = dest_height / display_height;
 	if (vertical_scale < 1 || source_width > render_width) {

--- a/src/osdep/amiberry_gfx_geometry.h
+++ b/src/osdep/amiberry_gfx_geometry.h
@@ -52,6 +52,14 @@ static inline AmiberryGfxRect amiberry_gfx_final_presentation_rect(
 	};
 }
 
+static inline bool amiberry_gfx_rect_covers_area(
+	const AmiberryGfxRect& rect, const AmiberryGfxRect& area)
+{
+	return rect.x <= area.x && rect.y <= area.y
+		&& rect.x + rect.w >= area.x + area.w
+		&& rect.y + rect.h >= area.y + area.h;
+}
+
 static inline void amiberry_gfx_auto_crop_presentation_dimensions(
 	int source_width, int source_height, bool is_ntsc, bool correct_aspect,
 	bool integer_scaling, int output_width, int output_height,

--- a/src/osdep/imgui/play.cpp
+++ b/src/osdep/imgui/play.cpp
@@ -19,6 +19,7 @@
 #include "play_content_detection.h"
 #include "play_setup.h"
 #include "rommgr.h"
+#include "shader_catalog.h"
 #include "target.h"
 
 namespace {
@@ -36,22 +37,6 @@ int quickstart_override_model = 0;
 int quickstart_override_conf = 0;
 int quickstart_override_compa = 0;
 std::string applied_config_summary;
-
-const char* shader_choice_name(const PlayShaderChoice choice)
-{
-	switch (choice) {
-	case PlayShaderChoice::None:
-		return "none";
-	case PlayShaderChoice::Crt:
-		return "tv";
-	case PlayShaderChoice::Monitor1084:
-		return "1084";
-	case PlayShaderChoice::Custom:
-		return nullptr;
-	}
-
-	return "none";
-}
 
 const char* follow_up_text(const PlayFollowUp follow_up)
 {
@@ -143,21 +128,8 @@ void initialize_display_defaults()
 		break;
 	}
 
-	const auto is_custom_shader = [](const char* shader) {
-		return shader[0] != '\0' &&
-			strcmp(shader, "none") != 0 &&
-			strcmp(shader, "tv") != 0 &&
-			strcmp(shader, "1084") != 0;
-	};
-
-	if (is_custom_shader(changed_prefs.shader) || is_custom_shader(changed_prefs.shader_rtg))
-		display_defaults.shader = PlayShaderChoice::Custom;
-	else if (strcmp(changed_prefs.shader, "1084") == 0)
-		display_defaults.shader = PlayShaderChoice::Monitor1084;
-	else if (strcmp(changed_prefs.shader, "tv") == 0)
-		display_defaults.shader = PlayShaderChoice::Crt;
-	else
-		display_defaults.shader = PlayShaderChoice::None;
+	const char* native_shader = changed_prefs.shader[0] ? changed_prefs.shader : "none";
+	display_defaults.shader = native_shader;
 
 	display_defaults.auto_crop = changed_prefs.gfx_auto_crop;
 	display_defaults_initialized = true;
@@ -185,11 +157,7 @@ void apply_display_defaults_to_changed_prefs()
 	if (changed_prefs.gfx_auto_crop)
 		changed_prefs.gfx_manual_crop = false;
 
-	if (!prefs.preserve_shader) {
-		const char* shader = shader_choice_name(display_defaults.shader);
-		copy_shader_name(changed_prefs.shader, sizeof changed_prefs.shader, shader);
-		copy_shader_name(changed_prefs.shader_rtg, sizeof changed_prefs.shader_rtg, shader);
-	}
+	copy_shader_name(changed_prefs.shader, sizeof changed_prefs.shader, prefs.shader.c_str());
 }
 
 void save_display_defaults()
@@ -201,14 +169,7 @@ void save_display_defaults()
 	amiberry_options.default_gfx_autoresolution = prefs.gfx_autoresolution;
 	amiberry_options.default_auto_crop = prefs.gfx_auto_crop;
 
-	if (prefs.preserve_shader) {
-		copy_shader_name(amiberry_options.shader, sizeof amiberry_options.shader, changed_prefs.shader);
-		copy_shader_name(amiberry_options.shader_rtg, sizeof amiberry_options.shader_rtg, changed_prefs.shader_rtg);
-	} else {
-		const char* shader = shader_choice_name(display_defaults.shader);
-		copy_shader_name(amiberry_options.shader, sizeof amiberry_options.shader, shader);
-		copy_shader_name(amiberry_options.shader_rtg, sizeof amiberry_options.shader_rtg, shader);
-	}
+	copy_shader_name(amiberry_options.shader, sizeof amiberry_options.shader, prefs.shader.c_str());
 
 	save_amiberry_settings();
 }
@@ -761,13 +722,37 @@ bool render_combo(const char* label, int* value, const char* const* items, const
 	return changed;
 }
 
+bool render_shader_combo(std::string& value, const std::vector<std::string>& items)
+{
+	bool changed = false;
+	ImGui::AlignTextToFramePadding();
+	ImGui::TextUnformatted("Shader:");
+	ImGui::SameLine(BUTTON_WIDTH * 1.5f);
+	ImGui::SetNextItemWidth(BUTTON_WIDTH * 1.5f);
+	if (ImGui::BeginCombo("##Shader:", value.c_str())) {
+		for (const auto& item : items) {
+			const bool selected = value == item;
+			if (ImGui::Selectable(item.c_str(), selected)) {
+				value = item;
+				changed = true;
+			}
+			if (selected)
+				ImGui::SetItemDefaultFocus();
+		}
+		ImGui::EndCombo();
+	}
+	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActive());
+	ImGui::Spacing();
+	return changed;
+}
+
 void render_display_defaults()
 {
 	initialize_display_defaults();
 
 	static const char* screen_items[] = { "Windowed", "Full-window" };
 	static const char* scaling_items[] = { "Auto", "Integer", "Smooth" };
-	static const char* shader_items[] = { "None", "CRT", "1084", "Custom" };
+	const auto& shader_items = get_available_shader_names();
 
 	if (kmsdrm_detected)
 		display_defaults.screen_mode = PlayScreenMode::FullWindow;
@@ -800,13 +785,11 @@ void render_display_defaults()
 		apply_display_defaults_to_changed_prefs();
 	ShowHelpMarker("Automatically crop black borders from the display.");
 
-	int shader = static_cast<int>(display_defaults.shader);
-	if (render_combo("Shader:", &shader, shader_items, IM_ARRAYSIZE(shader_items))) {
-		display_defaults.shader = static_cast<PlayShaderChoice>(shader);
+	if (render_shader_combo(display_defaults.shader, shader_items)) {
 		apply_display_defaults_to_changed_prefs();
 	}
-	ShowHelpMarker("This Play choice is applied after content auto-configuration, including WHDLoad. "
-		"Custom preserves the native and RTG shader names selected in Display or Global Settings.");
+	ShowHelpMarker("Uses the same shader list as Filter's Native Display Shader. This Play choice is "
+		"applied after content auto-configuration, including WHDLoad. The RTG shader is unchanged.");
 
 	ImGui::Spacing();
 	if (AmigaButton("Apply now", ImVec2(BUTTON_WIDTH * 1.2f, BUTTON_HEIGHT)))

--- a/src/osdep/imgui/play_setup.cpp
+++ b/src/osdep/imgui/play_setup.cpp
@@ -17,22 +17,6 @@ static int screen_mode_to_fullscreen(const PlayScreenMode mode)
 	return GFX_WINDOW;
 }
 
-static int shader_choice_to_prefs(const PlayShaderChoice choice)
-{
-	switch (choice) {
-	case PlayShaderChoice::None:
-		return 0;
-	case PlayShaderChoice::Crt:
-		return 1;
-	case PlayShaderChoice::Monitor1084:
-		return 2;
-	case PlayShaderChoice::Custom:
-		return -1;
-	}
-
-	return 0;
-}
-
 void play_apply_display_defaults(const PlayDisplayDefaults& defaults, PlayDisplayPrefs& prefs)
 {
 	const auto fullscreen = screen_mode_to_fullscreen(defaults.screen_mode);
@@ -54,8 +38,7 @@ void play_apply_display_defaults(const PlayDisplayDefaults& defaults, PlayDispla
 		break;
 	}
 
-	prefs.shader_choice = shader_choice_to_prefs(defaults.shader);
-	prefs.preserve_shader = defaults.shader == PlayShaderChoice::Custom;
+	prefs.shader = defaults.shader.empty() ? "none" : defaults.shader;
 	prefs.gfx_auto_crop = defaults.auto_crop;
 }
 

--- a/src/osdep/imgui/play_setup.h
+++ b/src/osdep/imgui/play_setup.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "amiberry_gfx_mode.h"
 
 enum class PlayScreenMode
@@ -15,19 +17,11 @@ enum class PlayScalingMode
 	Smooth
 };
 
-enum class PlayShaderChoice
-{
-	None,
-	Crt,
-	Monitor1084,
-	Custom
-};
-
 struct PlayDisplayDefaults
 {
 	PlayScreenMode screen_mode = PlayScreenMode::Windowed;
 	PlayScalingMode scaling = PlayScalingMode::Auto;
-	PlayShaderChoice shader = PlayShaderChoice::None;
+	std::string shader = "none";
 	bool auto_crop = false;
 };
 
@@ -37,8 +31,7 @@ struct PlayDisplayPrefs
 	int rtg_fullscreen = 0;
 	int scaling_method = -1;
 	int gfx_autoresolution = 0;
-	int shader_choice = static_cast<int>(PlayShaderChoice::None);
-	bool preserve_shader = false;
+	std::string shader = "none";
 	bool gfx_auto_crop = false;
 };
 

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -633,12 +633,14 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 	// that all shader paths use instead of the full drawable.
 	int renderAreaX = 0, renderAreaY = 0;
 	int renderAreaW = drawableWidth, renderAreaH = drawableHeight;
+	bool has_bounded_bezel_area = false;
 
 	if (filter_prefs.use_custom_bezel && m_overlay.bezel_texture != 0 && m_overlay.bezel_hole_w > 0.0f && m_overlay.bezel_hole_h > 0.0f) {
 		renderAreaX = bezelDisplayX + static_cast<int>(m_overlay.bezel_hole_x * bezelDisplayW);
 		renderAreaY = bezelDisplayY + static_cast<int>(m_overlay.bezel_hole_y * bezelDisplayH);
 		renderAreaW = static_cast<int>(m_overlay.bezel_hole_w * bezelDisplayW);
 		renderAreaH = static_cast<int>(m_overlay.bezel_hole_h * bezelDisplayH);
+		has_bounded_bezel_area = true;
 	}
 
 	// Compute source dimensions early (needed for integer scaling)
@@ -668,30 +670,14 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 	bool use_center = mon->screen_is_picasso
 		&& mon->scalepicasso == RTG_MODE_CENTER;
 
-	int destW, destH, destX, destY;
+	int destW, destH;
 
-	if (renderAreaX != 0 || renderAreaY != 0 ||
-		renderAreaW != drawableWidth || renderAreaH != drawableHeight) {
-		destW = renderAreaW;
-		destH = renderAreaH;
-		destX = renderAreaX;
-		destY = renderAreaY;
-	} else if (use_center && src_w > 0 && src_h > 0) {
+	if (use_center && src_w > 0 && src_h > 0) {
 		destW = src_w;
 		destH = src_h;
-		destX = (renderAreaW - destW) / 2;
-		destY = (renderAreaH - destH) / 2;
 	} else {
-		destW = renderAreaW;
-		destH = static_cast<int>(renderAreaW / desired_aspect);
-
-		if (destH > renderAreaH) {
-			destH = renderAreaH;
-			destW = static_cast<int>(renderAreaH * desired_aspect);
-		}
-
-		if (destW <= 0) destW = 1;
-		if (destH <= 0) destH = 1;
+		amiberry_gfx_aspect_fit_dimensions(
+			renderAreaW, renderAreaH, desired_aspect, destW, destH);
 
 		if (use_integer_scaling && src_w > 0 && src_h > 0) {
 			// Use the aspect-corrected dimensions from auto_crop_image()
@@ -724,51 +710,58 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 			}
 		}
 
-		destX = (renderAreaW - destW) / 2;
-		destY = (renderAreaH - destH) / 2;
 	}
 
+	const AmiberryGfxRect available_area{
+		renderAreaX, renderAreaY, renderAreaW, renderAreaH
+	};
+	const float bounded_fallback_aspect = use_integer_scaling
+		&& !mon->screen_is_picasso && currprefs.gfx_correct_aspect
+		? integer_target_aspect : desired_aspect;
+	const AmiberryGfxRect final_rect = amiberry_gfx_final_presentation_rect(
+		available_area, destW, destH, bounded_fallback_aspect,
+		has_bounded_bezel_area && use_integer_scaling && !use_center);
+
 	// Flip Y for GL viewport: OpenGL has y=0 at bottom, bezel hole Y is y=0 at top
-	int glDestY = drawableHeight - destY - destH;
-	int glAreaY = drawableHeight - renderAreaY - renderAreaH;
+	const int glDestY = drawableHeight - final_rect.y - final_rect.h;
 
 	// Only clear if letterboxing is active (frame doesn't cover entire window)
-	if (destW < drawableWidth || destH < drawableHeight) {
+	if (final_rect.w < drawableWidth || final_rect.h < drawableHeight) {
 		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
 	}
 
-	glViewport(destX, glDestY, destW, destH);
+	glViewport(final_rect.x, glDestY, final_rect.w, final_rect.h);
 
 	// Update render_quad to reflect the actual drawn area
-	render_quad.x = destX;
-	render_quad.y = destY;
-	render_quad.w = destW;
-	render_quad.h = destH;
+	render_quad.x = final_rect.x;
+	render_quad.y = final_rect.y;
+	render_quad.w = final_rect.w;
+	render_quad.h = final_rect.h;
 
 	// Some CRT shaders require an output at least as large as their input. Render
 	// them at that safe size, then resolve back to the aspect-correct destination
 	// instead of letting the oversized viewport be clipped by the framebuffer.
-	int shader_viewport_w = destW;
-	int shader_viewport_h = destH;
+	int shader_viewport_w = final_rect.w;
+	int shader_viewport_h = final_rect.h;
 	amiberry_gfx_shader_render_dimensions(
-		destW, destH, src_w, src_h, shader_viewport_w, shader_viewport_h);
+		final_rect.w, final_rect.h, src_w, src_h, shader_viewport_w, shader_viewport_h);
 	const bool custom_shader_active = (m_shader.preset && m_shader.preset->is_valid())
 		|| (m_shader.external && m_shader.external->is_valid());
 	bool use_shader_resolve = custom_shader_active
-		&& (shader_viewport_w != destW || shader_viewport_h != destH);
+		&& (shader_viewport_w != final_rect.w || shader_viewport_h != final_rect.h);
 	if (use_shader_resolve
 		&& !ensure_shader_resolve_target(shader_viewport_w, shader_viewport_h)) {
 		// Preserve final presentation geometry if the intermediate target cannot
 		// be allocated, even though shaders that require >= 1x may degrade.
-		shader_viewport_w = destW;
-		shader_viewport_h = destH;
+		shader_viewport_w = final_rect.w;
+		shader_viewport_h = final_rect.h;
 		use_shader_resolve = false;
 	}
 	const int shader_viewport_x = use_shader_resolve
-		? 0 : renderAreaX + (renderAreaW - shader_viewport_w) / 2;
+		? 0 : final_rect.x;
 	const int shader_viewport_y = use_shader_resolve
-		? 0 : glAreaY + (renderAreaH - shader_viewport_h) / 2;
+		? 0 : glDestY;
 	const GLuint shader_framebuffer = use_shader_resolve
 		? m_shader.resolve_framebuffer : 0;
 	if (use_shader_resolve) {
@@ -833,13 +826,10 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 		glDisableVertexAttribArray(1);
 		glDisableVertexAttribArray(2);
 
-		// When a custom bezel defines the viewport, skip crtemu's internal 4:3 letterboxing
-		m_shader.crtemu->skip_aspect_correction = (renderAreaW != drawableWidth || renderAreaH != drawableHeight);
+		// Presentation geometry is already final. CRTEMU may change pixels, but it
+		// must fill this viewport without applying another aspect correction.
+		m_shader.crtemu->skip_aspect_correction = true;
 		m_shader.crtemu->desired_aspect = desired_aspect;
-
-		if (m_shader.crtemu->type != CRTEMU_TYPE_NONE) {
-			glViewport(renderAreaX, glAreaY, renderAreaW, renderAreaH);
-		}
 
 		if (is_cropped && surface) {
 			uae_u8* crop_ptr = static_cast<uae_u8*>(surface->pixels) + (crop_y * surface->pitch) + (crop_x * m_gl_format.bpp);
@@ -853,13 +843,13 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 	}
 
 	if (use_shader_resolve) {
-		render_shader_resolve(destX, glDestY, destW, destH);
+		render_shader_resolve(final_rect.x, glDestY, final_rect.w, final_rect.h);
 	}
 
-	render_software_cursor(monid, destX, glDestY, destW, destH);
+	render_software_cursor(monid, final_rect.x, glDestY, final_rect.w, final_rect.h);
 	int glBezelY = drawableHeight - bezelDisplayY - bezelDisplayH;
 	render_bezel(bezelDisplayX, glBezelY, bezelDisplayW, bezelDisplayH);
-	render_osd(monid, destX, glDestY, destW, destH);
+	render_osd(monid, final_rect.x, glDestY, final_rect.w, final_rect.h);
 
 	render_vkbd(monid);
 	render_onscreen_joystick(monid);

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -725,8 +725,9 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 	// Flip Y for GL viewport: OpenGL has y=0 at bottom, bezel hole Y is y=0 at top
 	const int glDestY = drawableHeight - final_rect.y - final_rect.h;
 
-	// Only clear if letterboxing is active (frame doesn't cover entire window)
-	if (final_rect.w < drawableWidth || final_rect.h < drawableHeight) {
+	// Clear whenever the presentation leaves any part of the drawable uncovered.
+	const AmiberryGfxRect drawable_area{0, 0, drawableWidth, drawableHeight};
+	if (!amiberry_gfx_rect_covers_area(final_rect, drawable_area)) {
 		glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT);
 	}

--- a/tests/benchmark_gfx_geometry.sh
+++ b/tests/benchmark_gfx_geometry.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+cxx=${CXX:-c++}
+iterations=${GFX_GEOMETRY_BENCH_ITERATIONS:-100000000}
+test_out="${TMPDIR:-/tmp}/gfx_geometry_test.$$"
+benchmark_out="${TMPDIR:-/tmp}/gfx_geometry_benchmark.$$"
+trap 'rm -f "$test_out" "$benchmark_out"' EXIT
+
+failure_json()
+{
+	printf '%s\n' '{"geometry_ns_per_scenario":1e30,"focused_tests_passed":'$1',"reference_outputs_match":0,"result_checksum":0,"timed_scenarios":0}'
+}
+
+if ! "$cxx" -std=c++17 -Wall -Wextra -Werror -Isrc/osdep \
+	-o "$test_out" tests/gfx_geometry_test.cpp; then
+	failure_json 0
+	exit 0
+fi
+
+if ! "$test_out"; then
+	failure_json 0
+	exit 0
+fi
+
+if ! "$cxx" -std=c++17 -O3 -DNDEBUG -march=native -Wall -Wextra -Werror \
+	-Isrc/osdep -o "$benchmark_out" tests/gfx_geometry_benchmark.cpp; then
+	failure_json 1
+	exit 0
+fi
+
+"$benchmark_out" "$iterations" 37

--- a/tests/gfx_geometry_benchmark.cpp
+++ b/tests/gfx_geometry_benchmark.cpp
@@ -1,0 +1,109 @@
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+
+#include "amiberry_gfx_geometry.h"
+
+struct PresentationScenario
+{
+	AmiberryGfxRect available_area;
+	int presentation_width;
+	int presentation_height;
+	float fallback_aspect;
+	bool use_bounded_fallback;
+	AmiberryGfxRect drawable_area;
+	AmiberryGfxRect expected_rect;
+	bool expected_covers_drawable;
+};
+
+static constexpr PresentationScenario scenarios[] = {
+	{{0, 0, 1920, 1080}, 1440, 1080, 4.0f / 3.0f, false,
+		{0, 0, 1920, 1080}, {240, 0, 1440, 1080}, false},
+	{{0, 0, 1920, 1080}, 1280, 800, 640.0f / 400.0f, false,
+		{0, 0, 1920, 1080}, {320, 140, 1280, 800}, false},
+	{{100, 50, 1000, 700}, 640, 480, 4.0f / 3.0f, true,
+		{0, 0, 1920, 1080}, {280, 160, 640, 480}, false},
+	{{100, 50, 300, 180}, 640, 400, 640.0f / 400.0f, true,
+		{0, 0, 1920, 1080}, {106, 50, 288, 180}, false},
+	{{250, 120, 640, 480}, 800, 600, 4.0f / 3.0f, false,
+		{0, 0, 1920, 1080}, {170, 60, 800, 600}, false},
+	{{0, 0, 1920, 1080}, 2000, 1200, 5.0f / 3.0f, false,
+		{0, 0, 1920, 1080}, {-40, -60, 2000, 1200}, true},
+	{{250, 120, 640, 480}, 2000, 1200, 5.0f / 3.0f, false,
+		{0, 0, 1920, 1080}, {-430, -240, 2000, 1200}, false},
+	{{10, 20, 300, 500}, 1000, 1000, 4.0f / 3.0f, true,
+		{0, 0, 320, 540}, {10, 157, 300, 225}, false},
+};
+
+static volatile std::uint32_t benchmark_sink;
+
+static bool rect_equals(const AmiberryGfxRect& lhs, const AmiberryGfxRect& rhs)
+{
+	return lhs.x == rhs.x && lhs.y == rhs.y && lhs.w == rhs.w && lhs.h == rhs.h;
+}
+
+static bool reference_outputs_match()
+{
+	for (const auto& scenario : scenarios) {
+		const AmiberryGfxRect rect = amiberry_gfx_final_presentation_rect(
+			scenario.available_area, scenario.presentation_width,
+			scenario.presentation_height, scenario.fallback_aspect,
+			scenario.use_bounded_fallback);
+		if (!rect_equals(rect, scenario.expected_rect)
+			|| amiberry_gfx_rect_covers_area(rect, scenario.drawable_area)
+				!= scenario.expected_covers_drawable) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static std::uint32_t run_scenarios(const std::uint64_t iterations, const std::uint64_t offset)
+{
+	std::uint32_t checksum = 0;
+	for (std::uint64_t iteration = 0; iteration < iterations; iteration++) {
+		const auto& scenario = scenarios[(iteration + offset) & 7];
+		const AmiberryGfxRect rect = amiberry_gfx_final_presentation_rect(
+			scenario.available_area, scenario.presentation_width,
+			scenario.presentation_height, scenario.fallback_aspect,
+			scenario.use_bounded_fallback);
+		const bool covers_drawable = amiberry_gfx_rect_covers_area(
+			rect, scenario.drawable_area);
+		checksum += static_cast<std::uint32_t>(rect.x)
+			+ static_cast<std::uint32_t>(rect.y) * 3U
+			+ static_cast<std::uint32_t>(rect.w) * 5U
+			+ static_cast<std::uint32_t>(rect.h) * 7U
+			+ static_cast<std::uint32_t>(covers_drawable);
+	}
+	return checksum;
+}
+
+int main(const int argc, char* argv[])
+{
+	const std::uint64_t iterations = argc > 1
+		? std::strtoull(argv[1], nullptr, 10) : 100000000ULL;
+	const std::uint64_t offset = argc > 2
+		? std::strtoull(argv[2], nullptr, 10) : 37ULL;
+	const bool outputs_match = reference_outputs_match();
+
+	benchmark_sink = run_scenarios(1000000ULL, offset);
+	const auto started_at = std::chrono::steady_clock::now();
+	const std::uint32_t checksum = run_scenarios(iterations, offset);
+	const auto finished_at = std::chrono::steady_clock::now();
+	benchmark_sink = checksum;
+
+	const double elapsed_ns = std::chrono::duration<double, std::nano>(
+		finished_at - started_at).count();
+	const double ns_per_scenario = iterations > 0
+		? elapsed_ns / static_cast<double>(iterations) : 0.0;
+
+	std::cout << std::fixed << std::setprecision(6)
+		<< "{\"geometry_ns_per_scenario\":" << ns_per_scenario
+		<< ",\"focused_tests_passed\":1"
+		<< ",\"reference_outputs_match\":" << (outputs_match ? 1 : 0)
+		<< ",\"result_checksum\":" << checksum
+		<< ",\"timed_scenarios\":" << iterations << "}\n";
+	return 0;
+}

--- a/tests/gfx_geometry_test.cpp
+++ b/tests/gfx_geometry_test.cpp
@@ -129,6 +129,67 @@ static void test_shader_render_size_resolves_to_compensated_viewport()
 		"shader rendering must keep a sufficiently large destination height");
 }
 
+static void expect_rect_eq(const AmiberryGfxRect& actual,
+	const int x, const int y, const int w, const int h, const char* message)
+{
+	expect_int_eq(actual.x, x, message);
+	expect_int_eq(actual.y, y, message);
+	expect_int_eq(actual.w, w, message);
+	expect_int_eq(actual.h, h, message);
+}
+
+static void test_full_drawable_presentation_geometry_is_unchanged()
+{
+	const AmiberryGfxRect available_area{0, 0, 1920, 1080};
+	int aspect_width = 0;
+	int aspect_height = 0;
+	amiberry_gfx_aspect_fit_dimensions(
+		available_area.w, available_area.h, 4.0f / 3.0f,
+		aspect_width, aspect_height);
+	const AmiberryGfxRect aspect_fit = amiberry_gfx_final_presentation_rect(
+		available_area, aspect_width, aspect_height, 4.0f / 3.0f, false);
+	expect_rect_eq(aspect_fit, 240, 0, 1440, 1080,
+		"full-drawable aspect fit must remain centered");
+
+	const int scale = amiberry_gfx_native_integer_scale(1920, 1080, 640, 400);
+	const AmiberryGfxRect integer_scaled = amiberry_gfx_final_presentation_rect(
+		available_area, 640 * scale, 400 * scale, 640.0f / 400.0f, false);
+	expect_rect_eq(integer_scaled, 320, 140, 1280, 800,
+		"full-drawable integer scaling must retain its whole-number size");
+}
+
+static void test_bezel_area_centers_integer_scaled_presentation()
+{
+	const AmiberryGfxRect available_area{100, 50, 1000, 700};
+	const int scale = amiberry_gfx_native_integer_scale(
+		available_area.w, available_area.h, 320, 240);
+	const AmiberryGfxRect final_rect = amiberry_gfx_final_presentation_rect(
+		available_area, 320 * scale, 240 * scale, 4.0f / 3.0f, true);
+
+	expect_rect_eq(final_rect, 280, 160, 640, 480,
+		"integer-scaled presentation must be centered within the bezel hole origin");
+}
+
+static void test_rtg_center_remains_source_sized_inside_bezel_area()
+{
+	const AmiberryGfxRect available_area{250, 120, 640, 480};
+	const AmiberryGfxRect final_rect = amiberry_gfx_final_presentation_rect(
+		available_area, 800, 600, 4.0f / 3.0f, false);
+
+	expect_rect_eq(final_rect, 170, 60, 800, 600,
+		"RTG Center must remain source-sized even when it exceeds the bezel hole");
+}
+
+static void test_bezel_bounded_integer_scaling_falls_back_below_one_x()
+{
+	const AmiberryGfxRect available_area{100, 50, 300, 180};
+	const AmiberryGfxRect final_rect = amiberry_gfx_final_presentation_rect(
+		available_area, 640, 400, 640.0f / 400.0f, true);
+
+	expect_rect_eq(final_rect, 106, 50, 288, 180,
+		"sub-1x integer scaling must use a centered fractional aspect fit inside the bezel hole");
+}
+
 int main()
 {
 	test_ntsc_integer_scaling_without_aspect_uses_crop_geometry();
@@ -137,5 +198,9 @@ int main()
 	test_exclusive_fullscreen_compensates_for_display_mode_stretch();
 	test_corrected_integer_scaling_stays_within_fullscreen_mode();
 	test_shader_render_size_resolves_to_compensated_viewport();
+	test_full_drawable_presentation_geometry_is_unchanged();
+	test_bezel_area_centers_integer_scaled_presentation();
+	test_rtg_center_remains_source_sized_inside_bezel_area();
+	test_bezel_bounded_integer_scaling_falls_back_below_one_x();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/gfx_geometry_test.cpp
+++ b/tests/gfx_geometry_test.cpp
@@ -190,6 +190,27 @@ static void test_bezel_bounded_integer_scaling_falls_back_below_one_x()
 		"sub-1x integer scaling must use a centered fractional aspect fit inside the bezel hole");
 }
 
+static void test_oversized_centered_presentation_covers_drawable()
+{
+	const AmiberryGfxRect drawable_area{0, 0, 1920, 1080};
+	const AmiberryGfxRect final_rect = amiberry_gfx_final_presentation_rect(
+		drawable_area, 2000, 1200, 5.0f / 3.0f, false);
+
+	expect_int_eq(amiberry_gfx_rect_covers_area(final_rect, drawable_area), 1,
+		"an oversized presentation centered on the drawable must cover every edge");
+}
+
+static void test_oversized_offset_presentation_leaves_drawable_uncovered()
+{
+	const AmiberryGfxRect drawable_area{0, 0, 1920, 1080};
+	const AmiberryGfxRect offset_bezel_area{250, 120, 640, 480};
+	const AmiberryGfxRect final_rect = amiberry_gfx_final_presentation_rect(
+		offset_bezel_area, 2000, 1200, 5.0f / 3.0f, false);
+
+	expect_int_eq(amiberry_gfx_rect_covers_area(final_rect, drawable_area), 0,
+		"an oversized presentation shifted by its bezel hole must clear uncovered drawable edges");
+}
+
 int main()
 {
 	test_ntsc_integer_scaling_without_aspect_uses_crop_geometry();
@@ -202,5 +223,7 @@ int main()
 	test_bezel_area_centers_integer_scaled_presentation();
 	test_rtg_center_remains_source_sized_inside_bezel_area();
 	test_bezel_bounded_integer_scaling_falls_back_below_one_x();
+	test_oversized_centered_presentation_covers_drawable();
+	test_oversized_offset_presentation_leaves_drawable_uncovered();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/gfx_geometry_test.cpp
+++ b/tests/gfx_geometry_test.cpp
@@ -190,6 +190,24 @@ static void test_bezel_bounded_integer_scaling_falls_back_below_one_x()
 		"sub-1x integer scaling must use a centered fractional aspect fit inside the bezel hole");
 }
 
+static void test_invalid_bounded_fallback_inputs_keep_presentation_size()
+{
+	AmiberryGfxRect final_rect = amiberry_gfx_final_presentation_rect(
+		{10, 20, 0, 180}, 640, 400, 640.0f / 400.0f, true);
+	expect_rect_eq(final_rect, -310, -90, 640, 400,
+		"a zero-width fallback area must not resize the presentation");
+
+	final_rect = amiberry_gfx_final_presentation_rect(
+		{10, 20, 300, -10}, 640, 400, 640.0f / 400.0f, true);
+	expect_rect_eq(final_rect, -160, -185, 640, 400,
+		"a negative-height fallback area must not resize the presentation");
+
+	final_rect = amiberry_gfx_final_presentation_rect(
+		{10, 20, 300, 180}, 640, 400, 0.0f, true);
+	expect_rect_eq(final_rect, -160, -90, 640, 400,
+		"an invalid fallback aspect must not resize the presentation");
+}
+
 static void test_oversized_centered_presentation_covers_drawable()
 {
 	const AmiberryGfxRect drawable_area{0, 0, 1920, 1080};
@@ -223,6 +241,7 @@ int main()
 	test_bezel_area_centers_integer_scaled_presentation();
 	test_rtg_center_remains_source_sized_inside_bezel_area();
 	test_bezel_bounded_integer_scaling_falls_back_below_one_x();
+	test_invalid_bounded_fallback_inputs_keep_presentation_size();
 	test_oversized_centered_presentation_covers_drawable();
 	test_oversized_offset_presentation_leaves_drawable_uncovered();
 	return failures == 0 ? 0 : 1;

--- a/tests/play_setup_test.cpp
+++ b/tests/play_setup_test.cpp
@@ -18,7 +18,7 @@ static void test_fullwindow_integer_crt_defaults()
 	const PlayDisplayDefaults defaults{
 		PlayScreenMode::FullWindow,
 		PlayScalingMode::Integer,
-		PlayShaderChoice::Crt
+		"tv"
 	};
 
 	const auto prefs = play_apply_display_defaults(defaults);
@@ -27,7 +27,7 @@ static void test_fullwindow_integer_crt_defaults()
 	expect_eq(prefs.rtg_fullscreen, 2, "FullWindow must set RTG fullscreen to 2");
 	expect_eq(prefs.scaling_method, 2, "Integer scaling must set scaling method to 2");
 	expect_eq(prefs.gfx_autoresolution, 1, "Integer scaling must enable autoresolution");
-	expect_eq(prefs.shader_choice, static_cast<int>(PlayShaderChoice::Crt),
+	expect_eq(prefs.shader, std::string("tv"),
 		"CRT shader choice must be preserved");
 	expect_eq(prefs.gfx_auto_crop, false, "AutoCrop must default to disabled");
 }
@@ -37,7 +37,7 @@ static void test_windowed_auto_none_defaults()
 	const PlayDisplayDefaults defaults{
 		PlayScreenMode::Windowed,
 		PlayScalingMode::Auto,
-		PlayShaderChoice::None
+		"none"
 	};
 
 	const auto prefs = play_apply_display_defaults(defaults);
@@ -46,7 +46,7 @@ static void test_windowed_auto_none_defaults()
 	expect_eq(prefs.rtg_fullscreen, 0, "Windowed must set RTG fullscreen to 0");
 	expect_eq(prefs.scaling_method, -1, "Auto scaling must set scaling method to -1");
 	expect_eq(prefs.gfx_autoresolution, 0, "Auto scaling must disable autoresolution");
-	expect_eq(prefs.shader_choice, static_cast<int>(PlayShaderChoice::None),
+	expect_eq(prefs.shader, std::string("none"),
 		"No shader choice must be preserved");
 	expect_eq(prefs.gfx_auto_crop, false, "Auto scaling must not enable AutoCrop");
 }
@@ -56,7 +56,7 @@ static void test_fullwindow_smooth_scaling_defaults()
 	const PlayDisplayDefaults defaults{
 		PlayScreenMode::FullWindow,
 		PlayScalingMode::Smooth,
-		PlayShaderChoice::Monitor1084
+		"1084"
 	};
 
 	const auto prefs = play_apply_display_defaults(defaults);
@@ -65,7 +65,7 @@ static void test_fullwindow_smooth_scaling_defaults()
 	expect_eq(prefs.rtg_fullscreen, 2, "Full-window must set RTG fullscreen to 2");
 	expect_eq(prefs.scaling_method, 1, "Smooth scaling must set scaling method to 1");
 	expect_eq(prefs.gfx_autoresolution, 0, "Smooth scaling must disable autoresolution");
-	expect_eq(prefs.shader_choice, static_cast<int>(PlayShaderChoice::Monitor1084),
+	expect_eq(prefs.shader, std::string("1084"),
 		"1084 shader choice must be preserved");
 	expect_eq(prefs.gfx_auto_crop, false, "Smooth scaling must not enable AutoCrop");
 }
@@ -75,7 +75,7 @@ static void test_autocrop_default_is_preserved()
 	PlayDisplayDefaults defaults{
 		PlayScreenMode::FullWindow,
 		PlayScalingMode::Integer,
-		PlayShaderChoice::None
+		"none"
 	};
 	defaults.auto_crop = true;
 
@@ -84,18 +84,18 @@ static void test_autocrop_default_is_preserved()
 	expect_eq(prefs.gfx_auto_crop, true, "AutoCrop default must be preserved");
 }
 
-static void test_custom_shader_is_preserved()
+static void test_catalog_shader_name_is_preserved()
 {
 	const PlayDisplayDefaults defaults{
 		PlayScreenMode::Windowed,
 		PlayScalingMode::Auto,
-		PlayShaderChoice::Custom
+		"crt/crt-royale.glslp"
 	};
 
 	const auto prefs = play_apply_display_defaults(defaults);
 
-	expect_eq(prefs.preserve_shader, true, "Custom shader choices must preserve current shader names");
-	expect_eq(prefs.shader_choice, -1, "Custom shader choices must not map to a preset shader");
+	expect_eq(prefs.shader, std::string("crt/crt-royale.glslp"),
+		"Catalog shader names must pass through unchanged");
 }
 
 static void test_no_dependency_state_helpers_stay_false()
@@ -115,7 +115,7 @@ int main()
 	test_windowed_auto_none_defaults();
 	test_fullwindow_smooth_scaling_defaults();
 	test_autocrop_default_is_preserved();
-	test_custom_shader_is_preserved();
+	test_catalog_shader_name_is_preserved();
 	test_no_dependency_state_helpers_stay_false();
 
 	return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

Built-in CRT filters and custom bezels no longer replace the native or RTG scaling geometry selected by the user. The final presentation rectangle now remains authoritative through CRTEMU, external and preset shader resolves, `render_quad`, the software cursor, and the OSD; bezel holes bound scalable modes while RTG Center remains source-sized.

For bezel holes smaller than a 1x native frame, integer mode uses a centered fractional aspect fit instead of clipping outside the hole. Normal full-drawable behavior and source-safe shader intermediates remain unchanged.

Session-settled decisions carried from planning: user-selected presentation geometry remains authoritative (user-approved, over filter- or bezel-controlled geometry), and CRTEMU receives the final viewport without a second aspect correction (user-approved).

Fixes #2246.

## Validation

- Focused geometry regression suite passed through WSL: `sh tests/test_gfx_geometry.sh`.
- Linux Release build passed in the existing WSL build tree, including recompilation of the OpenGL renderer.
- `git diff --check` passed.
- The Windows Release build was attempted but stopped during CMake regeneration because the local vcpkg executable cannot read the current `vcpkg-tools.json` schema; compilation did not start.
- A physical Raspberry Pi KMSDRM matrix was not available on this host. Filter toggles, bezel combinations, RTG modes, cursor mapping, and OSD alignment still need that hardware validation.

## Post-Deploy Monitoring & Validation

- Logs/search: run with `--log` and inspect shader, OpenGL, and bezel initialization failures during the KMSDRM matrix.
- Healthy signals: frame edges do not move when filters are toggled; integer-scaled frames remain centered in bezel holes; RTG Center stays 1:1; cursor and OSD remain aligned.
- Failure signals: a filter expands the frame to the full drawable or bezel hole, content clips outside a scalable bezel area, or cursor/OSD placement diverges from the visible frame.
- Mitigation trigger: disable the affected filter or custom bezel for the session and revert this change if the geometry regression is reproducible across the baseline matrix.
- Validation window and owner: Amiberry maintainer during pre-merge Raspberry Pi 4/5 KMSDRM testing and the first release smoke test containing this change.

