### PR TITLE
fix(android): make ROM management reliable

### DIFF
--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/FilePickerFilters.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/FilePickerFilters.kt
@@ -5,7 +5,7 @@ import com.blitterstudio.amiberry.data.model.FileCategory
 object FilePickerFilters {
 
 	fun mimeTypesFor(category: FileCategory): Array<String> = when (category) {
-		FileCategory.ROMS -> arrayOf("application/octet-stream", "application/x-binary")
+		FileCategory.ROMS -> arrayOf("*/*")
 		FileCategory.FLOPPIES -> arrayOf("application/octet-stream", "application/zip", "application/gzip")
 		FileCategory.HARD_DRIVES -> arrayOf("application/octet-stream")
 		FileCategory.CD_IMAGES -> arrayOf("application/x-iso9660-image", "application/octet-stream", "application/x-cue", "application/x-chd")

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/AmigaFile.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/AmigaFile.kt
@@ -22,7 +22,7 @@ enum class FileCategory(
 	val displayName: String,
 	val extensions: Set<String>
 ) {
-	ROMS(StoragePaths.ROMS, "ROMs", setOf("rom", "bin")),
+	ROMS(StoragePaths.ROMS, "ROMs", setOf("rom", "bin", "a500", "a600", "a1200", "a3000", "a4000", "cdtv", "cd32")),
 	FLOPPIES(StoragePaths.FLOPPIES, "Floppies", setOf("adf", "adz", "dms", "ipf", "zip", "gz")),
 	HARD_DRIVES(StoragePaths.HARD_DRIVES, "Hard Drives", setOf("hdf", "hdi", "vhd")),
 	CD_IMAGES(StoragePaths.CDROMS, "CD Images", setOf("iso", "cue", "chd", "nrg", "mds")),

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/FileManagerScreen.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/FileManagerScreen.kt
@@ -221,7 +221,7 @@ fun FileManagerScreen(viewModel: FileManagerViewModel = viewModel()) {
 					onDismissRequest = { showRomImportMenu = false }
 				) {
 					DropdownMenuItem(
-						text = { Text(stringResource(R.string.action_import_rom_files)) },
+						text = { Text(stringResource(R.string.action_import_roms)) },
 						leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
 						onClick = {
 							showRomImportMenu = false
@@ -414,7 +414,12 @@ fun FileManagerScreen(viewModel: FileManagerViewModel = viewModel()) {
 				}
 			} else {
 				LazyColumn(
-					contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+					contentPadding = PaddingValues(
+						start = 16.dp,
+						top = 8.dp,
+						end = 16.dp,
+						bottom = 120.dp
+					),
 					verticalArrangement = Arrangement.spacedBy(6.dp)
 				) {
 					items(files, key = { it.path }) { file ->

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -149,7 +149,7 @@
     <string name="setup_required_title">ROM Setup Required</string>
     <string name="setup_required_message">An Amiga Kickstart ROM is required to start the emulator. Please import a valid ROM file.</string>
     <string name="action_import_rom">Import ROM</string>
-    <string name="action_import_rom_files">Import ROM files</string>
+    <string name="action_import_roms">Import ROMs</string>
     <string name="action_import_rom_folder">Import ROM folder</string>
     <string name="file_manager_import_category">Import %1$s</string>
     <string name="configurations_empty_cta">Create Initial Configuration</string>

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/FileManagerTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/FileManagerTest.kt
@@ -17,9 +17,13 @@ class FileManagerTest {
 	// --- FileCategory.fromExtension ---
 
 	@Test
-	fun `fromExtension returns ROMS for rom extension`() {
-		assertEquals(FileCategory.ROMS, FileCategory.fromExtension("rom"))
-		assertEquals(FileCategory.ROMS, FileCategory.fromExtension("bin"))
+	fun `ROM extensions match the native chooser set exactly`() {
+		val expected = setOf("rom", "bin", "a500", "a600", "a1200", "a3000", "a4000", "cdtv", "cd32")
+
+		assertEquals(expected, FileCategory.ROMS.extensions)
+		expected.forEach { extension ->
+			assertEquals(FileCategory.ROMS, FileCategory.fromExtension(extension))
+		}
 	}
 
 	@Test
@@ -56,6 +60,8 @@ class FileManagerTest {
 	@Test
 	fun `fromExtension is case insensitive`() {
 		assertEquals(FileCategory.ROMS, FileCategory.fromExtension("ROM"))
+		assertEquals(FileCategory.ROMS, FileCategory.fromExtension("A500"))
+		assertEquals(FileCategory.ROMS, FileCategory.fromExtension("CdTv"))
 		assertEquals(FileCategory.FLOPPIES, FileCategory.fromExtension("ADF"))
 		assertEquals(FileCategory.CD_IMAGES, FileCategory.fromExtension("ISO"))
 	}
@@ -65,6 +71,8 @@ class FileManagerTest {
 		assertNull(FileCategory.fromExtension("exe"))
 		assertNull(FileCategory.fromExtension("txt"))
 		assertNull(FileCategory.fromExtension("jpg"))
+		assertNull(FileCategory.fromExtension("roz"))
+		assertNull(FileCategory.fromExtension("U1"))
 		assertNull(FileCategory.fromExtension(""))
 	}
 
@@ -105,6 +113,20 @@ class FileManagerTest {
 			"Kickstart.ROM",
 			FileManager.importFileNameForCategory("Kickstart.ROM", FileCategory.ROMS)
 		)
+		assertEquals(
+			"Kickstart.CdTv",
+			FileManager.importFileNameForCategory("Kickstart.CdTv", FileCategory.ROMS)
+		)
+	}
+
+	@Test
+	fun `importFileNameForCategory accepts every supported ROM extension`() {
+		val expectedExtensions = setOf("rom", "bin", "a500", "a600", "a1200", "a3000", "a4000", "cdtv", "cd32")
+
+		expectedExtensions.forEach { extension ->
+			val name = "Kickstart.${extension.uppercase()}"
+			assertEquals(name, FileManager.importFileNameForCategory(name, FileCategory.ROMS))
+		}
 	}
 
 	@Test
@@ -112,6 +134,12 @@ class FileManagerTest {
 		assertNull(FileManager.importFileNameForCategory("disk", FileCategory.FLOPPIES))
 		assertNull(FileManager.importFileNameForCategory("notes.txt", FileCategory.FLOPPIES))
 		assertNull(FileManager.importFileNameForCategory("archive.zip", FileCategory.WHDLOAD_GAMES))
+		assertNull(FileManager.importFileNameForCategory("kickstart", FileCategory.ROMS))
+		assertNull(FileManager.importFileNameForCategory("kickstart.roz", FileCategory.ROMS))
+		assertNull(FileManager.importFileNameForCategory("kickstart.U1", FileCategory.ROMS))
+		assertNull(FileManager.importFileNameForCategory("kickstart.zip", FileCategory.ROMS))
+		assertNull(FileManager.importFileNameForCategory("kickstart.lha", FileCategory.ROMS))
+		assertNull(FileManager.importFileNameForCategory("kickstart.txt", FileCategory.ROMS))
 	}
 
 	@Test
@@ -130,6 +158,18 @@ class FileManagerTest {
 		assertEquals(
 			FileManager.ImportCandidate.Unsupported("disk", ""),
 			FileManager.importCandidateForCategory("disk", FileCategory.FLOPPIES)
+		)
+		assertEquals(
+			FileManager.ImportCandidate.Unsupported("kickstart.roz", "roz"),
+			FileManager.importCandidateForCategory("kickstart.roz", FileCategory.ROMS)
+		)
+		assertEquals(
+			FileManager.ImportCandidate.Unsupported("kickstart.U1", "u1"),
+			FileManager.importCandidateForCategory("kickstart.U1", FileCategory.ROMS)
+		)
+		assertEquals(
+			FileManager.ImportCandidate.Unsupported("kickstart", ""),
+			FileManager.importCandidateForCategory("kickstart", FileCategory.ROMS)
 		)
 	}
 
@@ -156,6 +196,18 @@ class FileManagerTest {
 
 		assertTrue(deleted)
 		assertFalse(floppy.exists())
+	}
+
+	@Test
+	fun `deleteManagedFile allows supported model ROM extensions`() {
+		val baseDir = tempDir.newFolder("app-storage")
+		val romDir = File(baseDir, StoragePaths.ROMS).also { it.mkdirs() }
+		val rom = File(romDir, "Kickstart.A1200").also { it.writeText("rom") }
+
+		val deleted = FileManager.deleteManagedFile(baseDir, amigaFile(rom, FileCategory.ROMS))
+
+		assertTrue(deleted)
+		assertFalse(rom.exists())
 	}
 
 	@Test
@@ -292,6 +344,21 @@ class FileManagerTest {
 		val result = FileManager.scanDirectory(dir, setOf("adf"))
 
 		assertEquals(3, result.size)
+	}
+
+	@Test
+	fun `scanDirectory finds supported model ROM extensions and rejects deep scan formats`() {
+		val dir = tempDir.newFolder(StoragePaths.ROMS)
+		File(dir, "Kickstart.A500").writeText("a500")
+		File(dir, "CDTV.CdTv").writeText("cdtv")
+		File(dir, "Encrypted.roz").writeText("roz")
+		File(dir, "Cloanto.U1").writeText("u1")
+		File(dir, "Archive.zip").writeText("zip")
+
+		val result = FileManager.scanDirectory(dir, FileCategory.ROMS.extensions, FileCategory.ROMS)
+
+		assertEquals(listOf("CDTV.CdTv", "Kickstart.A500"), result.map { it.name })
+		assertTrue(result.all { it.category == FileCategory.ROMS && it.crc32 != null })
 	}
 
 	@Test

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/FilePickerFiltersTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/FilePickerFiltersTest.kt
@@ -7,9 +7,9 @@ import org.junit.Test
 class FilePickerFiltersTest {
 
 	@Test
-	fun `rom picker prefers binary document types`() {
+	fun `rom picker shows all document types for extension validation`() {
 		assertArrayEquals(
-			arrayOf("application/octet-stream", "application/x-binary"),
+			arrayOf("*/*"),
 			FilePickerFilters.mimeTypesFor(FileCategory.ROMS)
 		)
 	}
@@ -27,6 +27,14 @@ class FilePickerFiltersTest {
 		assertArrayEquals(
 			arrayOf(".lha", ".lzx", ".lzh"),
 			FilePickerFilters.extensionLabelsFor(FileCategory.WHDLOAD_GAMES)
+		)
+	}
+
+	@Test
+	fun `ROM labels include every supported extension`() {
+		assertArrayEquals(
+			arrayOf(".rom", ".bin", ".a500", ".a600", ".a1200", ".a3000", ".a4000", ".cdtv", ".cd32"),
+			FilePickerFilters.extensionLabelsFor(FileCategory.ROMS)
 		)
 	}
 }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/IntentImportTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/IntentImportTest.kt
@@ -38,6 +38,14 @@ class IntentImportTest {
 			IntentImport.classify("Kick31.ROM")
 		)
 		assertEquals(
+			IntentImport.Classification.Media("Kick13.A500", FileCategory.ROMS),
+			IntentImport.classify("Kick13.A500")
+		)
+		assertEquals(
+			IntentImport.Classification.Media("CDTV.CdTv", FileCategory.ROMS),
+			IntentImport.classify("CDTV.CdTv")
+		)
+		assertEquals(
 			IntentImport.Classification.Media("Game.CHD", FileCategory.CD_IMAGES),
 			IntentImport.classify("Game.CHD")
 		)
@@ -52,6 +60,14 @@ class IntentImportTest {
 		assertEquals(
 			IntentImport.Classification.Unsupported("imported_file", ""),
 			IntentImport.classify("..")
+		)
+		assertEquals(
+			IntentImport.Classification.Unsupported("kickstart.roz", "roz"),
+			IntentImport.classify("kickstart.roz")
+		)
+		assertEquals(
+			IntentImport.Classification.Unsupported("kickstart.U1", "u1"),
+			IntentImport.classify("kickstart.U1")
 		)
 	}
 

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/RomExtensionContractTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/RomExtensionContractTest.kt
@@ -1,0 +1,73 @@
+package com.blitterstudio.amiberry.data
+
+import com.blitterstudio.amiberry.data.model.FileCategory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class RomExtensionContractTest {
+	@Test
+	fun `Android ROM extensions match every general native ROM chooser`() {
+		val romPanel = File("../../src/osdep/imgui/rom.cpp").readText()
+		val chooserFilters = Regex(
+			"""OpenFileDialogKey\("ROM", "Select (?:Main|Extended|Custom|Cartridge) ROM", "([^"]+)""""
+		).findAll(romPanel)
+			.map { match ->
+				match.groupValues[1]
+					.split(',')
+					.map { it.removePrefix(".").lowercase() }
+					.toSet()
+			}
+			.toList()
+
+		assertEquals("Expected all four general ROM chooser filters.", 4, chooserFilters.size)
+		chooserFilters.forEach { chooserExtensions ->
+			assertEquals(FileCategory.ROMS.extensions, chooserExtensions)
+		}
+	}
+
+	@Test
+	fun `native ROM scanner matches the chooser-compatible base extensions case-insensitively`() {
+		val nativeGui = File("../../src/osdep/amiberry_gui.cpp").readText()
+		val scanner = Regex(
+			"""static int isromext\(const std::string& path, bool deepscan\)([\s\S]*?)static bool scan_rom_hook"""
+		).find(nativeGui)?.groupValues?.get(1)
+			?: error("Could not find isromext() in src/osdep/amiberry_gui.cpp")
+		val baseVector = Regex(
+			"""static const std::vector<std::string> extensions = \{([^}]+)\};"""
+		).find(scanner)?.groupValues?.get(1)
+			?.let { initializer ->
+				Regex(""""([^"]+)"""").findAll(initializer)
+					.map { it.groupValues[1] }
+					.toSet()
+			}
+			?: error("Could not find the base ROM extension vector")
+		val expectedBaseVector = FileCategory.ROMS.extensions + "roz"
+
+		assertEquals(expectedBaseVector, baseVector)
+		assertTrue(
+			"The base vector must use a case-insensitive comparison so mixed-case CdTv and cD32 filenames survive native rescan.",
+			scanner.contains("strcasecmp(ext.c_str(), extension.c_str()) == 0") &&
+				baseVector.any { it.equals("CdTv", ignoreCase = true) } &&
+				baseVector.any { it.equals("cD32", ignoreCase = true) }
+		)
+		assertFalse(
+			"The base-vector check must not retain exact std::find matching.",
+			scanner.contains("std::find(extensions.begin(), extensions.end(), ext)")
+		)
+
+		val baseComparison = scanner.indexOf("strcasecmp(ext.c_str(), extension.c_str()) == 0")
+		val numberedExtension = scanner.indexOf("std::toupper(ext[0]) == 'U' && std::isdigit(ext[1])")
+		val deepScanGate = scanner.indexOf("if (!deepscan)")
+		val archiveLoop = scanner.indexOf("for (auto i = 0; uae_archive_extensions[i]; i++)")
+		assertTrue(
+			"Base ROMs and scanner-only U-numbered suffixes must remain unconditional, while archives stay behind the deep-scan gate.",
+			baseComparison >= 0 &&
+				baseComparison < numberedExtension &&
+				numberedExtension < deepScanGate &&
+				deepScanGate < archiveLoop
+		)
+	}
+}

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/model/ModelRomAvailabilityTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/model/ModelRomAvailabilityTest.kt
@@ -9,7 +9,7 @@ class ModelRomAvailabilityTest {
 
 	@Test
 	fun `available models only includes models with matching ROM profiles`() {
-		val roms = listOf(rom("kick13.rom", 0xc4f0f55fL))
+		val roms = listOf(rom("kick13.A500", 0xc4f0f55fL))
 
 		val models = ModelRomAvailability.availableModels(roms)
 
@@ -68,7 +68,7 @@ class ModelRomAvailabilityTest {
 	private fun rom(name: String, crc32: Long, path: String = "/roms/$name") = AmigaFile(
 		path = path,
 		name = name,
-		extension = "rom",
+		extension = name.substringAfterLast('.', missingDelimiterValue = "").lowercase(),
 		size = 512 * 1024,
 		lastModified = 0,
 		category = FileCategory.ROMS,

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/FileManagerScreenArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/FileManagerScreenArchitectureTest.kt
@@ -1,6 +1,8 @@
 package com.blitterstudio.amiberry.ui
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -30,6 +32,10 @@ class FileManagerScreenArchitectureTest {
 		val screen = source()
 
 		assertTrue(
+			"File Manager ROM import should preserve batch selection.",
+			screen.contains("ActivityResultContracts.OpenMultipleDocuments()")
+		)
+		assertTrue(
 			"ROM users should be able to select a directory tree once.",
 			screen.contains("ActivityResultContracts.OpenDocumentTree()")
 		)
@@ -37,8 +43,31 @@ class FileManagerScreenArchitectureTest {
 			"The selected ROM tree should be imported through the view model.",
 			screen.contains("viewModel.importFolder(uri, FileCategory.ROMS)")
 		)
-		assertTrue(screen.contains("R.string.action_import_rom_files"))
+		assertTrue(screen.contains("R.string.action_import_roms"))
+		assertFalse(
+			"File Manager should not reference the replaced ROM-file import label.",
+			screen.contains("R.string.action_import_rom_files")
+		)
 		assertTrue(screen.contains("R.string.action_import_rom_folder"))
+	}
+
+	@Test
+	fun `ROM import wording distinguishes batch and singular actions`() {
+		assertEquals("Import ROMs", stringResourceValue("action_import_roms"))
+		assertEquals("Import ROM", stringResourceValue("action_import_rom"))
+		assertNull(stringResourceValue("action_import_rom_files"))
+	}
+
+	@Test
+	fun `file list keeps its final row clear of the floating import action`() {
+		val screen = source()
+
+		assertTrue(
+			"LazyColumn content should retain 16dp horizontal, 8dp top, and 120dp bottom scroll clearance.",
+			Regex(
+				"""LazyColumn\(\s*contentPadding = PaddingValues\(\s*start = 16\.dp,\s*top = 8\.dp,\s*end = 16\.dp,\s*bottom = 120\.dp\s*\)"""
+			).containsMatchIn(screen)
+		)
 	}
 
 	@Test
@@ -60,6 +89,17 @@ class FileManagerScreenArchitectureTest {
 	fun `file manager disables delete actions while scan or import is in progress`() {
 		val screen = source()
 
+		assertTrue(
+			"Each file row should retain its own delete callback.",
+			screen.contains("onDelete = { viewModel.deleteFile(file) }")
+		)
+		assertTrue(
+			"Delete should continue to require local confirmation state.",
+			screen.contains("var showDeleteDialog by remember { mutableStateOf(false) }") &&
+				screen.contains("if (showDeleteDialog)") &&
+				screen.contains("AlertDialog(") &&
+				screen.contains("onDelete()")
+		)
 		assertTrue(
 			"File list rows should receive the same busy state used by refresh/import controls.",
 			screen.contains("deleteEnabled = !showProgress")
@@ -103,4 +143,12 @@ class FileManagerScreenArchitectureTest {
 
 	private fun source(): String =
 		File("src/main/java/com/blitterstudio/amiberry/ui/screens/FileManagerScreen.kt").readText()
+
+	private fun stringResourceValue(name: String): String? {
+		val strings = File("src/main/res/values/strings.xml").readText()
+		return Regex("""<string name="$name">([^<]*)</string>""")
+			.find(strings)
+			?.groupValues
+			?.get(1)
+	}
 }

--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -219,9 +219,12 @@ static int isromext(const std::string& path, bool deepscan)
 		return 0;
 	const std::string ext = path.substr(ext_pos + 1);
 
-	static const std::vector<std::string> extensions = { "rom", "ROM", "roz", "ROZ", "bin", "BIN",  "a500", "A500", "a600", "A600", "a1200", "A1200", "a3000", "A3000", "a4000", "A4000", "cdtv", "CDTV", "cd32", "CD32" };
-	if (std::find(extensions.begin(), extensions.end(), ext) != extensions.end())
-		return 1;
+	static const std::vector<std::string> extensions = { "rom", "bin", "a500", "a600", "a1200", "a3000", "a4000", "cdtv", "cd32", "roz" };
+	for (const auto& extension : extensions)
+	{
+		if (strcasecmp(ext.c_str(), extension.c_str()) == 0)
+			return 1;
+	}
 
 	if (ext.size() >= 2 && std::toupper(ext[0]) == 'U' && std::isdigit(ext[1]))
 		return 1;


### PR DESCRIPTION
## Summary

Android users can now import model-named Kickstart ROMs such as `.A500`, `.A1200`, `.CdTv`, and `.cD32` without renaming them to `.rom`. The File Manager also keeps the final ROM row and its confirmed delete action scrollable above the floating Import button, while the clearer “Import ROMs” action preserves multi-file and folder import.

The Android allowlist now matches the four general native ROM chooser filters. The unrestricted document picker lets SAF providers expose uncommon ROM suffixes, shared filename validation still rejects unsupported files, and native launch-time scanning handles the supported set case-insensitively without changing its scanner-only formats.

Session-settled decisions carried from planning: preserve row-level deletion and batch import (user-directed); match native chooser extensions, validate after wildcard selection, and retain the native scanner superset plus fixed list clearance (user-approved).

## Validation

- `:app:testDebugUnitTest` passed.
- `:app:lintDebug` passed.
- `:app:assembleDebug` passed for arm64-v8a and x86_64.
- `git diff --check` passed.
- Pixel Tablet emulator: verified final-row delete clearance in portrait, landscape, and a filtered list; verified confirmation gating; verified “Import ROMs” opens the unrestricted document picker; imported and then deleted a disposable uppercase `.A500` file without unsupported-type feedback.
- Native `DetectedROMs` regeneration is covered by the Kotlin/native contract test and compiled debug build; a full SDL launch and registry inspection was not completed in this run.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this changes local Android file handling, native startup scanning, and Compose layout only.

- Validation window and owner: the first Android smoke session after install, owned by the maintainer or reviewer.
- Log/search terms: `Unsupported file type`, `--rescan-roms`, and `DetectedROMs` when diagnosing a failed import or launch scan.
- Healthy signals: every supported suffix imports and remains listed; mixed-case model suffixes appear in `DetectedROMs` after launch; the final delete action remains fully reachable.
- Failure signals: a supported suffix still reports unsupported, an imported ROM is absent after native rescan, or the Import button overlaps the final row.
- Rollback trigger and mitigation: if any failure signal reproduces, revert the three Android ROM-management commits and restore the previous picker, scanner, and list-padding behavior.

