### PR TITLE
fix(android): add touch trackpad mouse controls

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -25,3 +25,9 @@ The transparent screen region inside a custom bezel that can replace the full dr
 An on-screen joystick gesture that owns directional input from an initial touch inside its acquisition area until finger-up, platform cancellation, application focus loss, or control shutdown.
 
 Moving the held finger outside the visible joystick base continues to update direction and does not release or recenter the gesture.
+
+### Captured trackpad gesture
+
+An Android free-area touch gesture that owns the exact SDL touch and finger identities accepted after the on-screen keyboard and joystick decline the initial contact.
+
+The gesture keeps that ownership when its fingers cross overlay geometry. Cancellation, lifecycle neutralization, an invalidated mouse mapping, or a terminal paired-finger condition releases its owned buttons and prevents surviving contacts from being reassigned until all tracked contacts lift.

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
@@ -328,12 +328,16 @@ class AndroidRuntimeControlsArchitectureTest {
 		val retireClick = pump.indexOf("android_touch_mouse_begin_pump()")
 		val pollEvents = pump.indexOf("while (SDL_PollEvent(&event))")
 		val secondDrain = pump.indexOf("drain_pending_touch_neutralization()", entryDrain + 1)
-		val deadlineTick = pump.indexOf("android_touch_mouse_tick(SDL_GetTicksNS())")
+		val deadlineTick = pump.indexOf("android_touch_mouse_tick()")
 
 		assertTrue(
 			"The main pump should drain, retire the prior click, process queued events, drain again, then tick nanosecond deadlines.",
 			entryDrain >= 0 && retireClick > entryDrain && pollEvents > retireClick &&
 				secondDrain > pollEvents && deadlineTick > secondDrain
+		)
+		assertTrue(
+			"The active-only touch tick should acquire its deadline from SDL's nanosecond clock.",
+			amiberryCpp.contains("android_touch_mouse_coordinator.tick(SDL_GetTicksNS())")
 		)
 		assertTrue(
 			"Android left and right guest writes should pass through source composition.",

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
@@ -471,15 +471,25 @@ class AndroidRuntimeControlsArchitectureTest {
 		val eventFilter = Regex(
 			"""static bool SDLCALL android_touch_event_filter[\s\S]*?\R\}"""
 		).find(amiberryCpp)?.value.orEmpty()
+		val guiSwipeFilter = Regex(
+			"""static bool amiberry_android_filter_gui_swipe_event[\s\S]*?\R\}"""
+		).find(amiberryCpp)?.value.orEmpty()
 		val publisher = Regex(
 			"""static void amiberry_android_publish_gui_swipe_filter[\s\S]*?\R\}"""
 		).find(amiberryCpp)?.value.orEmpty()
+		val retirement = Regex(
+			"""static void amiberry_android_retire_gui_swipe_filter_contact[\s\S]*?\R\}"""
+		).find(amiberryCpp)?.value.orEmpty()
+		val processEvent = amiberryCpp
+			.substringAfter("static void process_event(const SDL_Event& event)", "")
+			.substringBefore("int handle_msgpump(bool vblank)", "")
 
 		assertTrue(
-			"A winning GUI swipe should publish both composite contact identities to atomic filter state.",
+			"A winning GUI swipe should publish both composite contact identities before atomically activating their mask.",
 			publisher.contains("touch_id.store") &&
 				publisher.contains("finger_id.store") &&
-				publisher.contains("android_gui_swipe_filter_active.store(true")
+				publisher.indexOf("finger_id.store") in
+					0 until publisher.indexOf("android_gui_swipe_filter_active_mask.store")
 		)
 		assertTrue(
 			"The SDL filter should drop only SDL_TOUCH_MOUSEID mouse events while exact GUI-swipe contacts remain active.",
@@ -487,6 +497,19 @@ class AndroidRuntimeControlsArchitectureTest {
 				eventFilter.contains("return false") &&
 				amiberryCpp.contains("event->button.which == SDL_TOUCH_MOUSEID") &&
 				amiberryCpp.contains("event->motion.which == SDL_TOUCH_MOUSEID")
+		)
+		assertTrue(
+			"Both filter-time and already-queued main-thread terminals should use the same exact-contact retirement path.",
+			eventFilter.contains("amiberry_android_filter_gui_swipe_event(event)") &&
+				guiSwipeFilter.contains("amiberry_android_retire_gui_swipe_filter_contact(*event)") &&
+				processEvent.contains("amiberry_android_retire_gui_swipe_filter_contact(event)")
+		)
+		assertTrue(
+			"Exact contact retirement should only clear matching active bits so mouse suppression ends after both contacts retire.",
+			retirement.contains("touch_id.load") &&
+				retirement.contains("finger_id.load") &&
+				retirement.contains("android_gui_swipe_filter_active_mask.fetch_and") &&
+				amiberryCpp.contains("android_gui_swipe_filter_active_mask.load(std::memory_order_acquire) == 0")
 		)
 		assertFalse(
 			"The SDL event filter must not inject guest input.",

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
@@ -198,7 +198,7 @@ class AndroidRuntimeControlsArchitectureTest {
 		assertTrue(
 			"The global authority must release every overlay owner and the unified Android touch gesture.",
 			globalNeutralizer.contains("on_screen_joystick_release_all()") &&
-				globalNeutralizer.contains("android_touch_mouse_neutralize()")
+				globalNeutralizer.contains("amiberry_android_touch_mouse_neutralize()")
 		)
 		assertTrue(
 			"Finger cancellation must neutralize globally before ordinary per-finger routing.",
@@ -258,7 +258,7 @@ class AndroidRuntimeControlsArchitectureTest {
 			"""case SDL_EVENT_MOUSE_MOTION:[\s\S]*?case SDL_EVENT_MOUSE_WHEEL:"""
 		).find(amiberryCpp)?.value.orEmpty()
 		val resolver = Regex(
-			"""static int android_resolve_touch_mouse_index\(\)[\s\S]*?\R\}"""
+			"""static int amiberry_android_resolve_touch_mouse_index\(\)[\s\S]*?\R\}"""
 		).find(amiberryCpp)?.value.orEmpty()
 		assertTrue(
 			"Android native input should use the tested pure touch-mouse arbiter.",
@@ -283,21 +283,21 @@ class AndroidRuntimeControlsArchitectureTest {
 		)
 		assertTrue(
 			"Trackpad-owned continuation should route before overlay hit testing.",
-			fingerEvents.indexOf("android_touch_mouse_owns(event)") in
+			fingerEvents.indexOf("amiberry_android_touch_mouse_owns(event)") in
 				0 until fingerEvents.indexOf("imgui_osk_should_render()") &&
-				fingerMotion.indexOf("android_touch_mouse_owns(event)") in
+				fingerMotion.indexOf("amiberry_android_touch_mouse_owns(event)") in
 					0 until fingerMotion.indexOf("imgui_osk_should_render()")
 		)
 		assertTrue(
 			"An added same-device contact should terminate a held drag before an overlay may acquire it.",
-			fingerEvents.indexOf("android_touch_mouse_prepare_added_contact(event)") in
+			fingerEvents.indexOf("amiberry_android_touch_mouse_prepare_added_contact(event)") in
 				0 until fingerEvents.indexOf("imgui_osk_should_render()")
 		)
 		assertTrue(
 			"Touch-synthesized mouse events must be suppressed across eligible active emulation before finger ownership exists.",
-			mouseButtons.contains("android_touch_mouse_route_eligible()") &&
+			mouseButtons.contains("amiberry_android_touch_mouse_route_eligible()") &&
 				mouseButtons.contains("event.button.which == SDL_TOUCH_MOUSEID") &&
-				mouseMotion.contains("android_touch_mouse_route_eligible()") &&
+				mouseMotion.contains("amiberry_android_touch_mouse_route_eligible()") &&
 				mouseMotion.contains("event.motion.which == SDL_TOUCH_MOUSEID")
 		)
 		assertTrue(
@@ -319,16 +319,64 @@ class AndroidRuntimeControlsArchitectureTest {
 	}
 
 	@Test
+	fun `owned and drained Android touch terminals survive device deregistration`() {
+		val amiberryCpp = File("../../src/osdep/amiberry.cpp").readText()
+		val directEligibility = Regex(
+			"""static bool amiberry_android_direct_touch_eligible\(SDL_TouchID touch_id\)\s*\{[\s\S]*?\R\}"""
+		).find(amiberryCpp)?.value.orEmpty()
+		val drainedTouch = amiberryCpp
+			.substringAfter("static bool amiberry_android_handle_drained_touch", "")
+			.substringBefore("static bool amiberry_android_touch_mouse_route_eligible", "")
+		val ownership = amiberryCpp
+			.substringAfter("static bool amiberry_android_touch_mouse_owns", "")
+			.substringBefore("static void amiberry_android_touch_mouse_prepare_added_contact", "")
+		val prepareAddedContact = amiberryCpp
+			.substringAfter("static void amiberry_android_touch_mouse_prepare_added_contact", "")
+			.substringBefore("static bool amiberry_android_route_touch_mouse", "")
+		val routeTouch = amiberryCpp
+			.substringAfter("static bool amiberry_android_route_touch_mouse", "")
+			.substringBefore("static void amiberry_android_touch_mouse_begin_pump", "")
+
+		assertTrue(
+			"A newly acquired contact must still come from a registered direct touch device.",
+			directEligibility.contains("SDL_GetTouchDeviceType(touch_id) == SDL_TOUCH_DEVICE_DIRECT") &&
+				prepareAddedContact.contains("amiberry_android_direct_touch_eligible") &&
+				routeTouch.contains("!owned && !amiberry_android_direct_touch_eligible")
+		)
+		assertTrue(
+			"An exact owned key must route without rechecking live touch-device registration.",
+			ownership.contains("amiberry_android_touch_identity_eligible") &&
+				ownership.contains("android_touch_mouse_coordinator.owns") &&
+				!ownership.contains("amiberry_android_direct_touch_eligible") &&
+				routeTouch.contains("const bool owned = android_touch_mouse_coordinator.owns(key)")
+		)
+		assertTrue(
+			"An exact externally drained key must retire before direct-device eligibility is considered for a new down.",
+			drainedTouch.contains("const auto found = std::find") &&
+				drainedTouch.contains("if (found != android_touch_mouse_drain.end())") &&
+				drainedTouch.indexOf("return true;") in
+					0 until drainedTouch.indexOf("amiberry_android_direct_touch_eligible")
+		)
+		assertTrue(
+			"Owned and drained continuation must continue rejecting SDL synthetic mouse and pen identities.",
+			amiberryCpp.contains("touch_id != SDL_MOUSE_TOUCHID") &&
+				amiberryCpp.contains("touch_id != SDL_PEN_TOUCHID") &&
+				ownership.contains("amiberry_android_touch_identity_eligible") &&
+				drainedTouch.contains("amiberry_android_touch_identity_eligible")
+		)
+	}
+
+	@Test
 	fun `Android touch mouse pump preserves click and deadline ordering`() {
 		val amiberryCpp = File("../../src/osdep/amiberry.cpp").readText()
 		val pump = Regex(
 			"""int handle_msgpump\(bool vblank\)[\s\S]*?bool handle_events\(\)"""
 		).find(amiberryCpp)?.value.orEmpty()
 		val entryDrain = pump.indexOf("drain_pending_touch_neutralization()")
-		val retireClick = pump.indexOf("android_touch_mouse_begin_pump()")
+		val retireClick = pump.indexOf("amiberry_android_touch_mouse_begin_pump()")
 		val pollEvents = pump.indexOf("while (SDL_PollEvent(&event))")
 		val secondDrain = pump.indexOf("drain_pending_touch_neutralization()", entryDrain + 1)
-		val deadlineTick = pump.indexOf("android_touch_mouse_tick()")
+		val deadlineTick = pump.indexOf("amiberry_android_touch_mouse_tick()")
 
 		assertTrue(
 			"The main pump should drain, retire the prior click, process queued events, drain again, then tick nanosecond deadlines.",
@@ -341,7 +389,7 @@ class AndroidRuntimeControlsArchitectureTest {
 		)
 		assertTrue(
 			"Android left and right guest writes should pass through source composition.",
-			amiberryCpp.contains("android_set_composed_mouse_button") &&
+			amiberryCpp.contains("amiberry_android_set_composed_mouse_button") &&
 				amiberryCpp.contains("ButtonSource::physical") &&
 				amiberryCpp.contains("ButtonSource::pen") &&
 				amiberryCpp.contains("ButtonSource::gesture")
@@ -355,7 +403,7 @@ class AndroidRuntimeControlsArchitectureTest {
 			"""int handle_msgpump\(bool vblank\)[\s\S]*?bool handle_events\(\)"""
 		).find(amiberryCpp)?.value.orEmpty()
 		val overlayTransitions = Regex(
-			"""static void android_check_touch_overlay_transitions\(\)[\s\S]*?\R\}"""
+			"""static void amiberry_android_check_touch_overlay_transitions\(\)[\s\S]*?\R\}"""
 		).find(amiberryCpp)?.value.orEmpty()
 		val penHandler = amiberryCpp
 			.substringAfter("static void handle_pen_event(const SDL_Event& event)", "")
@@ -372,7 +420,7 @@ class AndroidRuntimeControlsArchitectureTest {
 			overlayTransitions.contains("imgui_osk_should_render()") &&
 				overlayTransitions.contains("on_screen_joystick_is_enabled()") &&
 				overlayTransitions.contains("neutralize_touch_controls()") &&
-				pump.contains("android_check_touch_overlay_transitions()")
+				pump.contains("amiberry_android_check_touch_overlay_transitions()")
 		)
 		assertTrue(
 			"Pen proximity-in must neutralize touch before blocking acquisition, and proximity-out must require a fresh down.",
@@ -385,8 +433,8 @@ class AndroidRuntimeControlsArchitectureTest {
 		)
 		assertTrue(
 			"Input unacquire should neutralize the gesture and clear every composed Android mouse-button source.",
-			unacquire.contains("android_touch_mouse_neutralize()") &&
-				unacquire.contains("android_clear_all_mouse_button_sources()")
+			unacquire.contains("amiberry_android_touch_mouse_neutralize()") &&
+				unacquire.contains("amiberry_android_clear_all_mouse_button_sources()")
 		)
 	}
 
@@ -413,7 +461,7 @@ class AndroidRuntimeControlsArchitectureTest {
 			"Removal should resolve the exact index before mutating input mappings and clear only that composed index.",
 			removalCase.indexOf("get_tracked_mouse_index_from_sdl_id") in
 				0 until removalCase.indexOf("handle_sdl_mouse_removed") &&
-				removalCase.contains("android_handle_removed_mouse_index")
+				removalCase.contains("amiberry_android_handle_removed_mouse_index")
 		)
 	}
 
@@ -424,7 +472,7 @@ class AndroidRuntimeControlsArchitectureTest {
 			"""static bool SDLCALL android_touch_event_filter[\s\S]*?\R\}"""
 		).find(amiberryCpp)?.value.orEmpty()
 		val publisher = Regex(
-			"""static void android_publish_gui_swipe_filter[\s\S]*?\R\}"""
+			"""static void amiberry_android_publish_gui_swipe_filter[\s\S]*?\R\}"""
 		).find(amiberryCpp)?.value.orEmpty()
 
 		assertTrue(
@@ -435,7 +483,7 @@ class AndroidRuntimeControlsArchitectureTest {
 		)
 		assertTrue(
 			"The SDL filter should drop only SDL_TOUCH_MOUSEID mouse events while exact GUI-swipe contacts remain active.",
-			eventFilter.contains("android_filter_gui_swipe_event(event)") &&
+			eventFilter.contains("amiberry_android_filter_gui_swipe_event(event)") &&
 				eventFilter.contains("return false") &&
 				amiberryCpp.contains("event->button.which == SDL_TOUCH_MOUSEID") &&
 				amiberryCpp.contains("event->motion.which == SDL_TOUCH_MOUSEID")

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
@@ -187,9 +187,9 @@ class AndroidRuntimeControlsArchitectureTest {
 				0 until processEvent.indexOf("switch (event.type)")
 		)
 		assertTrue(
-			"The global authority must release every overlay owner and reset both Android swipe slots.",
+			"The global authority must release every overlay owner and the unified Android touch gesture.",
 			globalNeutralizer.contains("on_screen_joystick_release_all()") &&
-				globalNeutralizer.contains("reset_android_two_finger_swipe()")
+				globalNeutralizer.contains("android_touch_mouse_neutralize()")
 		)
 		assertTrue(
 			"Finger cancellation must neutralize globally before ordinary per-finger routing.",
@@ -235,50 +235,104 @@ class AndroidRuntimeControlsArchitectureTest {
 	}
 
 	@Test
-	fun `only unconsumed paired touch fingers start Android GUI swipes and releases retire them`() {
+	fun `one Android touch arbiter owns free-area mouse and GUI swipe routing`() {
 		val amiberryCpp = File("../../src/osdep/amiberry.cpp").readText()
-		val swipeTracker = Regex(
-			"""struct AndroidSwipeFinger[\s\S]*?#endif"""
-		).find(amiberryCpp)?.value.orEmpty()
 		val fingerEvents = Regex(
 			"""case SDL_EVENT_FINGER_DOWN:[\s\S]*?case SDL_EVENT_MOUSE_BUTTON_DOWN:"""
 		).find(amiberryCpp)?.value.orEmpty()
 		val fingerMotion = Regex(
 			"""case SDL_EVENT_FINGER_MOTION:[\s\S]*?case SDL_EVENT_MOUSE_MOTION:"""
 		).find(amiberryCpp)?.value.orEmpty()
+		val mouseButtons = Regex(
+			"""case SDL_EVENT_MOUSE_BUTTON_DOWN:[\s\S]*?case SDL_EVENT_FINGER_MOTION:"""
+		).find(amiberryCpp)?.value.orEmpty()
+		val mouseMotion = Regex(
+			"""case SDL_EVENT_MOUSE_MOTION:[\s\S]*?case SDL_EVENT_MOUSE_WHEEL:"""
+		).find(amiberryCpp)?.value.orEmpty()
+		val resolver = Regex(
+			"""static int android_resolve_touch_mouse_index\(\)[\s\S]*?\R\}"""
+		).find(amiberryCpp)?.value.orEmpty()
 		assertTrue(
-			"Swipe slots must use explicit occupancy and paired touch/finger identifiers.",
-			swipeTracker.contains("bool occupied") &&
-				swipeTracker.contains("SDL_TouchID touch_id") &&
-				swipeTracker.contains("SDL_FingerID finger_id") &&
-				swipeTracker.contains("slot.touch_id == touch_id") &&
-				swipeTracker.contains("slot.finger_id == finger_id")
+			"Android native input should use the tested pure touch-mouse arbiter.",
+			amiberryCpp.contains("#include \"android_touch_mouse.h\"") &&
+				amiberryCpp.contains("android_touch_mouse::PumpCoordinator")
+		)
+		assertTrue(
+			"Only direct physical touch devices should be eligible for trackpad routing.",
+			amiberryCpp.contains("SDL_GetTouchDeviceType(touch_id) == SDL_TOUCH_DEVICE_DIRECT") &&
+				amiberryCpp.contains("touch_id != SDL_MOUSE_TOUCHID") &&
+				amiberryCpp.contains("touch_id != SDL_PEN_TOUCHID")
+		)
+		assertTrue(
+			"Focused Android emulation should accept trackpad touch without desktop mouse capture.",
+			amiberryCpp.contains("return !gui_running && isfocus() != 0;")
+		)
+		assertTrue(
+			"The lowest configured Amiga mouse mapping should be retained instead of a hardcoded mouse index.",
+			resolver.contains("port < MAX_JPORTS") &&
+				resolver.contains("jsem_ismouse(port, &currprefs)") &&
+				amiberryCpp.contains("android_touch_mouse_index")
+		)
+		assertTrue(
+			"Trackpad-owned continuation should route before overlay hit testing.",
+			fingerEvents.indexOf("android_touch_mouse_owns(event)") in
+				0 until fingerEvents.indexOf("imgui_osk_should_render()") &&
+				fingerMotion.indexOf("android_touch_mouse_owns(event)") in
+					0 until fingerMotion.indexOf("imgui_osk_should_render()")
+		)
+		assertTrue(
+			"An added same-device contact should terminate a held drag before an overlay may acquire it.",
+			fingerEvents.indexOf("android_touch_mouse_prepare_added_contact(event)") in
+				0 until fingerEvents.indexOf("imgui_osk_should_render()")
+		)
+		assertTrue(
+			"Touch-synthesized mouse events must be suppressed across eligible active emulation before finger ownership exists.",
+			mouseButtons.contains("android_touch_mouse_route_eligible()") &&
+				mouseButtons.contains("event.button.which == SDL_TOUCH_MOUSEID") &&
+				mouseMotion.contains("android_touch_mouse_route_eligible()") &&
+				mouseMotion.contains("event.motion.which == SDL_TOUCH_MOUSEID")
+		)
+		assertTrue(
+			"Real mouse and pen events should remain outside the touch-synthetic filter.",
+			!mouseButtons.contains("event.button.which != SDL_TOUCH_MOUSEID") &&
+				!mouseMotion.contains("event.motion.which != SDL_TOUCH_MOUSEID")
 		)
 		assertFalse(
-			"Swipe occupancy must not use a zero identifier sentinel.",
-			swipeTracker.contains("finger_ids[0] == 0") ||
-				swipeTracker.contains("finger_ids[slot] = 0")
+			"The independent Android GUI-swipe recognizer must be removed.",
+			amiberryCpp.contains("handle_android_two_finger_swipe")
 		)
 		assertTrue(
-			"Overlay-consumed downs must stay excluded, while every up can retire a previously tracked swipe finger.",
-			Regex("""if \(!consumed \|\| event\.type == SDL_EVENT_FINGER_UP\)\s*handle_android_two_finger_swipe\(event\);""")
-				.containsMatchIn(fingerEvents)
+			"Legacy capture-based finger mouse handling should be excluded from Android builds.",
+			Regex("""#ifndef __ANDROID__\s*static void handle_finger_event""")
+				.containsMatchIn(amiberryCpp) &&
+				Regex("""#ifndef __ANDROID__\s*static void handle_finger_motion_event""")
+					.containsMatchIn(amiberryCpp)
+		)
+	}
+
+	@Test
+	fun `Android touch mouse pump preserves click and deadline ordering`() {
+		val amiberryCpp = File("../../src/osdep/amiberry.cpp").readText()
+		val pump = Regex(
+			"""int handle_msgpump\(bool vblank\)[\s\S]*?bool handle_events\(\)"""
+		).find(amiberryCpp)?.value.orEmpty()
+		val entryDrain = pump.indexOf("drain_pending_touch_neutralization()")
+		val retireClick = pump.indexOf("android_touch_mouse_begin_pump()")
+		val pollEvents = pump.indexOf("while (SDL_PollEvent(&event))")
+		val secondDrain = pump.indexOf("drain_pending_touch_neutralization()", entryDrain + 1)
+		val deadlineTick = pump.indexOf("android_touch_mouse_tick(SDL_GetTicksNS())")
+
+		assertTrue(
+			"The main pump should drain, retire the prior click, process queued events, drain again, then tick nanosecond deadlines.",
+			entryDrain >= 0 && retireClick > entryDrain && pollEvents > retireClick &&
+				secondDrain > pollEvents && deadlineTick > secondDrain
 		)
 		assertTrue(
-			"Overlay-consumed motion must not participate in the GUI swipe gesture.",
-			Regex("""if \(!consumed\)\s*handle_android_two_finger_swipe\(event\);""")
-				.containsMatchIn(fingerMotion)
-		)
-		assertTrue(
-			"Two ordinary unconsumed fingers must retain the existing downward-swipe GUI action.",
-			swipeTracker.contains("android_swipe_finger_count() != 2") &&
-				swipeTracker.contains("inputdevice_add_inputcode(AKS_ENTERGUI, 1, nullptr)")
-		)
-		assertTrue(
-			"Global swipe reset must clear both occupied slots and the triggered state.",
-			swipeTracker.contains("static void reset_android_two_finger_swipe()") &&
-				swipeTracker.contains("slot = {}") &&
-				swipeTracker.contains("android_swipe_triggered = false")
+			"Android left and right guest writes should pass through source composition.",
+			amiberryCpp.contains("android_set_composed_mouse_button") &&
+				amiberryCpp.contains("ButtonSource::physical") &&
+				amiberryCpp.contains("ButtonSource::pen") &&
+				amiberryCpp.contains("ButtonSource::gesture")
 		)
 	}
 

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/AndroidRuntimeControlsArchitectureTest.kt
@@ -170,6 +170,15 @@ class AndroidRuntimeControlsArchitectureTest {
 		val processEvent = Regex(
 			"""static void process_event\(const SDL_Event& event\)[\s\S]*?void update_clipboard"""
 		).find(amiberryCpp)?.value.orEmpty()
+		val canceledTouch = Regex(
+			"""case SDL_EVENT_FINGER_CANCELED:[\s\S]*?break;"""
+		).find(processEvent)?.value.orEmpty()
+		val backgroundCase = Regex(
+			"""case SDL_EVENT_DID_ENTER_BACKGROUND:[\s\S]*?break;"""
+		).find(processEvent)?.value.orEmpty()
+		val foregroundCase = Regex(
+			"""case SDL_EVENT_DID_ENTER_FOREGROUND:[\s\S]*?break;"""
+		).find(processEvent)?.value.orEmpty()
 
 		assertTrue(
 			"The Android SDL event filter should only publish an atomic pending-neutralization request.",
@@ -195,8 +204,7 @@ class AndroidRuntimeControlsArchitectureTest {
 			"Finger cancellation must neutralize globally before ordinary per-finger routing.",
 			processEvent.indexOf("case SDL_EVENT_FINGER_CANCELED:") in
 				0 until processEvent.indexOf("case SDL_EVENT_FINGER_DOWN:") &&
-				Regex("""case SDL_EVENT_FINGER_CANCELED:\s*neutralize_touch_controls\(\);\s*break;""")
-					.containsMatchIn(processEvent)
+				canceledTouch.contains("neutralize_touch_controls()")
 		)
 		assertTrue(
 			"Focus loss and minimization must neutralize before input unacquire.",
@@ -205,10 +213,10 @@ class AndroidRuntimeControlsArchitectureTest {
 		)
 		assertTrue(
 			"Background must neutralize before pausing, and foreground before resuming.",
-			Regex("""case SDL_EVENT_DID_ENTER_BACKGROUND:\s*neutralize_touch_controls\(\);\s*pause_sound\(\);""")
-				.containsMatchIn(processEvent) &&
-				Regex("""case SDL_EVENT_DID_ENTER_FOREGROUND:\s*neutralize_touch_controls\(\);\s*pause_emulation = 0;\s*resume_sound\(\);""")
-					.containsMatchIn(processEvent)
+			backgroundCase.indexOf("neutralize_touch_controls()") in
+				0 until backgroundCase.indexOf("pause_sound()") &&
+				foregroundCase.indexOf("neutralize_touch_controls()") in
+					0 until foregroundCase.indexOf("resume_sound()")
 		)
 		assertTrue(
 			"Quit, close, and termination must neutralize before teardown.",
@@ -333,6 +341,105 @@ class AndroidRuntimeControlsArchitectureTest {
 				amiberryCpp.contains("ButtonSource::physical") &&
 				amiberryCpp.contains("ButtonSource::pen") &&
 				amiberryCpp.contains("ButtonSource::gesture")
+		)
+	}
+
+	@Test
+	fun `Android touch mouse lifecycle boundaries share one neutralizer`() {
+		val amiberryCpp = File("../../src/osdep/amiberry.cpp").readText()
+		val pump = Regex(
+			"""int handle_msgpump\(bool vblank\)[\s\S]*?bool handle_events\(\)"""
+		).find(amiberryCpp)?.value.orEmpty()
+		val overlayTransitions = Regex(
+			"""static void android_check_touch_overlay_transitions\(\)[\s\S]*?\R\}"""
+		).find(amiberryCpp)?.value.orEmpty()
+		val penHandler = amiberryCpp
+			.substringAfter("static void handle_pen_event(const SDL_Event& event)", "")
+			.substringBefore("std::string get_filename_extension", "")
+		val penProximityIn = Regex(
+			"""case SDL_EVENT_PEN_PROXIMITY_IN:[\s\S]*?break;"""
+		).find(penHandler)?.value.orEmpty()
+		val unacquire = Regex(
+			"""void target_inputdevice_unacquire\(const bool full\)[\s\S]*?\R\}"""
+		).find(amiberryCpp)?.value.orEmpty()
+
+		assertTrue(
+			"OSK render-lifetime and joystick-enabled transitions should route through global neutralization at the pump boundary.",
+			overlayTransitions.contains("imgui_osk_should_render()") &&
+				overlayTransitions.contains("on_screen_joystick_is_enabled()") &&
+				overlayTransitions.contains("neutralize_touch_controls()") &&
+				pump.contains("android_check_touch_overlay_transitions()")
+		)
+		assertTrue(
+			"Pen proximity-in must neutralize touch before blocking acquisition, and proximity-out must require a fresh down.",
+			penProximityIn.indexOf("neutralize_touch_controls()") in
+				0 until penProximityIn.indexOf("android_pen_blocks_touch = true") &&
+				penProximityIn.indexOf("android_pen_blocks_touch = true") in
+					0 until penProximityIn.indexOf("pen_in_proximity = 1") &&
+				penHandler.contains("case SDL_EVENT_PEN_PROXIMITY_OUT:") &&
+				penHandler.contains("android_pen_blocks_touch = false")
+		)
+		assertTrue(
+			"Input unacquire should neutralize the gesture and clear every composed Android mouse-button source.",
+			unacquire.contains("android_touch_mouse_neutralize()") &&
+				unacquire.contains("android_clear_all_mouse_button_sources()")
+		)
+	}
+
+	@Test
+	fun `Android touch mouse device removal is exact and preserves single mouse mode`() {
+		val amiberryCpp = File("../../src/osdep/amiberry.cpp").readText()
+		val inputCpp = File("../../src/osdep/amiberry_input.cpp").readText()
+		val inputHeader = File("../../src/osdep/amiberry_input.h").readText()
+		val removalCase = Regex(
+			"""case SDL_EVENT_MOUSE_REMOVED:[\s\S]*?break;"""
+		).find(amiberryCpp)?.value.orEmpty()
+		val exactLookup = Regex(
+			"""int get_tracked_mouse_index_from_sdl_id\(SDL_MouseID which\)[\s\S]*?\R\}"""
+		).find(inputCpp)?.value.orEmpty()
+
+		assertTrue(
+			"The input layer should expose an exact tracked-device lookup for teardown.",
+			inputHeader.contains("get_tracked_mouse_index_from_sdl_id") &&
+				exactLookup.contains("!currprefs.input_multi_mouse") &&
+				exactLookup.contains("return -1") &&
+				exactLookup.contains("mouse_id_map[i] == which")
+		)
+		assertTrue(
+			"Removal should resolve the exact index before mutating input mappings and clear only that composed index.",
+			removalCase.indexOf("get_tracked_mouse_index_from_sdl_id") in
+				0 until removalCase.indexOf("handle_sdl_mouse_removed") &&
+				removalCase.contains("android_handle_removed_mouse_index")
+		)
+	}
+
+	@Test
+	fun `GUI swipe filter drains only its exact touch synthesized stream`() {
+		val amiberryCpp = File("../../src/osdep/amiberry.cpp").readText()
+		val eventFilter = Regex(
+			"""static bool SDLCALL android_touch_event_filter[\s\S]*?\R\}"""
+		).find(amiberryCpp)?.value.orEmpty()
+		val publisher = Regex(
+			"""static void android_publish_gui_swipe_filter[\s\S]*?\R\}"""
+		).find(amiberryCpp)?.value.orEmpty()
+
+		assertTrue(
+			"A winning GUI swipe should publish both composite contact identities to atomic filter state.",
+			publisher.contains("touch_id.store") &&
+				publisher.contains("finger_id.store") &&
+				publisher.contains("android_gui_swipe_filter_active.store(true")
+		)
+		assertTrue(
+			"The SDL filter should drop only SDL_TOUCH_MOUSEID mouse events while exact GUI-swipe contacts remain active.",
+			eventFilter.contains("android_filter_gui_swipe_event(event)") &&
+				eventFilter.contains("return false") &&
+				amiberryCpp.contains("event->button.which == SDL_TOUCH_MOUSEID") &&
+				amiberryCpp.contains("event->motion.which == SDL_TOUCH_MOUSEID")
+		)
+		assertFalse(
+			"The SDL event filter must not inject guest input.",
+			eventFilter.contains("setmouse") ||
+				eventFilter.contains("inputdevice_add_inputcode")
 		)
 	}
 

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -458,7 +458,7 @@ static void android_touch_mouse_begin_pump()
 		android_touch_mouse_index);
 }
 
-static void android_touch_mouse_tick(android_touch_mouse::Timestamp now_ns)
+static void android_touch_mouse_tick()
 {
 	if (android_touch_mouse_coordinator.tracked_contacts() == 0)
 		return;
@@ -468,7 +468,8 @@ static void android_touch_mouse_tick(android_touch_mouse::Timestamp now_ns)
 	}
 	if (android_touch_mouse_index < 0)
 		return;
-	android_apply_touch_mouse_actions(android_touch_mouse_coordinator.tick(now_ns),
+	android_apply_touch_mouse_actions(
+		android_touch_mouse_coordinator.tick(SDL_GetTicksNS()),
 		android_touch_mouse_index);
 }
 
@@ -503,7 +504,6 @@ static bool SDLCALL android_touch_event_filter(void*, SDL_Event* event)
 
 static void neutralize_touch_controls()
 {
-	// Idempotently end every captured overlay and free-area touch gesture.
 	on_screen_joystick_release_all();
 #ifdef __ANDROID__
 	android_touch_mouse_neutralize();
@@ -514,8 +514,8 @@ static void drain_pending_touch_neutralization()
 {
 #ifdef __ANDROID__
 	// process_event() is the SDL event/main-thread boundary for input injection.
-	if (android_touch_neutralization_pending.load(std::memory_order_acquire)
-		&& android_touch_neutralization_pending.exchange(false, std::memory_order_acq_rel))
+	if (android_touch_neutralization_pending.exchange(false,
+		std::memory_order_acq_rel))
 		neutralize_touch_controls();
 #endif
 }
@@ -3929,7 +3929,7 @@ int handle_msgpump(bool vblank)
 	}
 	drain_pending_touch_neutralization();
 #ifdef __ANDROID__
-	android_touch_mouse_tick(SDL_GetTicksNS());
+	android_touch_mouse_tick();
 #endif
 	if (got_event && currprefs.clipboard_sharing)
 		update_clipboard();

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -144,12 +144,13 @@ static std::atomic<bool> android_touch_neutralization_pending{false};
 struct AndroidGuiSwipeFilterContact {
 	std::atomic<android_touch_mouse::TouchId> touch_id{0};
 	std::atomic<android_touch_mouse::FingerId> finger_id{0};
-	std::atomic<bool> active{false};
 };
 
 static std::array<AndroidGuiSwipeFilterContact, 2>
 	android_gui_swipe_filter_contacts;
-static std::atomic<bool> android_gui_swipe_filter_active{false};
+static constexpr std::uint32_t ANDROID_GUI_SWIPE_FILTER_ALL_CONTACTS =
+	(1u << android_gui_swipe_filter_contacts.size()) - 1u;
+static std::atomic<std::uint32_t> android_gui_swipe_filter_active_mask{0};
 
 static void neutralize_touch_controls(void);
 static bool amiberry_android_touch_identity_eligible(SDL_TouchID touch_id);
@@ -158,9 +159,7 @@ static android_touch_mouse::TouchKey amiberry_android_touch_key(const SDL_Event&
 
 static void amiberry_android_clear_gui_swipe_filter()
 {
-	android_gui_swipe_filter_active.store(false, std::memory_order_release);
-	for (auto& contact : android_gui_swipe_filter_contacts)
-		contact.active.store(false, std::memory_order_release);
+	android_gui_swipe_filter_active_mask.store(0, std::memory_order_release);
 }
 
 static void amiberry_android_publish_gui_swipe_filter(
@@ -173,14 +172,37 @@ static void amiberry_android_publish_gui_swipe_filter(
 		auto& contact = android_gui_swipe_filter_contacts[i];
 		contact.touch_id.store(keys[i].touch_id, std::memory_order_relaxed);
 		contact.finger_id.store(keys[i].finger_id, std::memory_order_relaxed);
-		contact.active.store(true, std::memory_order_release);
 	}
-	android_gui_swipe_filter_active.store(true, std::memory_order_release);
+	android_gui_swipe_filter_active_mask.store(
+		ANDROID_GUI_SWIPE_FILTER_ALL_CONTACTS, std::memory_order_release);
+}
+
+static void amiberry_android_retire_gui_swipe_filter_contact(const SDL_Event& event)
+{
+	if (event.type != SDL_EVENT_FINGER_UP
+		&& event.type != SDL_EVENT_FINGER_CANCELED)
+		return;
+	const auto key = amiberry_android_touch_key(event);
+	const auto active_mask = android_gui_swipe_filter_active_mask.load(
+		std::memory_order_acquire);
+	std::uint32_t retire_mask = 0;
+	for (std::size_t i = 0; i < android_gui_swipe_filter_contacts.size(); ++i) {
+		const std::uint32_t contact_mask = 1u << i;
+		if ((active_mask & contact_mask) == 0)
+			continue;
+		const auto& contact = android_gui_swipe_filter_contacts[i];
+		if (contact.touch_id.load(std::memory_order_relaxed) == key.touch_id
+			&& contact.finger_id.load(std::memory_order_relaxed) == key.finger_id)
+			retire_mask |= contact_mask;
+	}
+	if (retire_mask != 0)
+		android_gui_swipe_filter_active_mask.fetch_and(
+			~retire_mask, std::memory_order_acq_rel);
 }
 
 static bool amiberry_android_filter_gui_swipe_event(const SDL_Event* event)
 {
-	if (!android_gui_swipe_filter_active.load(std::memory_order_acquire))
+	if (android_gui_swipe_filter_active_mask.load(std::memory_order_acquire) == 0)
 		return false;
 	if ((event->type == SDL_EVENT_MOUSE_BUTTON_DOWN
 		|| event->type == SDL_EVENT_MOUSE_BUTTON_UP)
@@ -189,22 +211,7 @@ static bool amiberry_android_filter_gui_swipe_event(const SDL_Event* event)
 	if (event->type == SDL_EVENT_MOUSE_MOTION
 		&& event->motion.which == SDL_TOUCH_MOUSEID)
 		return true;
-	if (event->type != SDL_EVENT_FINGER_UP
-		&& event->type != SDL_EVENT_FINGER_CANCELED)
-		return false;
-
-	bool any_active = false;
-	for (auto& contact : android_gui_swipe_filter_contacts) {
-		if (contact.active.load(std::memory_order_acquire)
-			&& contact.touch_id.load(std::memory_order_relaxed)
-				== static_cast<android_touch_mouse::TouchId>(event->tfinger.touchID)
-			&& contact.finger_id.load(std::memory_order_relaxed)
-				== static_cast<android_touch_mouse::FingerId>(event->tfinger.fingerID))
-			contact.active.store(false, std::memory_order_release);
-		if (contact.active.load(std::memory_order_acquire))
-			any_active = true;
-	}
-	android_gui_swipe_filter_active.store(any_active, std::memory_order_release);
+	amiberry_android_retire_gui_swipe_filter_contact(*event);
 	return false;
 }
 
@@ -3647,6 +3654,9 @@ static AmigaMonitor* monitor_from_window_id(SDL_WindowID window_id)
 static void process_event(const SDL_Event& event)
 {
 	drain_pending_touch_neutralization();
+#ifdef __ANDROID__
+	amiberry_android_retire_gui_swipe_filter_contact(event);
+#endif
 	AmigaMonitor* mon = &AMonitors[0];
 
 	if (event.type >= SDL_EVENT_WINDOW_FIRST && event.type <= SDL_EVENT_WINDOW_LAST) {

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -135,7 +135,114 @@ static int android_touch_mouse_index = -1;
 static int android_touch_mouse_window_width = 640;
 static int android_touch_mouse_window_height = 480;
 static double android_touch_mouse_display_scale = 1.0;
+static std::vector<android_touch_mouse::TouchKey> android_touch_mouse_drain;
+static bool android_last_osk_rendering = false;
+static bool android_last_joystick_enabled = false;
+static bool android_pen_blocks_touch = false;
 static std::atomic<bool> android_touch_neutralization_pending{false};
+
+struct AndroidGuiSwipeFilterContact {
+	std::atomic<android_touch_mouse::TouchId> touch_id{0};
+	std::atomic<android_touch_mouse::FingerId> finger_id{0};
+	std::atomic<bool> active{false};
+};
+
+static std::array<AndroidGuiSwipeFilterContact, 2>
+	android_gui_swipe_filter_contacts;
+static std::atomic<bool> android_gui_swipe_filter_active{false};
+
+static void neutralize_touch_controls(void);
+static bool android_direct_touch_eligible(SDL_TouchID touch_id);
+static android_touch_mouse::TouchKey android_touch_key(const SDL_Event& event);
+
+static void android_clear_gui_swipe_filter()
+{
+	android_gui_swipe_filter_active.store(false, std::memory_order_release);
+	for (auto& contact : android_gui_swipe_filter_contacts)
+		contact.active.store(false, std::memory_order_release);
+}
+
+static void android_publish_gui_swipe_filter(
+	const std::vector<android_touch_mouse::TouchKey>& keys)
+{
+	android_clear_gui_swipe_filter();
+	if (keys.size() < android_gui_swipe_filter_contacts.size())
+		return;
+	for (std::size_t i = 0; i < android_gui_swipe_filter_contacts.size(); ++i) {
+		auto& contact = android_gui_swipe_filter_contacts[i];
+		contact.touch_id.store(keys[i].touch_id, std::memory_order_relaxed);
+		contact.finger_id.store(keys[i].finger_id, std::memory_order_relaxed);
+		contact.active.store(true, std::memory_order_release);
+	}
+	android_gui_swipe_filter_active.store(true, std::memory_order_release);
+}
+
+static bool android_filter_gui_swipe_event(const SDL_Event* event)
+{
+	if (!android_gui_swipe_filter_active.load(std::memory_order_acquire))
+		return false;
+	if ((event->type == SDL_EVENT_MOUSE_BUTTON_DOWN
+		|| event->type == SDL_EVENT_MOUSE_BUTTON_UP)
+		&& event->button.which == SDL_TOUCH_MOUSEID)
+		return true;
+	if (event->type == SDL_EVENT_MOUSE_MOTION
+		&& event->motion.which == SDL_TOUCH_MOUSEID)
+		return true;
+	if (event->type != SDL_EVENT_FINGER_UP
+		&& event->type != SDL_EVENT_FINGER_CANCELED)
+		return false;
+
+	bool any_active = false;
+	for (auto& contact : android_gui_swipe_filter_contacts) {
+		if (contact.active.load(std::memory_order_acquire)
+			&& contact.touch_id.load(std::memory_order_relaxed)
+				== static_cast<android_touch_mouse::TouchId>(event->tfinger.touchID)
+			&& contact.finger_id.load(std::memory_order_relaxed)
+				== static_cast<android_touch_mouse::FingerId>(event->tfinger.fingerID))
+			contact.active.store(false, std::memory_order_release);
+		if (contact.active.load(std::memory_order_acquire))
+			any_active = true;
+	}
+	android_gui_swipe_filter_active.store(any_active, std::memory_order_release);
+	return false;
+}
+
+static void android_clear_touch_drain()
+{
+	android_touch_mouse_drain.clear();
+}
+
+static void android_seed_touch_drain()
+{
+	if (android_touch_mouse_coordinator.state()
+		== android_touch_mouse::State::gui_consumed)
+		return;
+	const auto keys = android_touch_mouse_coordinator.tracked_keys();
+	if (keys.empty())
+		return;
+	android_touch_mouse_drain = keys;
+}
+
+static bool android_handle_drained_touch(const SDL_Event& event)
+{
+	if (android_touch_mouse_drain.empty()
+		|| !android_direct_touch_eligible(event.tfinger.touchID))
+		return false;
+	const auto key = android_touch_key(event);
+	if (key.touch_id != android_touch_mouse_drain.front().touch_id)
+		return false;
+	const auto found = std::find(android_touch_mouse_drain.begin(),
+		android_touch_mouse_drain.end(), key);
+	if (event.type == SDL_EVENT_FINGER_DOWN
+		&& found == android_touch_mouse_drain.end()) {
+		android_touch_mouse_drain.push_back(key);
+	} else if ((event.type == SDL_EVENT_FINGER_UP
+		|| event.type == SDL_EVENT_FINGER_CANCELED)
+		&& found != android_touch_mouse_drain.end()) {
+		android_touch_mouse_drain.erase(found);
+	}
+	return true;
+}
 
 static bool android_touch_mouse_route_eligible()
 {
@@ -180,6 +287,31 @@ static void android_set_composed_mouse_button(int mouse_index,
 	setmousebuttonstate(mouse_index, button_index, transition->pressed ? 1 : 0);
 }
 
+static void android_apply_button_transitions(int mouse_index,
+	const std::vector<android_touch_mouse::ButtonTransition>& transitions)
+{
+	for (const auto& transition : transitions) {
+		const int button_index = transition.button
+			== android_touch_mouse::MouseButton::left ? 0 : 1;
+		setmousebuttonstate(mouse_index, button_index,
+			transition.pressed ? 1 : 0);
+	}
+}
+
+static void android_clear_mouse_button_sources(int mouse_index)
+{
+	if (mouse_index < 0 || mouse_index >= MAX_INPUT_DEVICES)
+		return;
+	android_apply_button_transitions(mouse_index,
+		android_mouse_button_sources[mouse_index].clear_all());
+}
+
+static void android_clear_all_mouse_button_sources()
+{
+	for (int mouse_index = 0; mouse_index < MAX_INPUT_DEVICES; ++mouse_index)
+		android_clear_mouse_button_sources(mouse_index);
+}
+
 static void android_apply_touch_mouse_actions(
 	const std::vector<android_touch_mouse::Action>& actions, int mouse_index)
 {
@@ -187,6 +319,8 @@ static void android_apply_touch_mouse_actions(
 	using android_touch_mouse::ButtonSource;
 	for (const auto& action : actions) {
 		if (action.type == ActionType::open_gui) {
+			android_publish_gui_swipe_filter(
+				android_touch_mouse_coordinator.tracked_keys());
 			inputdevice_add_inputcode(AKS_ENTERGUI, 1, nullptr);
 			continue;
 		}
@@ -253,9 +387,30 @@ static bool android_touch_mouse_mapping_changed()
 
 static void android_touch_mouse_neutralize()
 {
+	android_seed_touch_drain();
 	android_apply_touch_mouse_actions(
 		android_touch_mouse_coordinator.neutralize(), android_touch_mouse_index);
 	android_touch_mouse_index = -1;
+}
+
+static void android_handle_removed_mouse_index(int mouse_index)
+{
+	if (mouse_index < 0)
+		return;
+	if (android_touch_mouse_index == mouse_index)
+		android_touch_mouse_neutralize();
+	android_clear_mouse_button_sources(mouse_index);
+}
+
+static void android_check_touch_overlay_transitions()
+{
+	const bool osk_rendering = imgui_osk_should_render();
+	const bool joystick_enabled = on_screen_joystick_is_enabled();
+	if (osk_rendering != android_last_osk_rendering
+		|| joystick_enabled != android_last_joystick_enabled)
+		neutralize_touch_controls();
+	android_last_osk_rendering = osk_rendering;
+	android_last_joystick_enabled = joystick_enabled;
 }
 
 static bool android_touch_mouse_owns(const SDL_Event& event)
@@ -277,6 +432,7 @@ static void android_touch_mouse_prepare_added_contact(const SDL_Event& event)
 static bool android_route_touch_mouse(const SDL_Event& event)
 {
 	if (!android_touch_mouse_route_eligible()
+		|| android_pen_blocks_touch
 		|| !android_direct_touch_eligible(event.tfinger.touchID))
 		return false;
 	if (android_touch_mouse_mapping_changed()) {
@@ -318,6 +474,8 @@ static void android_touch_mouse_tick(android_touch_mouse::Timestamp now_ns)
 
 static bool SDLCALL android_touch_event_filter(void*, SDL_Event* event)
 {
+	if (android_filter_gui_swipe_event(event))
+		return false;
 	// Android lifecycle delivery may occur away from the SDL event thread.
 	// Publish a request here; emulated input is neutralized by process_event().
 	switch (event->type) {
@@ -330,6 +488,9 @@ static bool SDLCALL android_touch_event_filter(void*, SDL_Event* event)
 	case SDL_EVENT_WINDOW_FOCUS_LOST:
 	case SDL_EVENT_WINDOW_MINIMIZED:
 	case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+		android_clear_gui_swipe_filter();
+		android_touch_neutralization_pending.store(true, std::memory_order_release);
+		break;
 	case SDL_EVENT_FINGER_CANCELED:
 		android_touch_neutralization_pending.store(true, std::memory_order_release);
 		break;
@@ -1584,6 +1745,10 @@ static bool accepts_uncaptured_guest_input()
 
 void target_inputdevice_unacquire(const bool full)
 {
+#ifdef __ANDROID__
+	android_touch_mouse_neutralize();
+	android_clear_all_mouse_button_sources();
+#endif
 	close_tablet(tablet);
 	tablet = NULL;
 	if (full) {
@@ -2369,6 +2534,9 @@ static int setsizemove(AmigaMonitor* mon, SDL_Window* hWnd)
 
 static void handle_focus_gained_event(AmigaMonitor* mon)
 {
+#ifdef __ANDROID__
+	android_clear_touch_drain();
+#endif
 	amiberry_active(mon, minimized);
 	unsetminimized(mon->monitor_id);
 
@@ -3280,6 +3448,10 @@ static void handle_pen_event(const SDL_Event& event)
 
 	switch (event.type) {
 	case SDL_EVENT_PEN_PROXIMITY_IN:
+#ifdef __ANDROID__
+		neutralize_touch_controls();
+		android_pen_blocks_touch = true;
+#endif
 		pen_in_proximity = 1;
 		if (tablet_real)
 			send_tablet_proximity(1);
@@ -3288,6 +3460,10 @@ static void handle_pen_event(const SDL_Event& event)
 	case SDL_EVENT_PEN_PROXIMITY_OUT:
 		pen_in_proximity = 0;
 		pen_pressure = 0;
+#ifdef __ANDROID__
+		android_pen_blocks_touch = false;
+		android_clear_touch_drain();
+#endif
 		if (tablet_real)
 			send_tablet_proximity(0);
 		break;
@@ -3487,6 +3663,9 @@ static void process_event(const SDL_Event& event)
 		case SDL_EVENT_WILL_ENTER_FOREGROUND:
 		case SDL_EVENT_DID_ENTER_FOREGROUND:
 			neutralize_touch_controls();
+#ifdef __ANDROID__
+			android_clear_touch_drain();
+#endif
 			pause_emulation = 0;
 			resume_sound();
 			break;
@@ -3541,6 +3720,9 @@ static void process_event(const SDL_Event& event)
 
 		case SDL_EVENT_FINGER_CANCELED:
 			neutralize_touch_controls();
+#ifdef __ANDROID__
+			android_clear_touch_drain();
+#endif
 			break;
 
 		case SDL_EVENT_FINGER_DOWN:
@@ -3552,6 +3734,8 @@ static void process_event(const SDL_Event& event)
 			if (mon->amiga_window)
 				SDL_GetWindowSize(mon->amiga_window, &ww, &wh);
 #ifdef __ANDROID__
+			if (android_handle_drained_touch(event))
+				break;
 			if (android_touch_mouse_owns(event)) {
 				android_route_touch_mouse(event);
 				break;
@@ -3622,6 +3806,8 @@ static void process_event(const SDL_Event& event)
 			if (mon->amiga_window)
 				SDL_GetWindowSize(mon->amiga_window, &ww, &wh);
 #ifdef __ANDROID__
+			if (android_handle_drained_touch(event))
+				break;
 			if (android_touch_mouse_owns(event)) {
 				android_route_touch_mouse(event);
 				break;
@@ -3673,6 +3859,10 @@ static void process_event(const SDL_Event& event)
 			handle_sdl_mouse_added(event.mdevice.which);
 			break;
 		case SDL_EVENT_MOUSE_REMOVED:
+#ifdef __ANDROID__
+			android_handle_removed_mouse_index(
+				get_tracked_mouse_index_from_sdl_id(event.mdevice.which));
+#endif
 			handle_sdl_mouse_removed(event.mdevice.which);
 			break;
 #endif
@@ -3725,6 +3915,7 @@ int handle_msgpump(bool vblank)
 		return 0;
 	drain_pending_touch_neutralization();
 #ifdef __ANDROID__
+	android_check_touch_overlay_transitions();
 	android_touch_mouse_begin_pump();
 #endif
 	lctrl_pressed = rctrl_pressed = lalt_pressed = ralt_pressed = lshift_pressed = rshift_pressed = lgui_pressed = rgui_pressed = false;

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -152,20 +152,21 @@ static std::array<AndroidGuiSwipeFilterContact, 2>
 static std::atomic<bool> android_gui_swipe_filter_active{false};
 
 static void neutralize_touch_controls(void);
-static bool android_direct_touch_eligible(SDL_TouchID touch_id);
-static android_touch_mouse::TouchKey android_touch_key(const SDL_Event& event);
+static bool amiberry_android_touch_identity_eligible(SDL_TouchID touch_id);
+static bool amiberry_android_direct_touch_eligible(SDL_TouchID touch_id);
+static android_touch_mouse::TouchKey amiberry_android_touch_key(const SDL_Event& event);
 
-static void android_clear_gui_swipe_filter()
+static void amiberry_android_clear_gui_swipe_filter()
 {
 	android_gui_swipe_filter_active.store(false, std::memory_order_release);
 	for (auto& contact : android_gui_swipe_filter_contacts)
 		contact.active.store(false, std::memory_order_release);
 }
 
-static void android_publish_gui_swipe_filter(
+static void amiberry_android_publish_gui_swipe_filter(
 	const std::vector<android_touch_mouse::TouchKey>& keys)
 {
-	android_clear_gui_swipe_filter();
+	amiberry_android_clear_gui_swipe_filter();
 	if (keys.size() < android_gui_swipe_filter_contacts.size())
 		return;
 	for (std::size_t i = 0; i < android_gui_swipe_filter_contacts.size(); ++i) {
@@ -177,7 +178,7 @@ static void android_publish_gui_swipe_filter(
 	android_gui_swipe_filter_active.store(true, std::memory_order_release);
 }
 
-static bool android_filter_gui_swipe_event(const SDL_Event* event)
+static bool amiberry_android_filter_gui_swipe_event(const SDL_Event* event)
 {
 	if (!android_gui_swipe_filter_active.load(std::memory_order_acquire))
 		return false;
@@ -207,12 +208,12 @@ static bool android_filter_gui_swipe_event(const SDL_Event* event)
 	return false;
 }
 
-static void android_clear_touch_drain()
+static void amiberry_android_clear_touch_drain()
 {
 	android_touch_mouse_drain.clear();
 }
 
-static void android_seed_touch_drain()
+static void amiberry_android_seed_touch_drain()
 {
 	if (android_touch_mouse_coordinator.state()
 		== android_touch_mouse::State::gui_consumed)
@@ -223,46 +224,54 @@ static void android_seed_touch_drain()
 	android_touch_mouse_drain = keys;
 }
 
-static bool android_handle_drained_touch(const SDL_Event& event)
+static bool amiberry_android_handle_drained_touch(const SDL_Event& event)
 {
 	if (android_touch_mouse_drain.empty()
-		|| !android_direct_touch_eligible(event.tfinger.touchID))
+		|| !amiberry_android_touch_identity_eligible(event.tfinger.touchID))
 		return false;
-	const auto key = android_touch_key(event);
+	const auto key = amiberry_android_touch_key(event);
 	if (key.touch_id != android_touch_mouse_drain.front().touch_id)
 		return false;
 	const auto found = std::find(android_touch_mouse_drain.begin(),
 		android_touch_mouse_drain.end(), key);
-	if (event.type == SDL_EVENT_FINGER_DOWN
-		&& found == android_touch_mouse_drain.end()) {
-		android_touch_mouse_drain.push_back(key);
-	} else if ((event.type == SDL_EVENT_FINGER_UP
-		|| event.type == SDL_EVENT_FINGER_CANCELED)
-		&& found != android_touch_mouse_drain.end()) {
-		android_touch_mouse_drain.erase(found);
+	if (found != android_touch_mouse_drain.end()) {
+		if (event.type == SDL_EVENT_FINGER_UP
+			|| event.type == SDL_EVENT_FINGER_CANCELED)
+			android_touch_mouse_drain.erase(found);
+		return true;
 	}
-	return true;
+	if (event.type == SDL_EVENT_FINGER_DOWN
+		&& amiberry_android_direct_touch_eligible(event.tfinger.touchID)) {
+		android_touch_mouse_drain.push_back(key);
+		return true;
+	}
+	return false;
 }
 
-static bool android_touch_mouse_route_eligible()
+static bool amiberry_android_touch_mouse_route_eligible()
 {
 	return !gui_running && isfocus() != 0;
 }
 
-static bool android_direct_touch_eligible(SDL_TouchID touch_id)
+static bool amiberry_android_touch_identity_eligible(SDL_TouchID touch_id)
 {
 	return touch_id != SDL_MOUSE_TOUCHID
-		&& touch_id != SDL_PEN_TOUCHID
+		&& touch_id != SDL_PEN_TOUCHID;
+}
+
+static bool amiberry_android_direct_touch_eligible(SDL_TouchID touch_id)
+{
+	return amiberry_android_touch_identity_eligible(touch_id)
 		&& SDL_GetTouchDeviceType(touch_id) == SDL_TOUCH_DEVICE_DIRECT;
 }
 
-static android_touch_mouse::TouchKey android_touch_key(const SDL_Event& event)
+static android_touch_mouse::TouchKey amiberry_android_touch_key(const SDL_Event& event)
 {
 	return {static_cast<android_touch_mouse::TouchId>(event.tfinger.touchID),
 		static_cast<android_touch_mouse::FingerId>(event.tfinger.fingerID)};
 }
 
-static int android_resolve_touch_mouse_index()
+static int amiberry_android_resolve_touch_mouse_index()
 {
 	for (int port = 0; port < MAX_JPORTS; ++port) {
 		const int mouse_index = jsem_ismouse(port, &currprefs);
@@ -272,7 +281,7 @@ static int android_resolve_touch_mouse_index()
 	return -1;
 }
 
-static void android_set_composed_mouse_button(int mouse_index,
+static void amiberry_android_set_composed_mouse_button(int mouse_index,
 	android_touch_mouse::ButtonSource source,
 	android_touch_mouse::MouseButton button, bool pressed)
 {
@@ -287,7 +296,7 @@ static void android_set_composed_mouse_button(int mouse_index,
 	setmousebuttonstate(mouse_index, button_index, transition->pressed ? 1 : 0);
 }
 
-static void android_apply_button_transitions(int mouse_index,
+static void amiberry_android_apply_button_transitions(int mouse_index,
 	const std::vector<android_touch_mouse::ButtonTransition>& transitions)
 {
 	for (const auto& transition : transitions) {
@@ -298,28 +307,28 @@ static void android_apply_button_transitions(int mouse_index,
 	}
 }
 
-static void android_clear_mouse_button_sources(int mouse_index)
+static void amiberry_android_clear_mouse_button_sources(int mouse_index)
 {
 	if (mouse_index < 0 || mouse_index >= MAX_INPUT_DEVICES)
 		return;
-	android_apply_button_transitions(mouse_index,
+	amiberry_android_apply_button_transitions(mouse_index,
 		android_mouse_button_sources[mouse_index].clear_all());
 }
 
-static void android_clear_all_mouse_button_sources()
+static void amiberry_android_clear_all_mouse_button_sources()
 {
 	for (int mouse_index = 0; mouse_index < MAX_INPUT_DEVICES; ++mouse_index)
-		android_clear_mouse_button_sources(mouse_index);
+		amiberry_android_clear_mouse_button_sources(mouse_index);
 }
 
-static void android_apply_touch_mouse_actions(
+static void amiberry_android_apply_touch_mouse_actions(
 	const std::vector<android_touch_mouse::Action>& actions, int mouse_index)
 {
 	using android_touch_mouse::ActionType;
 	using android_touch_mouse::ButtonSource;
 	for (const auto& action : actions) {
 		if (action.type == ActionType::open_gui) {
-			android_publish_gui_swipe_filter(
+			amiberry_android_publish_gui_swipe_filter(
 				android_touch_mouse_coordinator.tracked_keys());
 			inputdevice_add_inputcode(AKS_ENTERGUI, 1, nullptr);
 			continue;
@@ -333,7 +342,7 @@ static void android_apply_touch_mouse_actions(
 			break;
 		case ActionType::button_down:
 		case ActionType::button_up:
-			android_set_composed_mouse_button(mouse_index, ButtonSource::gesture,
+			amiberry_android_set_composed_mouse_button(mouse_index, ButtonSource::gesture,
 				action.button, action.type == ActionType::button_down);
 			break;
 		case ActionType::click_pulse:
@@ -343,7 +352,7 @@ static void android_apply_touch_mouse_actions(
 	}
 }
 
-static void android_snapshot_touch_geometry(const SDL_Event& event)
+static void amiberry_android_snapshot_touch_geometry(const SDL_Event& event)
 {
 	SDL_Window* window = SDL_GetWindowFromID(event.tfinger.windowID);
 	if (!window)
@@ -360,7 +369,7 @@ static void android_snapshot_touch_geometry(const SDL_Event& event)
 	android_touch_mouse_display_scale = scale > 0.0f ? scale : 1.0;
 }
 
-static android_touch_mouse::TouchFact android_touch_fact(const SDL_Event& event)
+static android_touch_mouse::TouchFact amiberry_android_touch_fact(const SDL_Event& event)
 {
 	using android_touch_mouse::ContactPhase;
 	ContactPhase phase = ContactPhase::motion;
@@ -373,36 +382,36 @@ static android_touch_mouse::TouchFact android_touch_fact(const SDL_Event& event)
 	const double width = android_touch_mouse_window_width;
 	const double height = android_touch_mouse_window_height;
 	const double scale = android_touch_mouse_display_scale;
-	return {android_touch_key(event), phase, event.tfinger.timestamp,
+	return {amiberry_android_touch_key(event), phase, event.tfinger.timestamp,
 		event.tfinger.x * width / scale, event.tfinger.y * height / scale,
 		event.tfinger.dx * width, event.tfinger.dy * height,
 		event.tfinger.y};
 }
 
-static bool android_touch_mouse_mapping_changed()
+static bool amiberry_android_touch_mouse_mapping_changed()
 {
 	return android_touch_mouse_coordinator.tracked_contacts() > 0
-		&& android_resolve_touch_mouse_index() != android_touch_mouse_index;
+		&& amiberry_android_resolve_touch_mouse_index() != android_touch_mouse_index;
 }
 
-static void android_touch_mouse_neutralize()
+static void amiberry_android_touch_mouse_neutralize()
 {
-	android_seed_touch_drain();
-	android_apply_touch_mouse_actions(
+	amiberry_android_seed_touch_drain();
+	amiberry_android_apply_touch_mouse_actions(
 		android_touch_mouse_coordinator.neutralize(), android_touch_mouse_index);
 	android_touch_mouse_index = -1;
 }
 
-static void android_handle_removed_mouse_index(int mouse_index)
+static void amiberry_android_handle_removed_mouse_index(int mouse_index)
 {
 	if (mouse_index < 0)
 		return;
 	if (android_touch_mouse_index == mouse_index)
-		android_touch_mouse_neutralize();
-	android_clear_mouse_button_sources(mouse_index);
+		amiberry_android_touch_mouse_neutralize();
+	amiberry_android_clear_mouse_button_sources(mouse_index);
 }
 
-static void android_check_touch_overlay_transitions()
+static void amiberry_android_check_touch_overlay_transitions()
 {
 	const bool osk_rendering = imgui_osk_should_render();
 	const bool joystick_enabled = on_screen_joystick_is_enabled();
@@ -413,69 +422,73 @@ static void android_check_touch_overlay_transitions()
 	android_last_joystick_enabled = joystick_enabled;
 }
 
-static bool android_touch_mouse_owns(const SDL_Event& event)
+static bool amiberry_android_touch_mouse_owns(const SDL_Event& event)
 {
-	return android_direct_touch_eligible(event.tfinger.touchID)
-		&& android_touch_mouse_coordinator.owns(android_touch_key(event));
+	return amiberry_android_touch_identity_eligible(event.tfinger.touchID)
+		&& android_touch_mouse_coordinator.owns(amiberry_android_touch_key(event));
 }
 
-static void android_touch_mouse_prepare_added_contact(const SDL_Event& event)
+static void amiberry_android_touch_mouse_prepare_added_contact(const SDL_Event& event)
 {
 	if (event.type != SDL_EVENT_FINGER_DOWN
-		|| !android_direct_touch_eligible(event.tfinger.touchID))
+		|| !amiberry_android_direct_touch_eligible(event.tfinger.touchID))
 		return;
-	android_apply_touch_mouse_actions(
+	amiberry_android_apply_touch_mouse_actions(
 		android_touch_mouse_coordinator.terminate_for_nonowning_contact(
-			android_touch_key(event)), android_touch_mouse_index);
+			amiberry_android_touch_key(event)), android_touch_mouse_index);
 }
 
-static bool android_route_touch_mouse(const SDL_Event& event)
+static bool amiberry_android_route_touch_mouse(const SDL_Event& event)
 {
-	if (!android_touch_mouse_route_eligible()
+	if (!amiberry_android_touch_mouse_route_eligible()
 		|| android_pen_blocks_touch
-		|| !android_direct_touch_eligible(event.tfinger.touchID))
+		|| !amiberry_android_touch_identity_eligible(event.tfinger.touchID))
 		return false;
-	if (android_touch_mouse_mapping_changed()) {
-		android_touch_mouse_neutralize();
+	const auto key = amiberry_android_touch_key(event);
+	const bool owned = android_touch_mouse_coordinator.owns(key);
+	if (!owned && !amiberry_android_direct_touch_eligible(event.tfinger.touchID))
+		return false;
+	if (amiberry_android_touch_mouse_mapping_changed()) {
+		amiberry_android_touch_mouse_neutralize();
 		return true;
 	}
 	if (event.type == SDL_EVENT_FINGER_DOWN
 		&& android_touch_mouse_coordinator.tracked_contacts() == 0) {
-		android_snapshot_touch_geometry(event);
-		android_touch_mouse_index = android_resolve_touch_mouse_index();
+		amiberry_android_snapshot_touch_geometry(event);
+		android_touch_mouse_index = amiberry_android_resolve_touch_mouse_index();
 	}
-	android_apply_touch_mouse_actions(
-		android_touch_mouse_coordinator.handle(android_touch_fact(event)),
+	amiberry_android_apply_touch_mouse_actions(
+		android_touch_mouse_coordinator.handle(amiberry_android_touch_fact(event)),
 		android_touch_mouse_index);
 	if (android_touch_mouse_index < 0)
 		android_touch_mouse_coordinator.forget_recent_tap();
 	return true;
 }
 
-static void android_touch_mouse_begin_pump()
+static void amiberry_android_touch_mouse_begin_pump()
 {
-	android_apply_touch_mouse_actions(android_touch_mouse_coordinator.begin_pump(),
+	amiberry_android_apply_touch_mouse_actions(android_touch_mouse_coordinator.begin_pump(),
 		android_touch_mouse_index);
 }
 
-static void android_touch_mouse_tick()
+static void amiberry_android_touch_mouse_tick()
 {
 	if (android_touch_mouse_coordinator.tracked_contacts() == 0)
 		return;
-	if (android_touch_mouse_mapping_changed()) {
-		android_touch_mouse_neutralize();
+	if (amiberry_android_touch_mouse_mapping_changed()) {
+		amiberry_android_touch_mouse_neutralize();
 		return;
 	}
 	if (android_touch_mouse_index < 0)
 		return;
-	android_apply_touch_mouse_actions(
+	amiberry_android_apply_touch_mouse_actions(
 		android_touch_mouse_coordinator.tick(SDL_GetTicksNS()),
 		android_touch_mouse_index);
 }
 
 static bool SDLCALL android_touch_event_filter(void*, SDL_Event* event)
 {
-	if (android_filter_gui_swipe_event(event))
+	if (amiberry_android_filter_gui_swipe_event(event))
 		return false;
 	// Android lifecycle delivery may occur away from the SDL event thread.
 	// Publish a request here; emulated input is neutralized by process_event().
@@ -489,7 +502,7 @@ static bool SDLCALL android_touch_event_filter(void*, SDL_Event* event)
 	case SDL_EVENT_WINDOW_FOCUS_LOST:
 	case SDL_EVENT_WINDOW_MINIMIZED:
 	case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
-		android_clear_gui_swipe_filter();
+		amiberry_android_clear_gui_swipe_filter();
 		android_touch_neutralization_pending.store(true, std::memory_order_release);
 		break;
 	case SDL_EVENT_FINGER_CANCELED:
@@ -506,7 +519,7 @@ static void neutralize_touch_controls()
 {
 	on_screen_joystick_release_all();
 #ifdef __ANDROID__
-	android_touch_mouse_neutralize();
+	amiberry_android_touch_mouse_neutralize();
 #endif
 }
 
@@ -1746,8 +1759,8 @@ static bool accepts_uncaptured_guest_input()
 void target_inputdevice_unacquire(const bool full)
 {
 #ifdef __ANDROID__
-	android_touch_mouse_neutralize();
-	android_clear_all_mouse_button_sources();
+	amiberry_android_touch_mouse_neutralize();
+	amiberry_android_clear_all_mouse_button_sources();
 #endif
 	close_tablet(tablet);
 	tablet = NULL;
@@ -2535,7 +2548,7 @@ static int setsizemove(AmigaMonitor* mon, SDL_Window* hWnd)
 static void handle_focus_gained_event(AmigaMonitor* mon)
 {
 #ifdef __ANDROID__
-	android_clear_touch_drain();
+	amiberry_android_clear_touch_drain();
 #endif
 	amiberry_active(mon, minimized);
 	unsetminimized(mon->monitor_id);
@@ -3195,7 +3208,7 @@ static void handle_mouse_button_event(const SDL_Event& event, const AmigaMonitor
 		{
 		case SDL_BUTTON_LEFT:
 #ifdef __ANDROID__
-			android_set_composed_mouse_button(midx,
+			amiberry_android_set_composed_mouse_button(midx,
 				android_touch_mouse::ButtonSource::physical,
 				android_touch_mouse::MouseButton::left, state);
 #else
@@ -3204,7 +3217,7 @@ static void handle_mouse_button_event(const SDL_Event& event, const AmigaMonitor
 			break;
 		case SDL_BUTTON_RIGHT:
 #ifdef __ANDROID__
-			android_set_composed_mouse_button(midx,
+			amiberry_android_set_composed_mouse_button(midx,
 				android_touch_mouse::ButtonSource::physical,
 				android_touch_mouse::MouseButton::right, state);
 #else
@@ -3462,7 +3475,7 @@ static void handle_pen_event(const SDL_Event& event)
 		pen_pressure = 0;
 #ifdef __ANDROID__
 		android_pen_blocks_touch = false;
-		android_clear_touch_drain();
+		amiberry_android_clear_touch_drain();
 #endif
 		if (tablet_real)
 			send_tablet_proximity(0);
@@ -3476,7 +3489,7 @@ static void handle_pen_event(const SDL_Event& event)
 		} else {
 			pen_position_via_mouse(mon, event.ptouch.x, event.ptouch.y);
 #ifdef __ANDROID__
-			android_set_composed_mouse_button(0,
+			amiberry_android_set_composed_mouse_button(0,
 				android_touch_mouse::ButtonSource::pen,
 				android_touch_mouse::MouseButton::left, true);
 #else
@@ -3493,7 +3506,7 @@ static void handle_pen_event(const SDL_Event& event)
 		} else {
 			pen_position_via_mouse(mon, event.ptouch.x, event.ptouch.y);
 #ifdef __ANDROID__
-			android_set_composed_mouse_button(0,
+			amiberry_android_set_composed_mouse_button(0,
 				android_touch_mouse::ButtonSource::pen,
 				android_touch_mouse::MouseButton::left, false);
 #else
@@ -3543,7 +3556,7 @@ static void handle_pen_event(const SDL_Event& event)
 				setmousebuttonstate(0, 2, 1);
 			else if (btn == 2) {
 #ifdef __ANDROID__
-				android_set_composed_mouse_button(0,
+				amiberry_android_set_composed_mouse_button(0,
 					android_touch_mouse::ButtonSource::pen,
 					android_touch_mouse::MouseButton::right, true);
 #else
@@ -3567,7 +3580,7 @@ static void handle_pen_event(const SDL_Event& event)
 				setmousebuttonstate(0, 2, 0);
 			else if (btn == 2) {
 #ifdef __ANDROID__
-				android_set_composed_mouse_button(0,
+				amiberry_android_set_composed_mouse_button(0,
 					android_touch_mouse::ButtonSource::pen,
 					android_touch_mouse::MouseButton::right, false);
 #else
@@ -3664,7 +3677,7 @@ static void process_event(const SDL_Event& event)
 		case SDL_EVENT_DID_ENTER_FOREGROUND:
 			neutralize_touch_controls();
 #ifdef __ANDROID__
-			android_clear_touch_drain();
+			amiberry_android_clear_touch_drain();
 #endif
 			pause_emulation = 0;
 			resume_sound();
@@ -3721,7 +3734,7 @@ static void process_event(const SDL_Event& event)
 		case SDL_EVENT_FINGER_CANCELED:
 			neutralize_touch_controls();
 #ifdef __ANDROID__
-			android_clear_touch_drain();
+			amiberry_android_clear_touch_drain();
 #endif
 			break;
 
@@ -3734,13 +3747,13 @@ static void process_event(const SDL_Event& event)
 			if (mon->amiga_window)
 				SDL_GetWindowSize(mon->amiga_window, &ww, &wh);
 #ifdef __ANDROID__
-			if (android_handle_drained_touch(event))
+			if (amiberry_android_handle_drained_touch(event))
 				break;
-			if (android_touch_mouse_owns(event)) {
-				android_route_touch_mouse(event);
+			if (amiberry_android_touch_mouse_owns(event)) {
+				amiberry_android_route_touch_mouse(event);
 				break;
 			}
-			android_touch_mouse_prepare_added_contact(event);
+			amiberry_android_touch_mouse_prepare_added_contact(event);
 #endif
 			bool consumed = false;
 
@@ -3774,7 +3787,7 @@ static void process_event(const SDL_Event& event)
 			}
 			if (!consumed) {
 #ifdef __ANDROID__
-				android_route_touch_mouse(event);
+				amiberry_android_route_touch_mouse(event);
 #else
 				handle_finger_event(event);
 #endif
@@ -3785,7 +3798,7 @@ static void process_event(const SDL_Event& event)
 		case SDL_EVENT_MOUSE_BUTTON_DOWN:
 		case SDL_EVENT_MOUSE_BUTTON_UP:
 #ifdef __ANDROID__
-			if (android_touch_mouse_route_eligible()
+			if (amiberry_android_touch_mouse_route_eligible()
 				&& event.button.which == SDL_TOUCH_MOUSEID)
 				break;
 #endif
@@ -3806,10 +3819,10 @@ static void process_event(const SDL_Event& event)
 			if (mon->amiga_window)
 				SDL_GetWindowSize(mon->amiga_window, &ww, &wh);
 #ifdef __ANDROID__
-			if (android_handle_drained_touch(event))
+			if (amiberry_android_handle_drained_touch(event))
 				break;
-			if (android_touch_mouse_owns(event)) {
-				android_route_touch_mouse(event);
+			if (amiberry_android_touch_mouse_owns(event)) {
+				amiberry_android_route_touch_mouse(event);
 				break;
 			}
 #endif
@@ -3827,7 +3840,7 @@ static void process_event(const SDL_Event& event)
 				consumed = on_screen_joystick_handle_finger_motion(event);
 			if (!consumed) {
 #ifdef __ANDROID__
-				android_route_touch_mouse(event);
+				amiberry_android_route_touch_mouse(event);
 #else
 				handle_finger_motion_event(event, ww, wh);
 #endif
@@ -3837,7 +3850,7 @@ static void process_event(const SDL_Event& event)
 
 		case SDL_EVENT_MOUSE_MOTION:
 #ifdef __ANDROID__
-			if (android_touch_mouse_route_eligible()
+			if (amiberry_android_touch_mouse_route_eligible()
 				&& event.motion.which == SDL_TOUCH_MOUSEID)
 				break;
 #endif
@@ -3860,7 +3873,7 @@ static void process_event(const SDL_Event& event)
 			break;
 		case SDL_EVENT_MOUSE_REMOVED:
 #ifdef __ANDROID__
-			android_handle_removed_mouse_index(
+			amiberry_android_handle_removed_mouse_index(
 				get_tracked_mouse_index_from_sdl_id(event.mdevice.which));
 #endif
 			handle_sdl_mouse_removed(event.mdevice.which);
@@ -3915,8 +3928,8 @@ int handle_msgpump(bool vblank)
 		return 0;
 	drain_pending_touch_neutralization();
 #ifdef __ANDROID__
-	android_check_touch_overlay_transitions();
-	android_touch_mouse_begin_pump();
+	amiberry_android_check_touch_overlay_transitions();
+	amiberry_android_touch_mouse_begin_pump();
 #endif
 	lctrl_pressed = rctrl_pressed = lalt_pressed = ralt_pressed = lshift_pressed = rshift_pressed = lgui_pressed = rgui_pressed = false;
 	auto got_event = 0;
@@ -3929,7 +3942,7 @@ int handle_msgpump(bool vblank)
 	}
 	drain_pending_touch_neutralization();
 #ifdef __ANDROID__
-	android_touch_mouse_tick();
+	amiberry_android_touch_mouse_tick();
 #endif
 	if (got_event && currprefs.clipboard_sharing)
 		update_clipboard();

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -80,6 +80,9 @@
 #include "gui/gui_handling.h"
 #include "on_screen_joystick.h"
 #include "imgui_osk.h"
+#ifdef __ANDROID__
+#include "android_touch_mouse.h"
+#endif
 #include "macos_bookmarks.h"
 #include <mutex>
 #if !defined(LIBRETRO) && defined(AMIBERRY_HAS_CURL)
@@ -125,8 +128,193 @@ extern int run_jit_selftest_cli(void);
 extern int console_logging;
 
 #ifdef __ANDROID__
-static void reset_android_two_finger_swipe();
+static android_touch_mouse::PumpCoordinator android_touch_mouse_coordinator;
+static std::array<android_touch_mouse::ButtonSourceComposer,
+	MAX_INPUT_DEVICES> android_mouse_button_sources;
+static int android_touch_mouse_index = -1;
+static int android_touch_mouse_window_width = 640;
+static int android_touch_mouse_window_height = 480;
+static double android_touch_mouse_display_scale = 1.0;
 static std::atomic<bool> android_touch_neutralization_pending{false};
+
+static bool android_touch_mouse_route_eligible()
+{
+	return !gui_running && isfocus() != 0;
+}
+
+static bool android_direct_touch_eligible(SDL_TouchID touch_id)
+{
+	return touch_id != SDL_MOUSE_TOUCHID
+		&& touch_id != SDL_PEN_TOUCHID
+		&& SDL_GetTouchDeviceType(touch_id) == SDL_TOUCH_DEVICE_DIRECT;
+}
+
+static android_touch_mouse::TouchKey android_touch_key(const SDL_Event& event)
+{
+	return {static_cast<android_touch_mouse::TouchId>(event.tfinger.touchID),
+		static_cast<android_touch_mouse::FingerId>(event.tfinger.fingerID)};
+}
+
+static int android_resolve_touch_mouse_index()
+{
+	for (int port = 0; port < MAX_JPORTS; ++port) {
+		const int mouse_index = jsem_ismouse(port, &currprefs);
+		if (mouse_index >= 0)
+			return mouse_index;
+	}
+	return -1;
+}
+
+static void android_set_composed_mouse_button(int mouse_index,
+	android_touch_mouse::ButtonSource source,
+	android_touch_mouse::MouseButton button, bool pressed)
+{
+	if (mouse_index < 0 || mouse_index >= MAX_INPUT_DEVICES)
+		return;
+	const auto transition = android_mouse_button_sources[mouse_index].set(
+		source, button, pressed);
+	if (!transition)
+		return;
+	const int button_index = transition->button == android_touch_mouse::MouseButton::left
+		? 0 : 1;
+	setmousebuttonstate(mouse_index, button_index, transition->pressed ? 1 : 0);
+}
+
+static void android_apply_touch_mouse_actions(
+	const std::vector<android_touch_mouse::Action>& actions, int mouse_index)
+{
+	using android_touch_mouse::ActionType;
+	using android_touch_mouse::ButtonSource;
+	for (const auto& action : actions) {
+		if (action.type == ActionType::open_gui) {
+			inputdevice_add_inputcode(AKS_ENTERGUI, 1, nullptr);
+			continue;
+		}
+		if (mouse_index < 0)
+			continue;
+		switch (action.type) {
+		case ActionType::relative_delta:
+			setmousestate(mouse_index, 0, action.delta_x, 0);
+			setmousestate(mouse_index, 1, action.delta_y, 0);
+			break;
+		case ActionType::button_down:
+		case ActionType::button_up:
+			android_set_composed_mouse_button(mouse_index, ButtonSource::gesture,
+				action.button, action.type == ActionType::button_down);
+			break;
+		case ActionType::click_pulse:
+		case ActionType::open_gui:
+			break;
+		}
+	}
+}
+
+static void android_snapshot_touch_geometry(const SDL_Event& event)
+{
+	SDL_Window* window = SDL_GetWindowFromID(event.tfinger.windowID);
+	if (!window)
+		return;
+	int width = 0;
+	int height = 0;
+	SDL_GetWindowSize(window, &width, &height);
+	if (width > 0)
+		android_touch_mouse_window_width = width;
+	if (height > 0)
+		android_touch_mouse_window_height = height;
+	const SDL_DisplayID display = SDL_GetDisplayForWindow(window);
+	const float scale = display ? SDL_GetDisplayContentScale(display) : 1.0f;
+	android_touch_mouse_display_scale = scale > 0.0f ? scale : 1.0;
+}
+
+static android_touch_mouse::TouchFact android_touch_fact(const SDL_Event& event)
+{
+	using android_touch_mouse::ContactPhase;
+	ContactPhase phase = ContactPhase::motion;
+	if (event.type == SDL_EVENT_FINGER_DOWN)
+		phase = ContactPhase::down;
+	else if (event.type == SDL_EVENT_FINGER_UP)
+		phase = ContactPhase::up;
+	else if (event.type == SDL_EVENT_FINGER_CANCELED)
+		phase = ContactPhase::cancel;
+	const double width = android_touch_mouse_window_width;
+	const double height = android_touch_mouse_window_height;
+	const double scale = android_touch_mouse_display_scale;
+	return {android_touch_key(event), phase, event.tfinger.timestamp,
+		event.tfinger.x * width / scale, event.tfinger.y * height / scale,
+		event.tfinger.dx * width, event.tfinger.dy * height,
+		event.tfinger.y};
+}
+
+static bool android_touch_mouse_mapping_changed()
+{
+	return android_touch_mouse_coordinator.tracked_contacts() > 0
+		&& android_resolve_touch_mouse_index() != android_touch_mouse_index;
+}
+
+static void android_touch_mouse_neutralize()
+{
+	android_apply_touch_mouse_actions(
+		android_touch_mouse_coordinator.neutralize(), android_touch_mouse_index);
+	android_touch_mouse_index = -1;
+}
+
+static bool android_touch_mouse_owns(const SDL_Event& event)
+{
+	return android_direct_touch_eligible(event.tfinger.touchID)
+		&& android_touch_mouse_coordinator.owns(android_touch_key(event));
+}
+
+static void android_touch_mouse_prepare_added_contact(const SDL_Event& event)
+{
+	if (event.type != SDL_EVENT_FINGER_DOWN
+		|| !android_direct_touch_eligible(event.tfinger.touchID))
+		return;
+	android_apply_touch_mouse_actions(
+		android_touch_mouse_coordinator.terminate_for_nonowning_contact(
+			android_touch_key(event)), android_touch_mouse_index);
+}
+
+static bool android_route_touch_mouse(const SDL_Event& event)
+{
+	if (!android_touch_mouse_route_eligible()
+		|| !android_direct_touch_eligible(event.tfinger.touchID))
+		return false;
+	if (android_touch_mouse_mapping_changed()) {
+		android_touch_mouse_neutralize();
+		return true;
+	}
+	if (event.type == SDL_EVENT_FINGER_DOWN
+		&& android_touch_mouse_coordinator.tracked_contacts() == 0) {
+		android_snapshot_touch_geometry(event);
+		android_touch_mouse_index = android_resolve_touch_mouse_index();
+	}
+	android_apply_touch_mouse_actions(
+		android_touch_mouse_coordinator.handle(android_touch_fact(event)),
+		android_touch_mouse_index);
+	if (android_touch_mouse_index < 0)
+		android_touch_mouse_coordinator.forget_recent_tap();
+	return true;
+}
+
+static void android_touch_mouse_begin_pump()
+{
+	android_apply_touch_mouse_actions(android_touch_mouse_coordinator.begin_pump(),
+		android_touch_mouse_index);
+}
+
+static void android_touch_mouse_tick(android_touch_mouse::Timestamp now_ns)
+{
+	if (android_touch_mouse_coordinator.tracked_contacts() == 0)
+		return;
+	if (android_touch_mouse_mapping_changed()) {
+		android_touch_mouse_neutralize();
+		return;
+	}
+	if (android_touch_mouse_index < 0)
+		return;
+	android_apply_touch_mouse_actions(android_touch_mouse_coordinator.tick(now_ns),
+		android_touch_mouse_index);
+}
 
 static bool SDLCALL android_touch_event_filter(void*, SDL_Event* event)
 {
@@ -154,10 +342,10 @@ static bool SDLCALL android_touch_event_filter(void*, SDL_Event* event)
 
 static void neutralize_touch_controls()
 {
-	// Idempotently end every captured joystick gesture and GUI swipe candidate.
+	// Idempotently end every captured overlay and free-area touch gesture.
 	on_screen_joystick_release_all();
 #ifdef __ANDROID__
-	reset_android_two_finger_swipe();
+	android_touch_mouse_neutralize();
 #endif
 }
 
@@ -2762,88 +2950,7 @@ static void handle_key_event(const SDL_Event& event)
 static int pen_in_proximity;
 #endif
 
-#ifdef __ANDROID__
-struct AndroidSwipeFinger {
-	bool occupied = false;
-	SDL_TouchID touch_id = 0;
-	SDL_FingerID finger_id = 0;
-	float start_y = -1.0f;
-	float y = -1.0f;
-};
-
-static AndroidSwipeFinger android_swipe_fingers[2];
-static bool android_swipe_triggered = false;
-
-static int android_find_finger_slot(SDL_TouchID touch_id, SDL_FingerID finger_id)
-{
-	for (int i = 0; i < 2; i++) {
-		const auto& slot = android_swipe_fingers[i];
-		if (slot.occupied && slot.touch_id == touch_id && slot.finger_id == finger_id)
-			return i;
-	}
-	return -1;
-}
-
-static int android_swipe_finger_count()
-{
-	int count = 0;
-	for (const auto& slot : android_swipe_fingers) {
-		if (slot.occupied)
-			count++;
-	}
-	return count;
-}
-
-static void reset_android_two_finger_swipe()
-{
-	for (auto& slot : android_swipe_fingers)
-		slot = {};
-	android_swipe_triggered = false;
-}
-
-static void handle_android_two_finger_swipe(const SDL_Event& event)
-{
-	if (event.type == SDL_EVENT_FINGER_DOWN) {
-		if (android_find_finger_slot(event.tfinger.touchID, event.tfinger.fingerID) >= 0)
-			return;
-		for (auto& slot : android_swipe_fingers) {
-			if (!slot.occupied) {
-				slot.occupied = true;
-				slot.touch_id = event.tfinger.touchID;
-				slot.finger_id = event.tfinger.fingerID;
-				slot.start_y = event.tfinger.y;
-				slot.y = event.tfinger.y;
-				android_swipe_triggered = false;
-				break;
-			}
-		}
-	} else if (event.type == SDL_EVENT_FINGER_UP) {
-		const int slot = android_find_finger_slot(
-			event.tfinger.touchID, event.tfinger.fingerID);
-		if (slot >= 0)
-			android_swipe_fingers[slot] = {};
-		if (android_swipe_finger_count() == 0)
-			reset_android_two_finger_swipe();
-	} else if (event.type == SDL_EVENT_FINGER_MOTION) {
-		if (android_swipe_triggered || android_swipe_finger_count() != 2)
-			return;
-
-		const int slot = android_find_finger_slot(
-			event.tfinger.touchID, event.tfinger.fingerID);
-		if (slot < 0)
-			return;
-
-		android_swipe_fingers[slot].y = event.tfinger.y;
-
-		if (android_swipe_fingers[0].y - android_swipe_fingers[0].start_y >= 0.15f &&
-			android_swipe_fingers[1].y - android_swipe_fingers[1].start_y >= 0.15f) {
-			android_swipe_triggered = true;
-			inputdevice_add_inputcode(AKS_ENTERGUI, 1, nullptr);
-		}
-	}
-}
-#endif
-
+#ifndef __ANDROID__
 static void handle_finger_event(const SDL_Event& event)
 {
 	if (!mouseactive || isfocus() <= 0)
@@ -2878,6 +2985,7 @@ static void handle_finger_event(const SDL_Event& event)
         }
     }
 }
+#endif
 
 static void handle_mouse_button_event(const SDL_Event& event, const AmigaMonitor* mon)
 {
@@ -2918,10 +3026,22 @@ static void handle_mouse_button_event(const SDL_Event& event, const AmigaMonitor
 		switch (button)
 		{
 		case SDL_BUTTON_LEFT:
+#ifdef __ANDROID__
+			android_set_composed_mouse_button(midx,
+				android_touch_mouse::ButtonSource::physical,
+				android_touch_mouse::MouseButton::left, state);
+#else
 			setmousebuttonstate(midx, 0, state);
+#endif
 			break;
 		case SDL_BUTTON_RIGHT:
+#ifdef __ANDROID__
+			android_set_composed_mouse_button(midx,
+				android_touch_mouse::ButtonSource::physical,
+				android_touch_mouse::MouseButton::right, state);
+#else
 			setmousebuttonstate(midx, 1, state);
+#endif
 			break;
 		case SDL_BUTTON_MIDDLE:
 			if (currprefs.input_mouse_untrap & MOUSEUNTRAP_MIDDLEBUTTON)
@@ -2941,6 +3061,7 @@ static void handle_mouse_button_event(const SDL_Event& event, const AmigaMonitor
 
 }
 
+#ifndef __ANDROID__
 static void handle_finger_motion_event(const SDL_Event& event, int window_width, int window_height)
 {
 #ifndef LIBRETRO
@@ -2963,6 +3084,7 @@ static void handle_finger_motion_event(const SDL_Event& event, int window_width,
 		setmousestate(0, 1, relY, 0);
 	}
 }
+#endif
 
 static void handle_mouse_motion_event(const SDL_Event& event, const AmigaMonitor* mon)
 {
@@ -3177,7 +3299,13 @@ static void handle_pen_event(const SDL_Event& event)
 			pen_send_current(mon, event.ptouch.x, event.ptouch.y);
 		} else {
 			pen_position_via_mouse(mon, event.ptouch.x, event.ptouch.y);
+#ifdef __ANDROID__
+			android_set_composed_mouse_button(0,
+				android_touch_mouse::ButtonSource::pen,
+				android_touch_mouse::MouseButton::left, true);
+#else
 			setmousebuttonstate(0, 0, 1);
+#endif
 		}
 		break;
 
@@ -3188,7 +3316,13 @@ static void handle_pen_event(const SDL_Event& event)
 			pen_send_current(mon, event.ptouch.x, event.ptouch.y);
 		} else {
 			pen_position_via_mouse(mon, event.ptouch.x, event.ptouch.y);
+#ifdef __ANDROID__
+			android_set_composed_mouse_button(0,
+				android_touch_mouse::ButtonSource::pen,
+				android_touch_mouse::MouseButton::left, false);
+#else
 			setmousebuttonstate(0, 0, 0);
+#endif
 		}
 		break;
 
@@ -3231,8 +3365,15 @@ static void handle_pen_event(const SDL_Event& event)
 			pen_position_via_mouse(mon, event.pbutton.x, event.pbutton.y);
 			if (btn == 1)
 				setmousebuttonstate(0, 2, 1);
-			else if (btn == 2)
+			else if (btn == 2) {
+#ifdef __ANDROID__
+				android_set_composed_mouse_button(0,
+					android_touch_mouse::ButtonSource::pen,
+					android_touch_mouse::MouseButton::right, true);
+#else
 				setmousebuttonstate(0, 1, 1);
+#endif
+			}
 		}
 		break;
 	}
@@ -3248,8 +3389,15 @@ static void handle_pen_event(const SDL_Event& event)
 			pen_position_via_mouse(mon, event.pbutton.x, event.pbutton.y);
 			if (btn == 1)
 				setmousebuttonstate(0, 2, 0);
-			else if (btn == 2)
+			else if (btn == 2) {
+#ifdef __ANDROID__
+				android_set_composed_mouse_button(0,
+					android_touch_mouse::ButtonSource::pen,
+					android_touch_mouse::MouseButton::right, false);
+#else
 				setmousebuttonstate(0, 1, 0);
+#endif
+			}
 		}
 		break;
 	}
@@ -3403,6 +3551,13 @@ static void process_event(const SDL_Event& event)
 			int ww = 0, wh = 0;
 			if (mon->amiga_window)
 				SDL_GetWindowSize(mon->amiga_window, &ww, &wh);
+#ifdef __ANDROID__
+			if (android_touch_mouse_owns(event)) {
+				android_route_touch_mouse(event);
+				break;
+			}
+			android_touch_mouse_prepare_added_contact(event);
+#endif
 			bool consumed = false;
 
 			// Let ImGui on-screen keyboard consume the event first when visible.
@@ -3433,17 +3588,23 @@ static void process_event(const SDL_Event& event)
 					imgui_osk_toggle();
 				}
 			}
+			if (!consumed) {
 #ifdef __ANDROID__
-			if (!consumed || event.type == SDL_EVENT_FINGER_UP)
-				handle_android_two_finger_swipe(event);
-#endif
-			if (!consumed)
+				android_route_touch_mouse(event);
+#else
 				handle_finger_event(event);
+#endif
+			}
 			break;
 		}
 
 		case SDL_EVENT_MOUSE_BUTTON_DOWN:
 		case SDL_EVENT_MOUSE_BUTTON_UP:
+#ifdef __ANDROID__
+			if (android_touch_mouse_route_eligible()
+				&& event.button.which == SDL_TOUCH_MOUSEID)
+				break;
+#endif
 			// Skip touch-synthesized mouse events when the on-screen keyboard or joystick is active,
 			// otherwise touches also inject unwanted mouse input into Amiga port 1
 			if ((imgui_osk_should_render() || on_screen_joystick_is_enabled()) && event.button.which == SDL_TOUCH_MOUSEID)
@@ -3460,6 +3621,12 @@ static void process_event(const SDL_Event& event)
 			int ww = 0, wh = 0;
 			if (mon->amiga_window)
 				SDL_GetWindowSize(mon->amiga_window, &ww, &wh);
+#ifdef __ANDROID__
+			if (android_touch_mouse_owns(event)) {
+				android_route_touch_mouse(event);
+				break;
+			}
+#endif
 			bool consumed = false;
 			// Let ImGui on-screen keyboard consume motion first (logical window space)
 			if (imgui_osk_should_render() && mon->amiga_window) {
@@ -3472,16 +3639,22 @@ static void process_event(const SDL_Event& event)
 			}
 			if (!consumed && !imgui_osk_should_render() && on_screen_joystick_is_enabled() && ww > 0 && wh > 0)
 				consumed = on_screen_joystick_handle_finger_motion(event);
+			if (!consumed) {
 #ifdef __ANDROID__
-			if (!consumed)
-				handle_android_two_finger_swipe(event);
-#endif
-			if (!consumed)
+				android_route_touch_mouse(event);
+#else
 				handle_finger_motion_event(event, ww, wh);
+#endif
+			}
 			break;
 		}
 
 		case SDL_EVENT_MOUSE_MOTION:
+#ifdef __ANDROID__
+			if (android_touch_mouse_route_eligible()
+				&& event.motion.which == SDL_TOUCH_MOUSEID)
+				break;
+#endif
 			// Skip touch-synthesized mouse events when touch overlays are active,
 			// otherwise overlay touches also inject unwanted mouse input into Amiga port 1
 			if ((imgui_osk_should_render() || on_screen_joystick_is_enabled()) && event.motion.which == SDL_TOUCH_MOUSEID)
@@ -3550,6 +3723,10 @@ int handle_msgpump(bool vblank)
 	 * every frame, so skipping it on any other thread is safe. */
 	if (!is_mainthread())
 		return 0;
+	drain_pending_touch_neutralization();
+#ifdef __ANDROID__
+	android_touch_mouse_begin_pump();
+#endif
 	lctrl_pressed = rctrl_pressed = lalt_pressed = ralt_pressed = lshift_pressed = rshift_pressed = lgui_pressed = rgui_pressed = false;
 	auto got_event = 0;
 	SDL_Event event;
@@ -3559,6 +3736,10 @@ int handle_msgpump(bool vblank)
 		got_event = 1;
 		process_event(event);
 	}
+	drain_pending_touch_neutralization();
+#ifdef __ANDROID__
+	android_touch_mouse_tick(SDL_GetTicksNS());
+#endif
 	if (got_event && currprefs.clipboard_sharing)
 		update_clipboard();
 	return got_event;

--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -1219,6 +1219,18 @@ int get_mouse_index_from_sdl_id(SDL_MouseID which)
 }
 
 #ifndef LIBRETRO
+int get_tracked_mouse_index_from_sdl_id(SDL_MouseID which)
+{
+	if (!currprefs.input_multi_mouse || which == 0
+		|| which == SDL_TOUCH_MOUSEID || which == SDL_PEN_MOUSEID)
+		return -1;
+	for (int i = 0; i < num_mouse; ++i) {
+		if (mouse_id_map[i] == which)
+			return i;
+	}
+	return -1;
+}
+
 void handle_sdl_mouse_added(SDL_MouseID which)
 {
 	// In single-mouse mode the hotplug event is irrelevant: the newly added

--- a/src/osdep/amiberry_input.h
+++ b/src/osdep/amiberry_input.h
@@ -163,6 +163,7 @@ extern void amiberry_restore_joystick_custom_mappings();
 // Multi-mouse support: SDL_MouseID to UAE device index mapping
 extern int get_mouse_index_from_sdl_id(SDL_MouseID which);
 #ifndef LIBRETRO
+extern int get_tracked_mouse_index_from_sdl_id(SDL_MouseID which);
 extern void handle_sdl_mouse_added(SDL_MouseID which);
 extern void handle_sdl_mouse_removed(SDL_MouseID which);
 #endif

--- a/src/osdep/android_touch_mouse.h
+++ b/src/osdep/android_touch_mouse.h
@@ -8,26 +8,14 @@
 #include <optional>
 #include <vector>
 
+#include "on_screen_joystick_capture.h"
+
 namespace android_touch_mouse {
 
-using TouchId = std::uint64_t;
-using FingerId = std::uint64_t;
+using TouchId = osj_capture::TouchId;
+using FingerId = osj_capture::FingerId;
 using Timestamp = std::uint64_t;
-
-struct TouchKey {
-	TouchId touch_id = 0;
-	FingerId finger_id = 0;
-};
-
-inline bool operator==(const TouchKey& lhs, const TouchKey& rhs)
-{
-	return lhs.touch_id == rhs.touch_id && lhs.finger_id == rhs.finger_id;
-}
-
-inline bool operator!=(const TouchKey& lhs, const TouchKey& rhs)
-{
-	return !(lhs == rhs);
-}
+using TouchKey = osj_capture::TouchKey;
 
 enum class ContactPhase {
 	down,
@@ -152,11 +140,6 @@ public:
 		return neutralize();
 	}
 
-	std::vector<Action> mapping_lost()
-	{
-		return neutralize();
-	}
-
 	std::vector<Action> terminate_for_nonowning_contact(TouchKey key)
 	{
 		if (!active_touch_id_ || key.touch_id != *active_touch_id_
@@ -276,13 +259,15 @@ private:
 			contact.origin_x, contact.origin_y) > slop_squared;
 	}
 
-	void update_contact(Contact& contact, const TouchFact& fact)
+	bool update_contact(Contact& contact, const TouchFact& fact)
 	{
 		contact.current_x = fact.gesture_x_dp;
 		contact.current_y = fact.gesture_y_dp;
 		contact.current_normalized_y = fact.normalized_y;
-		if (outside_slop(contact))
+		const bool moved_outside_slop = outside_slop(contact);
+		if (moved_outside_slop)
 			contact.tap_eligible = false;
+		return moved_outside_slop;
 	}
 
 	void reset_pair_origins()
@@ -366,7 +351,7 @@ private:
 		if (contact == contacts_.end())
 			return {};
 		const bool primary = contact == contacts_.begin();
-		update_contact(*contact, fact);
+		const bool moved_outside_slop = update_contact(*contact, fact);
 
 		if (state_ == State::one_finger)
 			return emit_relative(fact.relative_x, fact.relative_y);
@@ -374,7 +359,7 @@ private:
 		if (state_ == State::second_tap) {
 			buffered_x_ += fact.relative_x;
 			buffered_y_ += fact.relative_y;
-			if (outside_slop(*contact))
+			if (moved_outside_slop)
 				return activate_drag(MouseButton::left, State::left_drag);
 			return {};
 		}
@@ -390,7 +375,7 @@ private:
 			}
 			if (gui_swipe_complete())
 				return consume_gui_swipe();
-			if (pair_outside_slop()) {
+			if (moved_outside_slop) {
 				state_ = State::swipe_only;
 				clear_motion_accumulators();
 			}
@@ -447,12 +432,6 @@ private:
 			state_ = State::drain_until_all_up;
 		}
 		return actions;
-	}
-
-	bool pair_outside_slop() const
-	{
-		return contacts_.size() >= 2
-			&& (outside_slop(contacts_[0]) || outside_slop(contacts_[1]));
 	}
 
 	bool gui_swipe_complete() const
@@ -582,12 +561,10 @@ public:
 	{
 		std::vector<ButtonTransition> transitions;
 		for (std::size_t index = 0; index < button_count; ++index) {
-			const bool was_pressed = aggregate(index);
-			for (auto& source : sources_)
-				source[index] = false;
-			if (was_pressed)
+			if (aggregate(index))
 				transitions.push_back({button_for_index(index), false});
 		}
+		sources_ = {};
 		return transitions;
 	}
 
@@ -595,12 +572,6 @@ public:
 	{
 		const auto index = button_index(button);
 		return index && aggregate(*index);
-	}
-
-	bool source_pressed(ButtonSource source, MouseButton button) const
-	{
-		const auto index = button_index(button);
-		return index && sources_[source_index(source)][*index];
 	}
 
 private:
@@ -705,14 +676,15 @@ public:
 	}
 
 private:
-	std::vector<Action> expand(const std::vector<Action>& source_actions)
+	std::vector<Action> expand(std::vector<Action> actions)
 	{
-		std::vector<Action> actions;
-		for (const auto& action : source_actions) {
+		std::size_t output = 0;
+		for (std::size_t input = 0; input < actions.size(); ++input) {
+			const Action action = actions[input];
 			if (action.type == ActionType::click_pulse) {
 				if (!click_release_pending_)
-					actions.push_back({ActionType::button_down,
-						MouseButton::left, 0, 0});
+					actions[output++] = {ActionType::button_down,
+						MouseButton::left, 0, 0};
 				click_release_pending_ = true;
 				continue;
 			}
@@ -725,8 +697,9 @@ private:
 			if (action.type == ActionType::button_up
 				&& action.button == MouseButton::left)
 				click_release_pending_ = false;
-			actions.push_back(action);
+			actions[output++] = action;
 		}
+		actions.resize(output);
 		return actions;
 	}
 

--- a/src/osdep/android_touch_mouse.h
+++ b/src/osdep/android_touch_mouse.h
@@ -157,6 +157,29 @@ public:
 		return neutralize();
 	}
 
+	std::vector<Action> terminate_for_nonowning_contact(TouchKey key)
+	{
+		if (!active_touch_id_ || key.touch_id != *active_touch_id_
+			|| owns(key))
+			return {};
+		std::vector<Action> actions;
+		if (state_ == State::left_drag)
+			actions.push_back(button_action(ActionType::button_up, MouseButton::left));
+		else if (state_ == State::right_drag)
+			actions.push_back(button_action(ActionType::button_up, MouseButton::right));
+		else
+			return {};
+		state_ = State::drain_until_all_up;
+		recent_tap_.reset();
+		clear_motion_accumulators();
+		return actions;
+	}
+
+	void forget_recent_tap()
+	{
+		recent_tap_.reset();
+	}
+
 	State state() const
 	{
 		return state_;
@@ -601,6 +624,100 @@ private:
 	}
 
 	std::array<std::array<bool, button_count>, source_count> sources_{};
+};
+
+class PumpCoordinator {
+public:
+	explicit PumpCoordinator(GestureProfile profile = {})
+		: recognizer_(profile)
+	{
+	}
+
+	std::vector<Action> begin_pump()
+	{
+		if (!click_release_pending_)
+			return {};
+		click_release_pending_ = false;
+		return {{ActionType::button_up, MouseButton::left, 0, 0}};
+	}
+
+	std::vector<Action> handle(const TouchFact& fact)
+	{
+		return expand(recognizer_.handle(fact));
+	}
+
+	std::vector<Action> tick(Timestamp now_ns)
+	{
+		return expand(recognizer_.tick(now_ns));
+	}
+
+	std::vector<Action> neutralize()
+	{
+		auto actions = recognizer_.neutralize();
+		const bool releases_left = std::any_of(actions.begin(), actions.end(),
+			[](const Action& action) {
+				return action.type == ActionType::button_up
+					&& action.button == MouseButton::left;
+			});
+		if (click_release_pending_ && !releases_left)
+			actions.push_back({ActionType::button_up, MouseButton::left, 0, 0});
+		click_release_pending_ = false;
+		return actions;
+	}
+
+	std::vector<Action> terminate_for_nonowning_contact(TouchKey key)
+	{
+		return expand(recognizer_.terminate_for_nonowning_contact(key));
+	}
+
+	void forget_recent_tap()
+	{
+		recognizer_.forget_recent_tap();
+	}
+
+	State state() const
+	{
+		return recognizer_.state();
+	}
+
+	bool owns(TouchKey key) const
+	{
+		return recognizer_.owns(key);
+	}
+
+	std::size_t tracked_contacts() const
+	{
+		return recognizer_.tracked_contacts();
+	}
+
+private:
+	std::vector<Action> expand(const std::vector<Action>& source_actions)
+	{
+		std::vector<Action> actions;
+		for (const auto& action : source_actions) {
+			if (action.type == ActionType::click_pulse) {
+				if (!click_release_pending_)
+					actions.push_back({ActionType::button_down,
+						MouseButton::left, 0, 0});
+				click_release_pending_ = true;
+				continue;
+			}
+			if (action.type == ActionType::button_down
+				&& action.button == MouseButton::left
+				&& click_release_pending_) {
+				click_release_pending_ = false;
+				continue;
+			}
+			if (action.type == ActionType::button_up
+				&& action.button == MouseButton::left)
+				click_release_pending_ = false;
+			actions.push_back(action);
+		}
+		return actions;
+	}
+
+	Recognizer recognizer_;
+	bool click_release_pending_ = false;
 };
 
 } // namespace android_touch_mouse

--- a/src/osdep/android_touch_mouse.h
+++ b/src/osdep/android_touch_mouse.h
@@ -616,10 +616,14 @@ public:
 
 	std::vector<Action> begin_pump()
 	{
-		if (!click_release_pending_)
+		if (pending_click_pulses_ == 0)
 			return {};
-		click_release_pending_ = false;
-		return {{ActionType::button_up, MouseButton::left, 0, 0}};
+		std::vector<Action> actions{
+			{ActionType::button_up, MouseButton::left, 0, 0}};
+		--pending_click_pulses_;
+		if (pending_click_pulses_ != 0)
+			actions.push_back({ActionType::button_down, MouseButton::left, 0, 0});
+		return actions;
 	}
 
 	std::vector<Action> handle(const TouchFact& fact)
@@ -640,9 +644,9 @@ public:
 				return action.type == ActionType::button_up
 					&& action.button == MouseButton::left;
 			});
-		if (click_release_pending_ && !releases_left)
+		if (pending_click_pulses_ != 0 && !releases_left)
 			actions.push_back({ActionType::button_up, MouseButton::left, 0, 0});
-		click_release_pending_ = false;
+		pending_click_pulses_ = 0;
 		return actions;
 	}
 
@@ -683,21 +687,21 @@ private:
 		for (std::size_t input = 0; input < actions.size(); ++input) {
 			const Action action = actions[input];
 			if (action.type == ActionType::click_pulse) {
-				if (!click_release_pending_)
+				if (pending_click_pulses_ == 0)
 					actions[output++] = {ActionType::button_down,
 						MouseButton::left, 0, 0};
-				click_release_pending_ = true;
+				++pending_click_pulses_;
 				continue;
 			}
 			if (action.type == ActionType::button_down
 				&& action.button == MouseButton::left
-				&& click_release_pending_) {
-				click_release_pending_ = false;
+				&& pending_click_pulses_ != 0) {
+				pending_click_pulses_ = 0;
 				continue;
 			}
 			if (action.type == ActionType::button_up
 				&& action.button == MouseButton::left)
-				click_release_pending_ = false;
+				pending_click_pulses_ = 0;
 			actions[output++] = action;
 		}
 		actions.resize(output);
@@ -705,7 +709,7 @@ private:
 	}
 
 	Recognizer recognizer_;
-	bool click_release_pending_ = false;
+	std::size_t pending_click_pulses_ = 0;
 };
 
 } // namespace android_touch_mouse

--- a/src/osdep/android_touch_mouse.h
+++ b/src/osdep/android_touch_mouse.h
@@ -628,7 +628,22 @@ public:
 
 	std::vector<Action> handle(const TouchFact& fact)
 	{
-		return expand(recognizer_.handle(fact));
+		const State previous_state = recognizer_.state();
+		auto actions = expand(recognizer_.handle(fact));
+		const State current_state = recognizer_.state();
+		const bool starts_unrelated_gesture =
+			(previous_state == State::idle
+				&& current_state == State::one_finger)
+			|| (previous_state == State::second_tap
+				&& current_state == State::two_finger_pending);
+		if (fact.phase != ContactPhase::down
+			|| !starts_unrelated_gesture
+			|| pending_click_pulses_ == 0)
+			return actions;
+
+		auto releases = drain_pending_click_pulses();
+		releases.insert(releases.end(), actions.begin(), actions.end());
+		return releases;
 	}
 
 	std::vector<Action> tick(Timestamp now_ns)
@@ -681,6 +696,19 @@ public:
 	}
 
 private:
+	std::vector<Action> drain_pending_click_pulses()
+	{
+		std::vector<Action> actions;
+		while (pending_click_pulses_ != 0) {
+			actions.push_back({ActionType::button_up, MouseButton::left, 0, 0});
+			--pending_click_pulses_;
+			if (pending_click_pulses_ != 0)
+				actions.push_back({ActionType::button_down,
+					MouseButton::left, 0, 0});
+		}
+		return actions;
+	}
+
 	std::vector<Action> expand(std::vector<Action> actions)
 	{
 		std::size_t output = 0;

--- a/src/osdep/android_touch_mouse.h
+++ b/src/osdep/android_touch_mouse.h
@@ -1,0 +1,606 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace android_touch_mouse {
+
+using TouchId = std::uint64_t;
+using FingerId = std::uint64_t;
+using Timestamp = std::uint64_t;
+
+struct TouchKey {
+	TouchId touch_id = 0;
+	FingerId finger_id = 0;
+};
+
+inline bool operator==(const TouchKey& lhs, const TouchKey& rhs)
+{
+	return lhs.touch_id == rhs.touch_id && lhs.finger_id == rhs.finger_id;
+}
+
+inline bool operator!=(const TouchKey& lhs, const TouchKey& rhs)
+{
+	return !(lhs == rhs);
+}
+
+enum class ContactPhase {
+	down,
+	motion,
+	up,
+	cancel
+};
+
+struct TouchFact {
+	TouchKey key;
+	ContactPhase phase = ContactPhase::down;
+	Timestamp timestamp_ns = 0;
+	double gesture_x_dp = 0.0;
+	double gesture_y_dp = 0.0;
+	double relative_x = 0.0;
+	double relative_y = 0.0;
+	double normalized_y = 0.0;
+};
+
+enum class State {
+	idle,
+	one_finger,
+	second_tap,
+	left_drag,
+	two_finger_pending,
+	swipe_only,
+	right_drag,
+	gui_consumed,
+	drain_until_all_up
+};
+
+enum class MouseButton {
+	none,
+	left,
+	right
+};
+
+enum class ActionType {
+	relative_delta,
+	click_pulse,
+	button_down,
+	button_up,
+	open_gui
+};
+
+struct Action {
+	ActionType type = ActionType::relative_delta;
+	MouseButton button = MouseButton::none;
+	int delta_x = 0;
+	int delta_y = 0;
+};
+
+struct GestureProfile {
+	Timestamp hold_time_ns = 400000000ULL;
+	Timestamp double_tap_min_ns = 40000000ULL;
+	Timestamp double_tap_max_ns = 300000000ULL;
+	double movement_slop_dp = 8.0;
+	double double_tap_distance_dp = 100.0;
+	double gui_swipe_fraction = 0.15;
+};
+
+class Recognizer {
+public:
+	explicit Recognizer(GestureProfile profile = {})
+		: profile_(profile)
+	{
+	}
+
+	std::vector<Action> handle(const TouchFact& fact)
+	{
+		switch (fact.phase) {
+		case ContactPhase::down:
+			return handle_down(fact);
+		case ContactPhase::motion:
+			return handle_motion(fact);
+		case ContactPhase::up:
+			return handle_up(fact);
+		case ContactPhase::cancel:
+			return owns(fact.key) ? cancel() : std::vector<Action>{};
+		}
+		return {};
+	}
+
+	std::vector<Action> tick(Timestamp now_ns)
+	{
+		expire_recent_tap(now_ns);
+		if (contacts_.empty())
+			return {};
+
+		if (state_ == State::one_finger) {
+			if (elapsed(now_ns, contacts_.front().down_timestamp)
+				>= profile_.hold_time_ns)
+				contacts_.front().tap_eligible = false;
+			return {};
+		}
+
+		if (state_ == State::second_tap
+			&& elapsed(now_ns, contacts_.front().down_timestamp)
+				>= profile_.hold_time_ns)
+			return activate_drag(MouseButton::left, State::left_drag);
+
+		if (state_ == State::two_finger_pending
+			&& elapsed(now_ns, pair_started_at_) >= profile_.hold_time_ns)
+			return activate_drag(MouseButton::right, State::right_drag);
+
+		return {};
+	}
+
+	std::vector<Action> neutralize()
+	{
+		std::vector<Action> actions;
+		if (state_ == State::left_drag)
+			actions.push_back(button_action(ActionType::button_up, MouseButton::left));
+		else if (state_ == State::right_drag)
+			actions.push_back(button_action(ActionType::button_up, MouseButton::right));
+		reset_all();
+		return actions;
+	}
+
+	std::vector<Action> cancel()
+	{
+		return neutralize();
+	}
+
+	std::vector<Action> mapping_lost()
+	{
+		return neutralize();
+	}
+
+	State state() const
+	{
+		return state_;
+	}
+
+	bool owns(TouchKey key) const
+	{
+		return find_contact(key) != contacts_.end();
+	}
+
+	std::size_t tracked_contacts() const
+	{
+		return contacts_.size();
+	}
+
+	bool has_recent_tap() const
+	{
+		return recent_tap_.has_value();
+	}
+
+private:
+	struct Contact {
+		TouchKey key;
+		Timestamp down_timestamp = 0;
+		double origin_x = 0.0;
+		double origin_y = 0.0;
+		double current_x = 0.0;
+		double current_y = 0.0;
+		double origin_normalized_y = 0.0;
+		double current_normalized_y = 0.0;
+		bool tap_eligible = true;
+	};
+
+	struct RecentTap {
+		Timestamp up_timestamp = 0;
+		double x = 0.0;
+		double y = 0.0;
+	};
+
+	using ContactIterator = std::vector<Contact>::iterator;
+	using ConstContactIterator = std::vector<Contact>::const_iterator;
+
+	static Timestamp elapsed(Timestamp now, Timestamp then)
+	{
+		return now >= then ? now - then : 0;
+	}
+
+	static double distance_squared(double first_x, double first_y,
+		double second_x, double second_y)
+	{
+		const double dx = first_x - second_x;
+		const double dy = first_y - second_y;
+		return dx * dx + dy * dy;
+	}
+
+	static Action button_action(ActionType type, MouseButton button)
+	{
+		return {type, button, 0, 0};
+	}
+
+	Contact make_contact(const TouchFact& fact) const
+	{
+		return {fact.key, fact.timestamp_ns, fact.gesture_x_dp, fact.gesture_y_dp,
+			fact.gesture_x_dp, fact.gesture_y_dp, fact.normalized_y,
+			fact.normalized_y, true};
+	}
+
+	ContactIterator find_contact(TouchKey key)
+	{
+		return std::find_if(contacts_.begin(), contacts_.end(),
+			[key](const Contact& contact) { return contact.key == key; });
+	}
+
+	ConstContactIterator find_contact(TouchKey key) const
+	{
+		return std::find_if(contacts_.begin(), contacts_.end(),
+			[key](const Contact& contact) { return contact.key == key; });
+	}
+
+	bool outside_slop(const Contact& contact) const
+	{
+		const double slop_squared = profile_.movement_slop_dp
+			* profile_.movement_slop_dp;
+		return distance_squared(contact.current_x, contact.current_y,
+			contact.origin_x, contact.origin_y) > slop_squared;
+	}
+
+	void update_contact(Contact& contact, const TouchFact& fact)
+	{
+		contact.current_x = fact.gesture_x_dp;
+		contact.current_y = fact.gesture_y_dp;
+		contact.current_normalized_y = fact.normalized_y;
+		if (outside_slop(contact))
+			contact.tap_eligible = false;
+	}
+
+	void reset_pair_origins()
+	{
+		for (auto& contact : contacts_) {
+			contact.origin_x = contact.current_x;
+			contact.origin_y = contact.current_y;
+			contact.origin_normalized_y = contact.current_normalized_y;
+			contact.tap_eligible = true;
+		}
+	}
+
+	void expire_recent_tap(Timestamp now_ns)
+	{
+		if (!recent_tap_)
+			return;
+		if (now_ns < recent_tap_->up_timestamp
+			|| elapsed(now_ns, recent_tap_->up_timestamp)
+				> profile_.double_tap_max_ns)
+			recent_tap_.reset();
+	}
+
+	bool matches_recent_tap(const TouchFact& fact) const
+	{
+		if (!recent_tap_ || fact.timestamp_ns < recent_tap_->up_timestamp)
+			return false;
+		const Timestamp interval = elapsed(fact.timestamp_ns,
+			recent_tap_->up_timestamp);
+		if (interval < profile_.double_tap_min_ns
+			|| interval > profile_.double_tap_max_ns)
+			return false;
+		const double distance_limit = profile_.double_tap_distance_dp
+			* profile_.double_tap_distance_dp;
+		return distance_squared(fact.gesture_x_dp, fact.gesture_y_dp,
+			recent_tap_->x, recent_tap_->y) <= distance_limit;
+	}
+
+	std::vector<Action> handle_down(const TouchFact& fact)
+	{
+		if (state_ == State::idle) {
+			expire_recent_tap(fact.timestamp_ns);
+			const bool second_tap = matches_recent_tap(fact);
+			if (!second_tap)
+				recent_tap_.reset();
+			contacts_.push_back(make_contact(fact));
+			active_touch_id_ = fact.key.touch_id;
+			state_ = second_tap ? State::second_tap : State::one_finger;
+			return {};
+		}
+
+		if (!active_touch_id_ || fact.key.touch_id != *active_touch_id_
+			|| owns(fact.key))
+			return {};
+
+		if (state_ == State::one_finger || state_ == State::second_tap) {
+			contacts_.push_back(make_contact(fact));
+			reset_pair_origins();
+			pair_started_at_ = fact.timestamp_ns;
+			buffered_x_ = 0.0;
+			buffered_y_ = 0.0;
+			recent_tap_.reset();
+			state_ = State::two_finger_pending;
+			return {};
+		}
+
+		contacts_.push_back(make_contact(fact));
+		std::vector<Action> actions;
+		if (state_ == State::left_drag)
+			actions.push_back(button_action(ActionType::button_up, MouseButton::left));
+		else if (state_ == State::right_drag)
+			actions.push_back(button_action(ActionType::button_up, MouseButton::right));
+		state_ = State::drain_until_all_up;
+		recent_tap_.reset();
+		clear_motion_accumulators();
+		return actions;
+	}
+
+	std::vector<Action> handle_motion(const TouchFact& fact)
+	{
+		auto contact = find_contact(fact.key);
+		if (contact == contacts_.end())
+			return {};
+		const bool primary = contact == contacts_.begin();
+		update_contact(*contact, fact);
+
+		if (state_ == State::one_finger)
+			return emit_relative(fact.relative_x, fact.relative_y);
+
+		if (state_ == State::second_tap) {
+			buffered_x_ += fact.relative_x;
+			buffered_y_ += fact.relative_y;
+			if (outside_slop(*contact))
+				return activate_drag(MouseButton::left, State::left_drag);
+			return {};
+		}
+
+		if (state_ == State::left_drag)
+			return primary ? emit_relative(fact.relative_x, fact.relative_y)
+				: std::vector<Action>{};
+
+		if (state_ == State::two_finger_pending) {
+			if (primary) {
+				buffered_x_ += fact.relative_x;
+				buffered_y_ += fact.relative_y;
+			}
+			if (gui_swipe_complete())
+				return consume_gui_swipe();
+			if (pair_outside_slop()) {
+				state_ = State::swipe_only;
+				clear_motion_accumulators();
+			}
+			return {};
+		}
+
+		if (state_ == State::swipe_only)
+			return gui_swipe_complete() ? consume_gui_swipe()
+				: std::vector<Action>{};
+
+		if (state_ == State::right_drag)
+			return primary ? emit_relative(fact.relative_x, fact.relative_y)
+				: std::vector<Action>{};
+
+		return {};
+	}
+
+	std::vector<Action> handle_up(const TouchFact& fact)
+	{
+		auto contact = find_contact(fact.key);
+		if (contact == contacts_.end())
+			return {};
+		update_contact(*contact, fact);
+		std::vector<Action> actions;
+
+		if (state_ == State::one_finger || state_ == State::second_tap) {
+			const bool tap = contact->tap_eligible
+				&& elapsed(fact.timestamp_ns, contact->down_timestamp)
+					< profile_.hold_time_ns;
+			if (tap) {
+				actions.push_back(button_action(ActionType::click_pulse,
+					MouseButton::left));
+				recent_tap_ = RecentTap{fact.timestamp_ns,
+					contact->current_x, contact->current_y};
+			} else {
+				recent_tap_.reset();
+			}
+			contacts_.erase(contact);
+			finish_active_gesture();
+			return actions;
+		}
+
+		if (state_ == State::left_drag)
+			actions.push_back(button_action(ActionType::button_up, MouseButton::left));
+		else if (state_ == State::right_drag)
+			actions.push_back(button_action(ActionType::button_up, MouseButton::right));
+
+		contacts_.erase(contact);
+		recent_tap_.reset();
+		clear_motion_accumulators();
+		if (contacts_.empty()) {
+			finish_active_gesture();
+		} else {
+			state_ = State::drain_until_all_up;
+		}
+		return actions;
+	}
+
+	bool pair_outside_slop() const
+	{
+		return contacts_.size() >= 2
+			&& (outside_slop(contacts_[0]) || outside_slop(contacts_[1]));
+	}
+
+	bool gui_swipe_complete() const
+	{
+		if (contacts_.size() < 2)
+			return false;
+		constexpr double epsilon = 1e-12;
+		for (std::size_t index = 0; index < 2; ++index) {
+			const Contact& contact = contacts_[index];
+			if (contact.current_normalized_y - contact.origin_normalized_y
+				+ epsilon < profile_.gui_swipe_fraction)
+				return false;
+		}
+		return true;
+	}
+
+	std::vector<Action> consume_gui_swipe()
+	{
+		state_ = State::gui_consumed;
+		recent_tap_.reset();
+		clear_motion_accumulators();
+		return {{ActionType::open_gui, MouseButton::none, 0, 0}};
+	}
+
+	std::vector<Action> activate_drag(MouseButton button, State state)
+	{
+		state_ = state;
+		recent_tap_.reset();
+		std::vector<Action> actions{button_action(ActionType::button_down, button)};
+		auto movement = emit_relative(buffered_x_, buffered_y_);
+		actions.insert(actions.end(), movement.begin(), movement.end());
+		buffered_x_ = 0.0;
+		buffered_y_ = 0.0;
+		return actions;
+	}
+
+	std::vector<Action> emit_relative(double x, double y)
+	{
+		residual_x_ += x;
+		residual_y_ += y;
+		const int integer_x = static_cast<int>(std::trunc(residual_x_));
+		const int integer_y = static_cast<int>(std::trunc(residual_y_));
+		residual_x_ -= integer_x;
+		residual_y_ -= integer_y;
+		if (integer_x == 0 && integer_y == 0)
+			return {};
+		return {{ActionType::relative_delta, MouseButton::none,
+			integer_x, integer_y}};
+	}
+
+	void clear_motion_accumulators()
+	{
+		buffered_x_ = 0.0;
+		buffered_y_ = 0.0;
+		residual_x_ = 0.0;
+		residual_y_ = 0.0;
+	}
+
+	void finish_active_gesture()
+	{
+		contacts_.clear();
+		active_touch_id_.reset();
+		pair_started_at_ = 0;
+		state_ = State::idle;
+		clear_motion_accumulators();
+	}
+
+	void reset_all()
+	{
+		finish_active_gesture();
+		recent_tap_.reset();
+	}
+
+	GestureProfile profile_;
+	State state_ = State::idle;
+	std::vector<Contact> contacts_;
+	std::optional<TouchId> active_touch_id_;
+	std::optional<RecentTap> recent_tap_;
+	Timestamp pair_started_at_ = 0;
+	double buffered_x_ = 0.0;
+	double buffered_y_ = 0.0;
+	double residual_x_ = 0.0;
+	double residual_y_ = 0.0;
+};
+
+enum class ButtonSource {
+	physical,
+	pen,
+	gesture
+};
+
+struct ButtonTransition {
+	MouseButton button = MouseButton::none;
+	bool pressed = false;
+};
+
+class ButtonSourceComposer {
+public:
+	std::optional<ButtonTransition> set(ButtonSource source,
+		MouseButton button, bool pressed)
+	{
+		const auto index = button_index(button);
+		if (!index)
+			return std::nullopt;
+		const bool was_pressed = aggregate(*index);
+		sources_[source_index(source)][*index] = pressed;
+		const bool is_pressed = aggregate(*index);
+		if (was_pressed == is_pressed)
+			return std::nullopt;
+		return ButtonTransition{button, is_pressed};
+	}
+
+	std::vector<ButtonTransition> clear_source(ButtonSource source)
+	{
+		std::vector<ButtonTransition> transitions;
+		for (std::size_t index = 0; index < button_count; ++index) {
+			const bool was_pressed = aggregate(index);
+			sources_[source_index(source)][index] = false;
+			const bool is_pressed = aggregate(index);
+			if (was_pressed != is_pressed)
+				transitions.push_back({button_for_index(index), is_pressed});
+		}
+		return transitions;
+	}
+
+	std::vector<ButtonTransition> clear_all()
+	{
+		std::vector<ButtonTransition> transitions;
+		for (std::size_t index = 0; index < button_count; ++index) {
+			const bool was_pressed = aggregate(index);
+			for (auto& source : sources_)
+				source[index] = false;
+			if (was_pressed)
+				transitions.push_back({button_for_index(index), false});
+		}
+		return transitions;
+	}
+
+	bool pressed(MouseButton button) const
+	{
+		const auto index = button_index(button);
+		return index && aggregate(*index);
+	}
+
+	bool source_pressed(ButtonSource source, MouseButton button) const
+	{
+		const auto index = button_index(button);
+		return index && sources_[source_index(source)][*index];
+	}
+
+private:
+	static constexpr std::size_t source_count = 3;
+	static constexpr std::size_t button_count = 2;
+
+	static std::size_t source_index(ButtonSource source)
+	{
+		return static_cast<std::size_t>(source);
+	}
+
+	static std::optional<std::size_t> button_index(MouseButton button)
+	{
+		if (button == MouseButton::left)
+			return 0;
+		if (button == MouseButton::right)
+			return 1;
+		return std::nullopt;
+	}
+
+	static MouseButton button_for_index(std::size_t index)
+	{
+		return index == 0 ? MouseButton::left : MouseButton::right;
+	}
+
+	bool aggregate(std::size_t button) const
+	{
+		return std::any_of(sources_.begin(), sources_.end(),
+			[button](const auto& source) { return source[button]; });
+	}
+
+	std::array<std::array<bool, button_count>, source_count> sources_{};
+};
+
+} // namespace android_touch_mouse

--- a/src/osdep/android_touch_mouse.h
+++ b/src/osdep/android_touch_mouse.h
@@ -150,7 +150,8 @@ public:
 			actions.push_back(button_action(ActionType::button_up, MouseButton::left));
 		else if (state_ == State::right_drag)
 			actions.push_back(button_action(ActionType::button_up, MouseButton::right));
-		else
+		else if (state_ != State::two_finger_pending
+			&& state_ != State::swipe_only)
 			return {};
 		state_ = State::drain_until_all_up;
 		recent_tap_.reset();

--- a/src/osdep/android_touch_mouse.h
+++ b/src/osdep/android_touch_mouse.h
@@ -195,6 +195,15 @@ public:
 		return contacts_.size();
 	}
 
+	std::vector<TouchKey> tracked_keys() const
+	{
+		std::vector<TouchKey> keys;
+		keys.reserve(contacts_.size());
+		for (const auto& contact : contacts_)
+			keys.push_back(contact.key);
+		return keys;
+	}
+
 	bool has_recent_tap() const
 	{
 		return recent_tap_.has_value();
@@ -688,6 +697,11 @@ public:
 	std::size_t tracked_contacts() const
 	{
 		return recognizer_.tracked_contacts();
+	}
+
+	std::vector<TouchKey> tracked_keys() const
+	{
+		return recognizer_.tracked_keys();
 	}
 
 private:

--- a/tests/android_touch_mouse_test.cpp
+++ b/tests/android_touch_mouse_test.cpp
@@ -555,6 +555,30 @@ static void test_pump_coordinator_neutralizes_pending_click()
 		"a neutralized click must not release twice on the next pump");
 }
 
+static void test_pump_coordinator_preserves_queued_click_pulses()
+{
+	const TouchKey key{236, 936};
+	PumpCoordinator coordinator;
+	coordinator.handle(down(key, 0));
+	expect_single_action(coordinator.handle(up(key, 20)),
+		ActionType::button_down, MouseButton::left,
+		"the first queued tap must press left immediately");
+	coordinator.handle(down(key, 100));
+	expect_no_actions(coordinator.handle(up(key, 120)),
+		"the second queued tap must wait behind the active click pulse");
+
+	const auto next_pulse = coordinator.begin_pump();
+	expect(next_pulse.size() == 2
+		&& is_action(next_pulse[0], ActionType::button_up, MouseButton::left)
+		&& is_action(next_pulse[1], ActionType::button_down, MouseButton::left),
+		"a pump boundary must release the first tap before pressing the second");
+	expect_single_action(coordinator.begin_pump(),
+		ActionType::button_up, MouseButton::left,
+		"the following pump boundary must release the second tap");
+	expect_no_actions(coordinator.begin_pump(),
+		"all queued tap pulses must be retired after their final release");
+}
+
 static void test_nonowning_added_contact_terminates_before_overlay_capture()
 {
 	const TouchKey primary{241, 941};
@@ -636,6 +660,7 @@ int main()
 	test_button_source_composition();
 	test_pump_coordinator_click_and_deadline_ordering();
 	test_pump_coordinator_neutralizes_pending_click();
+	test_pump_coordinator_preserves_queued_click_pulses();
 	test_nonowning_added_contact_terminates_before_overlay_capture();
 	test_nonowning_added_contact_drains_pending_pairs();
 	return failures == 0 ? 0 : 1;

--- a/tests/android_touch_mouse_test.cpp
+++ b/tests/android_touch_mouse_test.cpp
@@ -513,6 +513,67 @@ static void test_button_source_composition()
 		"clearing the remaining source must emit the aggregate release");
 }
 
+static void test_pump_coordinator_click_and_deadline_ordering()
+{
+	const TouchKey primary{221, 921};
+	const TouchKey secondary{221, 922};
+	PumpCoordinator coordinator;
+
+	expect_no_actions(coordinator.begin_pump(),
+		"the first pump must not retire a click");
+	expect_no_actions(coordinator.handle(down(primary, 0)),
+		"tap down must remain pending in the coordinator");
+	expect_single_action(coordinator.handle(up(primary, 20)),
+		ActionType::button_down, MouseButton::left,
+		"a click pulse must become an observable left down");
+	expect_single_action(coordinator.begin_pump(),
+		ActionType::button_up, MouseButton::left,
+		"the click release must wait until the next pump boundary");
+
+	coordinator.handle(down(primary, 100, 0.0, 0.0, 0.10));
+	coordinator.handle(down(secondary, 110, 0.0, 0.0, 0.10));
+	expect_no_actions(coordinator.handle(up(primary, 509)),
+		"a queued terminal event must retire the pair without a button");
+	expect_no_actions(coordinator.tick(ns(510)),
+		"a later deadline tick must not activate a retired right hold");
+}
+
+static void test_pump_coordinator_neutralizes_pending_click()
+{
+	const TouchKey key{231, 931};
+	PumpCoordinator coordinator;
+	coordinator.handle(down(key, 0));
+	coordinator.handle(up(key, 20));
+	expect_single_action(coordinator.neutralize(), ActionType::button_up,
+		MouseButton::left,
+		"neutralization must release a click that is waiting for the next pump");
+	expect_no_actions(coordinator.begin_pump(),
+		"a neutralized click must not release twice on the next pump");
+}
+
+static void test_nonowning_added_contact_terminates_before_overlay_capture()
+{
+	const TouchKey primary{241, 941};
+	const TouchKey overlay_contact{241, 942};
+	PumpCoordinator coordinator;
+	coordinator.handle(down(primary, 0));
+	coordinator.handle(up(primary, 20));
+	coordinator.begin_pump();
+	coordinator.handle(down(primary, 100));
+	coordinator.tick(ns(500));
+
+	expect_single_action(
+		coordinator.terminate_for_nonowning_contact(overlay_contact),
+		ActionType::button_up, MouseButton::left,
+		"an overlay candidate must release an active left drag first");
+	expect(coordinator.state() == State::drain_until_all_up
+		&& coordinator.owns(primary) && !coordinator.owns(overlay_contact),
+		"the added overlay contact must remain nonowning while trackpad survivors drain");
+	expect_no_actions(coordinator.handle(motion(primary, 510, 20.0, 0.0,
+		10.0, 0.0)),
+		"a surviving trackpad contact must remain inert after overlay takeover");
+}
+
 int main()
 {
 	test_identity_and_reordered_events();
@@ -529,5 +590,8 @@ int main()
 	test_cancellation_matrix();
 	test_mapping_loss_uses_same_neutralization_contract();
 	test_button_source_composition();
+	test_pump_coordinator_click_and_deadline_ordering();
+	test_pump_coordinator_neutralizes_pending_click();
+	test_nonowning_added_contact_terminates_before_overlay_capture();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/android_touch_mouse_test.cpp
+++ b/tests/android_touch_mouse_test.cpp
@@ -1,0 +1,533 @@
+#include "android_touch_mouse.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace android_touch_mouse;
+
+static int failures = 0;
+
+static void expect(bool condition, const std::string& message)
+{
+	if (!condition) {
+		std::cerr << "FAIL: " << message << '\n';
+		failures++;
+	}
+}
+
+static Timestamp ns(std::uint64_t milliseconds)
+{
+	return milliseconds * 1000000ULL;
+}
+
+static TouchFact down(TouchKey key, std::uint64_t milliseconds,
+	double x = 0.0, double y = 0.0, double normalized_y = 0.0)
+{
+	return {key, ContactPhase::down, ns(milliseconds), x, y, 0.0, 0.0,
+		normalized_y};
+}
+
+static TouchFact motion(TouchKey key, std::uint64_t milliseconds,
+	double x, double y, double relative_x, double relative_y,
+	double normalized_y = 0.0)
+{
+	return {key, ContactPhase::motion, ns(milliseconds), x, y,
+		relative_x, relative_y, normalized_y};
+}
+
+static TouchFact up(TouchKey key, std::uint64_t milliseconds,
+	double x = 0.0, double y = 0.0, double normalized_y = 0.0)
+{
+	return {key, ContactPhase::up, ns(milliseconds), x, y, 0.0, 0.0,
+		normalized_y};
+}
+
+static bool is_action(const Action& action, ActionType type,
+	MouseButton button = MouseButton::none)
+{
+	return action.type == type && action.button == button;
+}
+
+static void expect_no_actions(const std::vector<Action>& actions,
+	const std::string& message)
+{
+	expect(actions.empty(), message);
+}
+
+static void expect_single_action(const std::vector<Action>& actions,
+	ActionType type, MouseButton button, const std::string& message)
+{
+	expect(actions.size() == 1 && is_action(actions.front(), type, button), message);
+}
+
+static void complete_tap(Recognizer& recognizer, TouchKey key,
+	std::uint64_t down_ms = 0, double x = 0.0, double y = 0.0)
+{
+	expect_no_actions(recognizer.handle(down(key, down_ms, x, y)),
+		"tap down must remain pending");
+	expect_single_action(recognizer.handle(up(key, down_ms + 20, x, y)),
+		ActionType::click_pulse, MouseButton::left,
+		"stationary short tap must emit a left click pulse");
+}
+
+static void test_identity_and_reordered_events()
+{
+	Recognizer recognizer;
+	const TouchKey first{37, 91};
+	const TouchKey same_finger_other_device{38, 91};
+	const TouchKey second_same_device{37, 407};
+
+	expect_no_actions(recognizer.handle(motion(first, 1, 1.0, 0.0, 1.0, 0.0)),
+		"motion arriving before down must be ignored");
+	expect_no_actions(recognizer.handle(up(first, 2)),
+		"up arriving before down must be ignored");
+	recognizer.handle(down(first, 10));
+	expect(recognizer.owns(first),
+		"arbitrary nonzero touch and finger IDs must be tracked exactly");
+	expect_no_actions(recognizer.handle(down(same_finger_other_device, 15)),
+		"same finger ID on another device must not join the active gesture");
+	expect(!recognizer.owns(same_finger_other_device)
+		&& recognizer.state() == State::one_finger,
+		"device identity must be part of the contact key");
+	expect_no_actions(recognizer.handle(down(second_same_device, 20)),
+		"a second arbitrary finger on the same device must pair");
+	expect(recognizer.owns(second_same_device)
+		&& recognizer.state() == State::two_finger_pending,
+		"same-device pairing must not depend on ordinal finger IDs");
+	expect_no_actions(recognizer.handle(up({37, 999}, 21)),
+		"a mismatched terminal ID must not release tracked contacts");
+	expect(recognizer.tracked_contacts() == 2,
+		"mismatched terminal events must preserve the pair");
+}
+
+static State state_for_second_down(std::uint64_t interval_ms, double distance)
+{
+	Recognizer recognizer;
+	const TouchKey key{101, 701};
+	complete_tap(recognizer, key, 0, 0.0, 0.0);
+	recognizer.handle(down(key, 20 + interval_ms, distance, 0.0));
+	return recognizer.state();
+}
+
+static void test_double_tap_time_and_distance_boundaries()
+{
+	expect(state_for_second_down(39, 0.0) == State::one_finger,
+		"39 ms must be too soon for the second tap");
+	expect(state_for_second_down(40, 0.0) == State::second_tap,
+		"40 ms must be included in the double-tap interval");
+	expect(state_for_second_down(300, 0.0) == State::second_tap,
+		"300 ms must be included in the double-tap interval");
+	expect(state_for_second_down(301, 0.0) == State::one_finger,
+		"301 ms must be outside the double-tap interval");
+	expect(state_for_second_down(100, 99.999) == State::second_tap,
+		"a second tap just inside 100 dp must match");
+	expect(state_for_second_down(100, 100.001) == State::one_finger,
+		"a second tap just outside 100 dp must start a new gesture");
+}
+
+static void test_one_finger_tap_motion_and_hold()
+{
+	const TouchKey key{111, 811};
+	Recognizer tap;
+	complete_tap(tap, key);
+	expect(tap.has_recent_tap(), "a completed tap must retain recent-tap history");
+
+	Recognizer moving;
+	moving.handle(down(key, 0));
+	auto actions = moving.handle(motion(key, 10, 8.001, 0.0, 2.0, -1.0));
+	expect(actions.size() == 1 && actions.front().type == ActionType::relative_delta
+		&& actions.front().delta_x == 2 && actions.front().delta_y == -1,
+		"ordinary one-finger movement must emit relative pointer movement");
+	expect_no_actions(moving.handle(up(key, 20, 8.001, 0.0)),
+		"movement just outside tap slop must not click");
+	expect(!moving.has_recent_tap(), "a non-tap completion must clear tap history");
+
+	Recognizer inside;
+	inside.handle(down(key, 0));
+	inside.handle(motion(key, 10, 7.999, 0.0, 0.0, 0.0));
+	expect_single_action(inside.handle(up(key, 399, 7.999, 0.0)),
+		ActionType::click_pulse, MouseButton::left,
+		"399 ms and movement just inside slop must remain a tap");
+
+	Recognizer boundary;
+	boundary.handle(down(key, 0));
+	expect_no_actions(boundary.handle(up(key, 400)),
+		"a one-finger contact ending at 400 ms must not click");
+
+	Recognizer long_hold;
+	long_hold.handle(down(key, 0));
+	expect_no_actions(long_hold.tick(ns(399)),
+		"a lone finger must emit no button before the hold cutoff");
+	expect_no_actions(long_hold.tick(ns(400)),
+		"a lone finger reaching the hold cutoff must not press a button");
+	expect_no_actions(long_hold.handle(up(key, 500)),
+		"a lone long hold must finish without a button action");
+}
+
+static void test_fractional_pointer_residue()
+{
+	Recognizer recognizer;
+	const TouchKey key{121, 821};
+	recognizer.handle(down(key, 0));
+	expect_no_actions(recognizer.handle(motion(key, 10, 0.25, 0.0, 0.25, 0.0)),
+		"fractional pointer movement must wait for a whole unit");
+	auto actions = recognizer.handle(motion(key, 20, 1.0, 0.0, 0.75, 0.0));
+	expect(actions.size() == 1 && actions.front().type == ActionType::relative_delta
+		&& actions.front().delta_x == 1 && actions.front().delta_y == 0,
+		"fractional pointer movement must be retained until it forms an integer delta");
+}
+
+static void test_second_tap_click_and_movement_drag_order()
+{
+	const TouchKey key{131, 831};
+	Recognizer second_click;
+	complete_tap(second_click, key, 0);
+	second_click.handle(down(key, 100));
+	expect_single_action(second_click.handle(up(key, 120)),
+		ActionType::click_pulse, MouseButton::left,
+		"a short stationary second tap must emit an ordinary second click");
+
+	Recognizer drag;
+	complete_tap(drag, key, 0);
+	drag.handle(down(key, 100));
+	expect_no_actions(drag.handle(motion(key, 110, 7.999, 0.0, 2.0, 0.0)),
+		"second-contact movement inside slop must stay buffered");
+	auto actions = drag.handle(motion(key, 120, 8.001, 0.0, 3.0, 0.0));
+	expect(actions.size() == 2
+		&& is_action(actions[0], ActionType::button_down, MouseButton::left)
+		&& actions[1].type == ActionType::relative_delta
+		&& actions[1].delta_x == 5,
+		"crossing second-tap slop must press left before flushing buffered movement");
+	expect(drag.state() == State::left_drag,
+		"movement outside slop must establish a left drag");
+	expect_single_action(drag.handle(up(key, 130, 8.001, 0.0)),
+		ActionType::button_up, MouseButton::left,
+		"left drag terminal event must release the left button");
+}
+
+static void test_second_tap_hold_boundary_and_added_contact()
+{
+	const TouchKey key{141, 841};
+	Recognizer drag;
+	complete_tap(drag, key, 0);
+	drag.handle(down(key, 100));
+	drag.handle(motion(key, 150, 1.0, 0.0, 1.0, 0.0));
+	expect_no_actions(drag.tick(ns(499)),
+		"a second tap held for 399 ms must remain pending");
+	auto actions = drag.tick(ns(500));
+	expect(actions.size() == 2
+		&& is_action(actions[0], ActionType::button_down, MouseButton::left)
+		&& actions[1].type == ActionType::relative_delta
+		&& actions[1].delta_x == 1,
+		"a second tap held for 400 ms must press left before buffered movement");
+
+	const TouchKey added{141, 999};
+	expect_single_action(drag.handle(down(added, 510)),
+		ActionType::button_up, MouseButton::left,
+		"an added same-device contact must terminate an active left drag");
+	expect(drag.state() == State::drain_until_all_up
+		&& drag.tracked_contacts() == 2,
+		"left-drag contacts must remain inert until every tracked contact lifts");
+	expect_no_actions(drag.handle(motion(key, 520, 20.0, 0.0, 10.0, 0.0)),
+		"a surviving drained contact must not move the pointer");
+}
+
+static void begin_pair(Recognizer& recognizer, TouchKey primary,
+	TouchKey secondary, std::uint64_t second_down_ms = 10)
+{
+	expect_no_actions(recognizer.handle(down(primary, 0, 0.0, 0.0, 0.10)),
+		"primary down must remain pending");
+	expect_no_actions(recognizer.handle(down(secondary, second_down_ms,
+		0.0, 0.0, 0.10)), "secondary down must begin two-finger arbitration");
+	expect(recognizer.state() == State::two_finger_pending,
+		"same-device second contact must enter two-finger pending state");
+}
+
+static void test_two_finger_hold_and_buffer_order()
+{
+	Recognizer recognizer;
+	const TouchKey primary{151, 851};
+	const TouchKey secondary{151, 852};
+	begin_pair(recognizer, primary, secondary, 10);
+	expect_no_actions(recognizer.handle(motion(primary, 20, 1.0, 0.0,
+		1.0, 0.0, 0.10)), "pending right hold must buffer primary movement");
+	expect_no_actions(recognizer.tick(ns(409)),
+		"a two-finger hold at 399 ms must remain pending");
+	auto actions = recognizer.tick(ns(410));
+	expect(actions.size() == 2
+		&& is_action(actions[0], ActionType::button_down, MouseButton::right)
+		&& actions[1].type == ActionType::relative_delta
+		&& actions[1].delta_x == 1,
+		"a 400 ms two-finger hold must press right before buffered primary movement");
+	expect(recognizer.state() == State::right_drag,
+		"stationary pair at the hold deadline must become a right drag");
+}
+
+static void test_gui_swipe_precedes_hold_without_mouse_mapping_gate()
+{
+	Recognizer recognizer;
+	const TouchKey primary{161, 861};
+	const TouchKey secondary{161, 862};
+	complete_tap(recognizer, primary);
+	recognizer.handle(down(primary, 100, 0.0, 0.0, 0.10));
+	expect(recognizer.state() == State::second_tap && recognizer.has_recent_tap(),
+		"a qualifying second contact must begin with recent-tap history");
+	recognizer.handle(down(secondary, 110, 0.0, 0.0, 0.10));
+	expect(recognizer.state() == State::two_finger_pending,
+		"adding a same-device finger must turn second-tap intent into pair arbitration");
+	expect_no_actions(recognizer.handle(motion(primary, 150, 0.0, 20.0,
+		0.0, 12.0, 0.25)),
+		"one downward finger must not open the GUI alone");
+	auto actions = recognizer.handle(motion(secondary, 160, 0.0, 20.0,
+		0.0, 12.0, 0.25));
+	expect_single_action(actions, ActionType::open_gui, MouseButton::none,
+		"two downward contacts crossing 15 percent must open the GUI even though the pure recognizer has no mouse mapping");
+	expect(recognizer.state() == State::gui_consumed,
+		"a winning GUI swipe must retain ownership of its contacts");
+	expect(!recognizer.has_recent_tap(),
+		"a winning GUI swipe must clear recent-tap history");
+	expect_no_actions(recognizer.handle(motion(primary, 170, 0.0, 30.0,
+		5.0, 5.0, 0.40)), "GUI ownership must suppress later pointer and GUI actions");
+	expect_no_actions(recognizer.handle(up(primary, 180, 0.0, 30.0, 0.40)),
+		"first GUI-swipe lift must remain captured and inert");
+	expect(recognizer.state() == State::drain_until_all_up,
+		"GUI-swipe survivor must enter drain state");
+	expect_no_actions(recognizer.handle(up(secondary, 190, 0.0, 30.0, 0.40)),
+		"last GUI-swipe lift must emit no mouse action");
+	expect(recognizer.state() == State::idle && recognizer.tracked_contacts() == 0,
+		"GUI-swipe ownership must clear only after every tracked contact lifts");
+}
+
+static void test_swipe_only_and_right_hold_precedence()
+{
+	const TouchKey primary{171, 871};
+	const TouchKey secondary{171, 872};
+	Recognizer swipe_only;
+	begin_pair(swipe_only, primary, secondary);
+	expect_no_actions(swipe_only.handle(motion(primary, 20, 8.001, 0.0,
+		4.0, 0.0, 0.10)), "movement outside pair slop must emit no pointer action");
+	expect(swipe_only.state() == State::swipe_only,
+		"movement just outside 8 dp must permanently disqualify right hold");
+	expect_no_actions(swipe_only.tick(ns(500)),
+		"a slop-disqualified pair must never activate right hold");
+	expect_no_actions(swipe_only.handle(up(primary, 510, 8.001, 0.0, 0.10)),
+		"an incomplete GUI swipe must finish without mouse output");
+
+	Recognizer inside;
+	begin_pair(inside, primary, secondary);
+	inside.handle(motion(primary, 20, 7.999, 0.0, 0.0, 0.0, 0.10));
+	expect_single_action(inside.tick(ns(410)), ActionType::button_down,
+		MouseButton::right, "movement just inside pair slop must permit right hold");
+	auto actions = inside.handle(motion(primary, 420, 20.0, 20.0,
+		3.0, 4.0, 0.30));
+	expect(actions.size() == 1 && actions.front().type == ActionType::relative_delta
+		&& actions.front().delta_x == 3 && actions.front().delta_y == 4,
+		"after right hold wins, primary downward movement must move the pointer");
+	expect(inside.state() == State::right_drag,
+		"right-drag ownership must permanently block the GUI swipe");
+	expect_no_actions(inside.handle(motion(secondary, 430, 0.0, 20.0,
+		8.0, 8.0, 0.30)),
+		"secondary movement during right drag must be inert");
+}
+
+static void test_right_drag_terminal_and_drain()
+{
+	const TouchKey primary{181, 881};
+	const TouchKey secondary{181, 882};
+	for (int lifted_index = 0; lifted_index < 2; ++lifted_index) {
+		Recognizer recognizer;
+		begin_pair(recognizer, primary, secondary);
+		recognizer.tick(ns(410));
+		const TouchKey lifted = lifted_index == 0 ? primary : secondary;
+		const TouchKey survivor = lifted_index == 0 ? secondary : primary;
+		expect_single_action(recognizer.handle(up(lifted, 420)),
+			ActionType::button_up, MouseButton::right,
+			"lifting either member of a right drag must release right");
+		expect(recognizer.state() == State::drain_until_all_up
+			&& recognizer.owns(survivor),
+			"the surviving right-drag contact must remain tracked and inert");
+		expect_no_actions(recognizer.handle(motion(survivor, 430, 20.0, 0.0,
+			10.0, 0.0)), "right-drag survivor must not be promoted");
+		recognizer.handle(up(survivor, 440));
+		expect(recognizer.state() == State::idle,
+			"right-drag drain must end after its final contact lifts");
+	}
+}
+
+static void test_third_contact_terminates_right_drag()
+{
+	Recognizer recognizer;
+	const TouchKey primary{191, 891};
+	const TouchKey secondary{191, 892};
+	const TouchKey third{191, 893};
+	const TouchKey other_device{192, 893};
+	begin_pair(recognizer, primary, secondary);
+	recognizer.tick(ns(410));
+	expect_no_actions(recognizer.handle(down(other_device, 415)),
+		"a contact on another device must not terminate a held pair");
+	expect(recognizer.state() == State::right_drag,
+		"same finger ID on another device must not join the held pair");
+	expect_single_action(recognizer.handle(down(third, 420)),
+		ActionType::button_up, MouseButton::right,
+		"a third same-device contact must release a held right button");
+	expect(recognizer.state() == State::drain_until_all_up
+		&& recognizer.tracked_contacts() == 3,
+		"all three same-device contacts must drain without reassignment");
+	expect_no_actions(recognizer.handle(motion(primary, 430, 20.0, 0.0,
+		10.0, 0.0)), "drained contacts must remain inert");
+	recognizer.handle(up(primary, 440));
+	recognizer.handle(up(secondary, 450));
+	expect(recognizer.state() == State::drain_until_all_up,
+		"drain must retain the added contact until it lifts");
+	recognizer.handle(up(third, 460));
+	expect(recognizer.state() == State::idle,
+		"third-contact drain must end only after all tracked contacts lift");
+}
+
+static void expect_cancelled(Recognizer& recognizer, bool expected_release,
+	MouseButton button, const std::string& label)
+{
+	auto actions = recognizer.cancel();
+	if (expected_release) {
+		expect_single_action(actions, ActionType::button_up, button,
+			label + " cancellation must release its held button");
+	} else {
+		expect_no_actions(actions, label + " cancellation must emit no spurious action");
+	}
+	expect(recognizer.state() == State::idle && recognizer.tracked_contacts() == 0
+		&& !recognizer.has_recent_tap(),
+		label + " cancellation must clear contacts, state, and tap history");
+	expect_no_actions(recognizer.cancel(),
+		label + " repeated cancellation must be idempotent");
+}
+
+static void test_cancellation_matrix()
+{
+	const TouchKey primary{201, 901};
+	const TouchKey secondary{201, 902};
+
+	Recognizer one;
+	one.handle(down(primary, 0));
+	expect_cancelled(one, false, MouseButton::none, "one-finger pending");
+
+	Recognizer second;
+	complete_tap(second, primary);
+	second.handle(down(primary, 100));
+	expect_cancelled(second, false, MouseButton::none, "second-tap pending");
+
+	Recognizer pair;
+	begin_pair(pair, primary, secondary);
+	expect_cancelled(pair, false, MouseButton::none, "two-finger pending");
+
+	Recognizer swipe;
+	begin_pair(swipe, primary, secondary);
+	swipe.handle(motion(primary, 20, 8.001, 0.0, 0.0, 0.0));
+	expect_cancelled(swipe, false, MouseButton::none, "swipe-only");
+
+	Recognizer left;
+	complete_tap(left, primary);
+	left.handle(down(primary, 100));
+	left.tick(ns(500));
+	expect_cancelled(left, true, MouseButton::left, "left drag");
+
+	Recognizer right;
+	begin_pair(right, primary, secondary);
+	right.tick(ns(410));
+	expect_cancelled(right, true, MouseButton::right, "right drag");
+
+	Recognizer gui;
+	begin_pair(gui, primary, secondary);
+	gui.handle(motion(primary, 20, 0.0, 20.0, 0.0, 0.0, 0.30));
+	gui.handle(motion(secondary, 30, 0.0, 20.0, 0.0, 0.0, 0.30));
+	expect_cancelled(gui, false, MouseButton::none, "GUI-consumed");
+
+	Recognizer drain;
+	begin_pair(drain, primary, secondary);
+	drain.handle(up(primary, 20));
+	expect_cancelled(drain, false, MouseButton::none, "drain");
+}
+
+static void test_mapping_loss_uses_same_neutralization_contract()
+{
+	Recognizer recognizer;
+	const TouchKey primary{211, 911};
+	const TouchKey secondary{211, 912};
+	begin_pair(recognizer, primary, secondary);
+	recognizer.tick(ns(410));
+	expect_single_action(recognizer.mapping_lost(), ActionType::button_up,
+		MouseButton::right, "mapping loss must release a held right button");
+	expect(recognizer.state() == State::idle && !recognizer.has_recent_tap(),
+		"mapping loss must clear the pure gesture state");
+}
+
+static void test_button_source_composition()
+{
+	ButtonSourceComposer composer;
+	auto transition = composer.set(ButtonSource::physical, MouseButton::left, true);
+	expect(transition && transition->button == MouseButton::left
+		&& transition->pressed,
+		"first physical left press must raise aggregate left");
+	expect(!composer.set(ButtonSource::gesture, MouseButton::left, true),
+		"gesture press must not duplicate an already-held aggregate left");
+	expect(!composer.set(ButtonSource::physical, MouseButton::left, false),
+		"physical release must preserve gesture-held aggregate left");
+	transition = composer.set(ButtonSource::gesture, MouseButton::left, false);
+	expect(transition && transition->button == MouseButton::left
+		&& !transition->pressed,
+		"last left source release must lower aggregate left");
+
+	transition = composer.set(ButtonSource::pen, MouseButton::right, true);
+	expect(transition && transition->button == MouseButton::right
+		&& transition->pressed,
+		"first pen right press must raise aggregate right");
+	expect(!composer.set(ButtonSource::physical, MouseButton::right, true),
+		"physical right press must compose with a pen-held right");
+	expect(!composer.set(ButtonSource::pen, MouseButton::right, false),
+		"pen release must preserve physical-held aggregate right");
+	transition = composer.set(ButtonSource::physical, MouseButton::right, false);
+	expect(transition && transition->button == MouseButton::right
+		&& !transition->pressed,
+		"last right source release must lower aggregate right");
+
+	ButtonSourceComposer reverse_right;
+	reverse_right.set(ButtonSource::physical, MouseButton::right, true);
+	reverse_right.set(ButtonSource::pen, MouseButton::right, true);
+	expect(!reverse_right.set(ButtonSource::physical, MouseButton::right, false),
+		"physical release must preserve pen-held aggregate right");
+	transition = reverse_right.set(ButtonSource::pen, MouseButton::right, false);
+	expect(transition && transition->button == MouseButton::right
+		&& !transition->pressed,
+		"pen must release aggregate right when it is the last source");
+
+	composer.set(ButtonSource::physical, MouseButton::left, true);
+	composer.set(ButtonSource::gesture, MouseButton::left, true);
+	expect(composer.clear_source(ButtonSource::gesture).empty(),
+		"clearing gesture ownership must preserve physical ownership");
+	expect(composer.pressed(MouseButton::left),
+		"aggregate left must remain held by the physical source");
+	auto transitions = composer.clear_source(ButtonSource::physical);
+	expect(transitions.size() == 1 && transitions.front().button == MouseButton::left
+		&& !transitions.front().pressed,
+		"clearing the remaining source must emit the aggregate release");
+}
+
+int main()
+{
+	test_identity_and_reordered_events();
+	test_double_tap_time_and_distance_boundaries();
+	test_one_finger_tap_motion_and_hold();
+	test_fractional_pointer_residue();
+	test_second_tap_click_and_movement_drag_order();
+	test_second_tap_hold_boundary_and_added_contact();
+	test_two_finger_hold_and_buffer_order();
+	test_gui_swipe_precedes_hold_without_mouse_mapping_gate();
+	test_swipe_only_and_right_hold_precedence();
+	test_right_drag_terminal_and_drain();
+	test_third_contact_terminates_right_drag();
+	test_cancellation_matrix();
+	test_mapping_loss_uses_same_neutralization_contract();
+	test_button_source_composition();
+	return failures == 0 ? 0 : 1;
+}

--- a/tests/android_touch_mouse_test.cpp
+++ b/tests/android_touch_mouse_test.cpp
@@ -579,6 +579,95 @@ static void test_pump_coordinator_preserves_queued_click_pulses()
 		"all queued tap pulses must be retired after their final release");
 }
 
+static void test_pump_coordinator_releases_clicks_before_unrelated_motion()
+{
+	const TouchKey key{237, 937};
+	PumpCoordinator coordinator;
+	coordinator.handle(down(key, 0));
+	expect_single_action(coordinator.handle(up(key, 20)),
+		ActionType::button_down, MouseButton::left,
+		"the completed tap must press left before the unrelated contact");
+	expect_single_action(coordinator.handle(down(key, 321)),
+		ActionType::button_up, MouseButton::left,
+		"an unrelated contact in the same pump must release the queued click");
+	expect(coordinator.state() == State::one_finger,
+		"a contact outside the double-tap interval must remain an ordinary gesture");
+
+	const auto movement = coordinator.handle(motion(key, 330, 8.001, 0.0,
+		3.0, 0.0));
+	expect(movement.size() == 1
+		&& movement.front().type == ActionType::relative_delta
+		&& movement.front().delta_x == 3 && movement.front().delta_y == 0,
+		"unrelated motion must follow the queued click release without becoming a drag");
+	expect(coordinator.state() == State::one_finger,
+		"unrelated motion must not leak a false left-drag state");
+	expect_no_actions(coordinator.begin_pump(),
+		"the unrelated contact must leave no click release for the next pump");
+	expect_no_actions(coordinator.handle(up(key, 340, 8.001, 0.0)),
+		"the moved unrelated contact must finish without another click");
+
+	PumpCoordinator drag;
+	drag.handle(down(key, 0));
+	drag.handle(up(key, 20));
+	expect_no_actions(drag.handle(down(key, 100)),
+		"a qualifying second tap must retain the pending left press");
+	const auto drag_motion = drag.handle(motion(key, 110, 8.001, 0.0,
+		2.0, 0.0));
+	expect(drag_motion.size() == 1
+		&& drag_motion.front().type == ActionType::relative_delta
+		&& drag_motion.front().delta_x == 2
+		&& drag.state() == State::left_drag,
+		"a qualifying second tap must take over the pending press without a transition");
+	expect_single_action(drag.handle(up(key, 120, 8.001, 0.0)),
+		ActionType::button_up, MouseButton::left,
+		"the seamless second-tap drag must release left when it finishes");
+	expect_no_actions(drag.begin_pump(),
+		"a second-tap drag takeover must consume the pending click release");
+
+	PumpCoordinator queued;
+	queued.handle(down(key, 0));
+	queued.handle(up(key, 20));
+	queued.handle(down(key, 100));
+	queued.handle(up(key, 120));
+	const auto releases = queued.handle(down(key, 421));
+	expect(releases.size() == 3
+		&& is_action(releases[0], ActionType::button_up, MouseButton::left)
+		&& is_action(releases[1], ActionType::button_down, MouseButton::left)
+		&& is_action(releases[2], ActionType::button_up, MouseButton::left),
+		"an unrelated contact must preserve every queued tap in release/down order");
+	expect_no_actions(queued.begin_pump(),
+		"draining multiple queued taps must leave no delayed release");
+}
+
+static void test_pump_coordinator_releases_click_before_pair_takeover()
+{
+	const TouchKey primary{238, 938};
+	const TouchKey secondary{238, 939};
+	PumpCoordinator coordinator;
+	coordinator.handle(down(primary, 0, 0.0, 0.0, 0.10));
+	coordinator.handle(up(primary, 20, 0.0, 0.0, 0.10));
+	expect_no_actions(coordinator.handle(down(primary, 100,
+		0.0, 0.0, 0.10)),
+		"a qualifying second tap must retain the pending left press");
+	expect(coordinator.state() == State::second_tap,
+		"the qualifying contact must retain second-tap intent by itself");
+	expect_single_action(coordinator.handle(down(secondary, 110,
+		0.0, 0.0, 0.10)), ActionType::button_up, MouseButton::left,
+		"pair takeover must release the pending left click immediately");
+	expect(coordinator.state() == State::two_finger_pending,
+		"the accepted second finger must begin normal pair arbitration");
+	expect_no_actions(coordinator.begin_pump(),
+		"pair takeover must leave no pending click release for the next pump");
+	expect_no_actions(coordinator.tick(ns(509)),
+		"the pair must remain pending before its ordinary hold deadline");
+	expect_single_action(coordinator.tick(ns(510)),
+		ActionType::button_down, MouseButton::right,
+		"the pair must still activate an ordinary right drag at its deadline");
+	expect_single_action(coordinator.handle(up(primary, 520,
+		0.0, 0.0, 0.10)), ActionType::button_up, MouseButton::right,
+		"the normal pair drag must release right on its first terminal event");
+}
+
 static void test_nonowning_added_contact_terminates_before_overlay_capture()
 {
 	const TouchKey primary{241, 941};
@@ -661,6 +750,8 @@ int main()
 	test_pump_coordinator_click_and_deadline_ordering();
 	test_pump_coordinator_neutralizes_pending_click();
 	test_pump_coordinator_preserves_queued_click_pulses();
+	test_pump_coordinator_releases_clicks_before_unrelated_motion();
+	test_pump_coordinator_releases_click_before_pair_takeover();
 	test_nonowning_added_contact_terminates_before_overlay_capture();
 	test_nonowning_added_contact_drains_pending_pairs();
 	return failures == 0 ? 0 : 1;

--- a/tests/android_touch_mouse_test.cpp
+++ b/tests/android_touch_mouse_test.cpp
@@ -453,14 +453,14 @@ static void test_cancellation_matrix()
 	expect_cancelled(drain, false, MouseButton::none, "drain");
 }
 
-static void test_mapping_loss_uses_same_neutralization_contract()
+static void test_mapping_loss_uses_neutralization_contract()
 {
 	Recognizer recognizer;
 	const TouchKey primary{211, 911};
 	const TouchKey secondary{211, 912};
 	begin_pair(recognizer, primary, secondary);
 	recognizer.tick(ns(410));
-	expect_single_action(recognizer.mapping_lost(), ActionType::button_up,
+	expect_single_action(recognizer.neutralize(), ActionType::button_up,
 		MouseButton::right, "mapping loss must release a held right button");
 	expect(recognizer.state() == State::idle && !recognizer.has_recent_tap(),
 		"mapping loss must clear the pure gesture state");
@@ -592,7 +592,7 @@ int main()
 	test_right_drag_terminal_and_drain();
 	test_third_contact_terminates_right_drag();
 	test_cancellation_matrix();
-	test_mapping_loss_uses_same_neutralization_contract();
+	test_mapping_loss_uses_neutralization_contract();
 	test_button_source_composition();
 	test_pump_coordinator_click_and_deadline_ordering();
 	test_pump_coordinator_neutralizes_pending_click();

--- a/tests/android_touch_mouse_test.cpp
+++ b/tests/android_touch_mouse_test.cpp
@@ -578,6 +578,46 @@ static void test_nonowning_added_contact_terminates_before_overlay_capture()
 		"a surviving trackpad contact must remain inert after overlay takeover");
 }
 
+static void test_nonowning_added_contact_drains_pending_pairs()
+{
+	const TouchKey primary{251, 951};
+	const TouchKey secondary{251, 952};
+	const TouchKey overlay_contact{251, 953};
+
+	Recognizer pending;
+	begin_pair(pending, primary, secondary);
+	expect_no_actions(pending.handle(motion(primary, 20, 1.0, 0.0,
+		1.0, 0.0)), "pending pair movement inside slop must remain buffered");
+	expect_no_actions(pending.terminate_for_nonowning_contact(overlay_contact),
+		"an overlay candidate must drain a pending pair without a button action");
+	expect(pending.state() == State::drain_until_all_up
+		&& pending.tracked_contacts() == 2 && !pending.owns(overlay_contact)
+		&& !pending.has_recent_tap(),
+		"the pending pair must remain inert and the overlay contact nonowning");
+	expect_no_actions(pending.tick(ns(410)),
+		"a drained pending pair must not activate right at its hold deadline");
+	expect_no_actions(pending.handle(motion(primary, 420, 20.0, 0.0,
+		10.0, 0.0)), "a drained pending pair must not flush buffered movement");
+
+	PumpCoordinator swipe;
+	swipe.handle(down(primary, 0, 0.0, 0.0, 0.10));
+	swipe.handle(down(secondary, 10, 0.0, 0.0, 0.10));
+	expect_no_actions(swipe.handle(motion(primary, 20, 8.001, 0.0,
+		4.0, 0.0, 0.10)), "pair movement outside slop must enter swipe-only arbitration");
+	expect(swipe.state() == State::swipe_only,
+		"the coordinator must expose swipe-only arbitration before overlay takeover");
+	expect_no_actions(swipe.terminate_for_nonowning_contact(overlay_contact),
+		"an overlay candidate must drain swipe-only arbitration without a button action");
+	expect(swipe.state() == State::drain_until_all_up
+		&& swipe.tracked_contacts() == 2 && !swipe.owns(overlay_contact),
+		"the swipe-only pair must remain inert and the overlay contact nonowning");
+	expect_no_actions(swipe.handle(motion(secondary, 30, 0.0, 20.0,
+		0.0, 12.0, 0.30)),
+		"a drained swipe-only pair must not open the GUI after overlay takeover");
+	expect_no_actions(swipe.tick(ns(410)),
+		"a drained swipe-only pair must not activate right at the hold deadline");
+}
+
 int main()
 {
 	test_identity_and_reordered_events();
@@ -597,5 +637,6 @@ int main()
 	test_pump_coordinator_click_and_deadline_ordering();
 	test_pump_coordinator_neutralizes_pending_click();
 	test_nonowning_added_contact_terminates_before_overlay_capture();
+	test_nonowning_added_contact_drains_pending_pairs();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/android_touch_mouse_test.cpp
+++ b/tests/android_touch_mouse_test.cpp
@@ -96,6 +96,10 @@ static void test_identity_and_reordered_events()
 	expect(recognizer.owns(second_same_device)
 		&& recognizer.state() == State::two_finger_pending,
 		"same-device pairing must not depend on ordinal finger IDs");
+	const auto tracked_keys = recognizer.tracked_keys();
+	expect(tracked_keys.size() == 2 && tracked_keys[0] == first
+		&& tracked_keys[1] == second_same_device,
+		"captured composite identities must be observable in acquisition order");
 	expect_no_actions(recognizer.handle(up({37, 999}, 21)),
 		"a mismatched terminal ID must not release tracked contacts");
 	expect(recognizer.tracked_contacts() == 2,

--- a/tests/test_android_touch_mouse.sh
+++ b/tests/test_android_touch_mouse.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+cxx=${CXX:-c++}
+out="${TMPDIR:-/tmp}/android_touch_mouse_test.$$"
+trap 'rm -f "$out"' EXIT
+
+"$cxx" -std=c++17 -Wall -Wextra -Werror -Isrc/osdep \
+	-o "$out" tests/android_touch_mouse_test.cpp
+"$out"


### PR DESCRIPTION
Changes proposed in this pull request:
- Android users can now operate WHDLoad option screens and non-sticky Amiga menus with free-area touch, without first capturing a physical mouse.
- One-finger motion behaves as a relative trackpad; taps click; double-tap-hold drags with left; and two-finger hold-and-move keeps right pressed for pull-down menus.
- Touch ownership remains exclusive across the on-screen keyboard, joystick, GUI swipe, pen, physical mouse, focus changes, device removal, and application lifecycle transitions.

@midwan

## Behavior and design

The native input path now arbitrates trackpad gestures and the existing two-finger downward GUI swipe as one state machine. It uses SDL's real touch and finger identities, retains the active emulated mouse mapping, and composes physical, pen, and gesture button sources so one source cannot release another.

The gesture recognizer is independent of SDL and emulator globals. This makes timing, distance, action ordering, cancellation, and drain behavior deterministic to test while the Android adapter remains responsible for event routing and guest input APIs.

New contacts still require a registered direct touchscreen. Once a contact is owned or explicitly draining, its exact terminal event is accepted even if SDL has already removed the device registration; this prevents stuck buttons during teardown.

Session-settled decisions carried from planning: free-area relative trackpad semantics and automatic activation (user-directed); tap and double-tap-hold left actions plus native input-path ownership (user-approved); two-finger-held right drag (user-directed, over a one-finger long-press).

## Validation

- Pure C++17 recognizer/source-composition suite passes with `-Wall -Wextra -Werror`.
- Android debug unit tests pass, including the native routing and lifecycle architecture contracts.
- Android lint and release assembly pass for `arm64-v8a` and `x86_64`.
- A clean Unix x86_64 libretro build passes, confirming the Android-only boundaries do not leak into the non-Android target.
- The debug app launches successfully to `MainActivity` on a Pixel Tablet emulator.
- `git diff --check` passes.

The full hands-on matrix still needs a configured Android device or emulator with Kickstart/WHDLoad content, plus physical mouse and pen input. In particular, reviewers should exercise WHDLoad controls, held-right Amiga menus, GUI-swipe arbitration, overlay transitions, lifecycle interruptions, and cross-input release ordering.

## Post-merge validation

- Validate during the first Android release-candidate smoke session with WHDLoad content.
- Healthy behavior: no stuck left/right button, no duplicate GUI opening, no cursor jump, and unchanged real-mouse, pen, joystick, and on-screen-keyboard input.
- Failure signals: a button remains held after interruption, a surviving touch is reassigned, or touch-synthesized mouse input leaks into the advanced GUI.
- Rollback: revert this PR to restore the prior Android touch path while the failing ownership sequence is isolated.
- Owner: Android/Amiberry maintainer running the release-candidate validation.

## New concepts

### Captured trackpad gesture

A captured trackpad gesture gives each physical contact one owner from finger-down through its terminal event. Crossing an overlay boundary does not transfer ownership; interruptions neutralize the owner and drain surviving contacts until a fresh down.

This is preferable here to hit-testing every event independently because Amiga drag interactions require a button to remain held while the pointer moves, and Android overlays can appear or move while contacts are active.

```mermaid
flowchart TB
    Down[Direct finger down] --> Owner{First accepting owner}
    Owner --> Overlay[OSK or joystick]
    Owner --> Trackpad[Trackpad recognizer]
    Trackpad --> Mouse[Relative motion and held buttons]
    Trackpad --> Gui[Two-finger GUI swipe]
    Overlay --> Terminal[Up, cancel, or neutralize]
    Mouse --> Terminal
    Gui --> Terminal
    Terminal --> Drain[Drain surviving contacts]
    Drain --> Fresh[Fresh down may acquire again]
```

For example, a two-finger right drag keeps both contacts owned by the trackpad even when the primary finger crosses the on-screen keyboard. If a third same-device contact is captured by an overlay, the pending pair is drained before it can press right.

Do not use this pattern for intentionally direct-positioned controls where continuously re-evaluating the current hit target is the desired behavior.

