### PR TITLE
fix(gfx): prevent autocrop panning around edge sprites

### DIFF
--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -5490,6 +5490,10 @@ static void reset_autoscale(void)
 	ddffirstword_total_old = ddffirstword_total;
 	ddflastword_total_old = ddflastword_total;
 
+#ifdef AMIBERRY
+	reset_autoscale_sprite_horizontal_edges();
+#endif
+
 	//write_log("%4d %4d %4d %4d %4d %4d\n", diwfirstword_total, diwlastword_total, ddffirstword_total, ddflastword_total, plffirstline_total, plflastline_total);
 
 	first_planes_vpos = 0;

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -673,6 +673,33 @@ extern bool lof_display;
 static int gclow, gcloh, gclox, gcloy, gclorealh;
 static int stored_left_start, stored_top_start, stored_width, stored_height;
 
+#ifdef AMIBERRY
+static constexpr int AUTOSCALE_SPRITE_LEFT_UNSET = 30000;
+static constexpr int AUTOSCALE_SPRITE_RIGHT_UNSET = 0;
+static int autoscale_sprite_firstword_total = AUTOSCALE_SPRITE_LEFT_UNSET;
+static int autoscale_sprite_lastword_total = AUTOSCALE_SPRITE_RIGHT_UNSET;
+
+int get_autoscale_sprite_horizontal_edges(void)
+{
+	int edges = 0;
+	if (autoscale_sprite_firstword_total != AUTOSCALE_SPRITE_LEFT_UNSET
+		&& autoscale_sprite_firstword_total == diwfirstword_total) {
+		edges |= AUTOSCALE_SPRITE_EDGE_LEFT;
+	}
+	if (autoscale_sprite_lastword_total != AUTOSCALE_SPRITE_RIGHT_UNSET
+		&& autoscale_sprite_lastword_total == diwlastword_total) {
+		edges |= AUTOSCALE_SPRITE_EDGE_RIGHT;
+	}
+	return edges;
+}
+
+void reset_autoscale_sprite_horizontal_edges(void)
+{
+	autoscale_sprite_firstword_total = AUTOSCALE_SPRITE_LEFT_UNSET;
+	autoscale_sprite_lastword_total = AUTOSCALE_SPRITE_RIGHT_UNSET;
+}
+#endif
+
 void get_custom_topedge (int *xp, int *yp, bool max)
 {
 	if (isnativevidbuf(0) && !max) {
@@ -4573,20 +4600,18 @@ static uae_u8 denise_render_sprites2(uae_u8 apixel, uae_u32 vs)
 static void autoscale_sprites(void)
 {
 #if AUTOSCALE_SPRITES
-#if defined(AMIBERRY) && !defined(LIBRETRO)
-	// Native AutoCrop scans rendered pixels outside DIW itself, so suppress only
-	// horizontal sprite expansion and retain vertical sprite bounds.
-	if (!currprefs.gfx_auto_crop) {
-#endif
 	if (diwfirstword_total > internal_pixel_cnt && internal_pixel_cnt > (48 << RES_MAX)) {
 		diwfirstword_total = internal_pixel_cnt;
+#ifdef AMIBERRY
+		autoscale_sprite_firstword_total = internal_pixel_cnt;
+#endif
 	}
 	if (diwlastword_total < internal_pixel_cnt && internal_pixel_cnt < (448 << RES_MAX)) {
 		diwlastword_total = internal_pixel_cnt;
-	}
-#if defined(AMIBERRY) && !defined(LIBRETRO)
-	}
+#ifdef AMIBERRY
+		autoscale_sprite_lastword_total = internal_pixel_cnt;
 #endif
+	}
 	if (this_line->linear_vpos < plffirstline_total) {
 		plffirstline_total = this_line->linear_vpos;
 	}

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -674,20 +674,42 @@ static int gclow, gcloh, gclox, gcloy, gclorealh;
 static int stored_left_start, stored_top_start, stored_width, stored_height;
 
 #ifdef AMIBERRY
-static constexpr int AUTOSCALE_SPRITE_LEFT_UNSET = 30000;
-static constexpr int AUTOSCALE_SPRITE_RIGHT_UNSET = 0;
-static int autoscale_sprite_firstword_total = AUTOSCALE_SPRITE_LEFT_UNSET;
-static int autoscale_sprite_lastword_total = AUTOSCALE_SPRITE_RIGHT_UNSET;
+static bool autoscale_sprite_left_edge;
+static bool autoscale_sprite_right_edge;
+#endif
 
+static void update_diwfirstword_total(const int firstword)
+{
+#ifdef AMIBERRY
+	if (firstword <= diwfirstword_total) {
+		autoscale_sprite_left_edge = false;
+	}
+#endif
+	if (firstword < diwfirstword_total) {
+		diwfirstword_total = firstword;
+	}
+}
+
+static void update_diwlastword_total(const int lastword)
+{
+#ifdef AMIBERRY
+	if (lastword >= diwlastword_total) {
+		autoscale_sprite_right_edge = false;
+	}
+#endif
+	if (lastword > diwlastword_total) {
+		diwlastword_total = lastword;
+	}
+}
+
+#ifdef AMIBERRY
 int get_autoscale_sprite_horizontal_edges(void)
 {
 	int edges = 0;
-	if (autoscale_sprite_firstword_total != AUTOSCALE_SPRITE_LEFT_UNSET
-		&& autoscale_sprite_firstword_total == diwfirstword_total) {
+	if (autoscale_sprite_left_edge) {
 		edges |= AUTOSCALE_SPRITE_EDGE_LEFT;
 	}
-	if (autoscale_sprite_lastword_total != AUTOSCALE_SPRITE_RIGHT_UNSET
-		&& autoscale_sprite_lastword_total == diwlastword_total) {
+	if (autoscale_sprite_right_edge) {
 		edges |= AUTOSCALE_SPRITE_EDGE_RIGHT;
 	}
 	return edges;
@@ -695,8 +717,8 @@ int get_autoscale_sprite_horizontal_edges(void)
 
 void reset_autoscale_sprite_horizontal_edges(void)
 {
-	autoscale_sprite_firstword_total = AUTOSCALE_SPRITE_LEFT_UNSET;
-	autoscale_sprite_lastword_total = AUTOSCALE_SPRITE_RIGHT_UNSET;
+	autoscale_sprite_left_edge = false;
+	autoscale_sprite_right_edge = false;
 }
 #endif
 
@@ -4603,13 +4625,13 @@ static void autoscale_sprites(void)
 	if (diwfirstword_total > internal_pixel_cnt && internal_pixel_cnt > (48 << RES_MAX)) {
 		diwfirstword_total = internal_pixel_cnt;
 #ifdef AMIBERRY
-		autoscale_sprite_firstword_total = internal_pixel_cnt;
+		autoscale_sprite_left_edge = true;
 #endif
 	}
 	if (diwlastword_total < internal_pixel_cnt && internal_pixel_cnt < (448 << RES_MAX)) {
 		diwlastword_total = internal_pixel_cnt;
 #ifdef AMIBERRY
-		autoscale_sprite_lastword_total = internal_pixel_cnt;
+		autoscale_sprite_right_edge = true;
 #endif
 	}
 	if (this_line->linear_vpos < plffirstline_total) {
@@ -4827,7 +4849,7 @@ static void do_hbstrt(int cnt)
 		hstart_new();
 		// hstop was not matched?
 		if (!diwlastword_total && bpl1dat_trigger_offset >= 0) {
-			diwlastword_total = internal_pixel_cnt;
+			update_diwlastword_total(internal_pixel_cnt);
 		}
 	}
 #ifdef DEBUGGER
@@ -4938,8 +4960,8 @@ static void do_hstrt_aga(int cnt)
 	}
 	denise_hdiw = true;
 	hstrt_offset = internal_pixel_cnt;
-	if (internal_pixel_cnt < diwfirstword_total && bpl1dat_trigger_offset >= 0) {
-		diwfirstword_total = internal_pixel_cnt;
+	if (bpl1dat_trigger_offset >= 0) {
+		update_diwfirstword_total(internal_pixel_cnt);
 	}
 #ifdef DEBUGGER
 	if (debug_dma) {
@@ -4953,8 +4975,8 @@ static void do_hstop_aga(int cnt)
 	sprites_hidden2 |= sprite_hidden_mask;
 	sprites_hidden = sprites_hidden2;
 	denise_hdiw = false;
-	if (internal_pixel_cnt > diwlastword_total && bpl1dat_trigger_offset >= 0) {
-		diwlastword_total = internal_pixel_cnt;
+	if (bpl1dat_trigger_offset >= 0) {
+		update_diwlastword_total(internal_pixel_cnt);
 	}
 #ifdef DEBUGGER
 	if (debug_dma) {
@@ -4976,8 +4998,8 @@ static void do_hstrt_ecs(int cnt)
 	}
 	hstrt_offset = internal_pixel_cnt;
 	denise_hdiw = true;
-	if (internal_pixel_cnt < diwfirstword_total && bpl1dat_trigger_offset >= 0) {
-		diwfirstword_total = internal_pixel_cnt;
+	if (bpl1dat_trigger_offset >= 0) {
+		update_diwfirstword_total(internal_pixel_cnt);
 	}
 #ifdef DEBUGGER
 	if (debug_dma) {
@@ -4996,8 +5018,8 @@ static void do_hstop_ecs(int cnt)
 		sprites_hidden2 |= sprite_hidden_mask;
 		sprites_hidden = sprites_hidden2;
 	}
-	if (internal_pixel_cnt > diwlastword_total && bpl1dat_trigger_offset >= 0) {
-		diwlastword_total = internal_pixel_cnt;
+	if (bpl1dat_trigger_offset >= 0) {
+		update_diwlastword_total(internal_pixel_cnt);
 	}
 #ifdef DEBUGGER
 	if (debug_dma) {
@@ -7987,11 +8009,9 @@ void draw_denise_bitplane_line_fast(int gfx_ypos, enum nln_how how, struct lines
 		memset(gbuf, 0, total);
 	}
 
-	if (ls->hstop_offset > diwlastword_total && ls->bpl1dat_trigger_offset >= 0) {
-		diwlastword_total = ls->hstop_offset;
-	}
-	if (ls->hstrt_offset < diwfirstword_total && ls->bpl1dat_trigger_offset >= 0) {
-		diwfirstword_total = ls->hstrt_offset;
+	if (ls->bpl1dat_trigger_offset >= 0) {
+		update_diwlastword_total(ls->hstop_offset);
+		update_diwfirstword_total(ls->hstrt_offset);
 	}
 
 #else

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -4573,6 +4573,13 @@ static uae_u8 denise_render_sprites2(uae_u8 apixel, uae_u32 vs)
 static void autoscale_sprites(void)
 {
 #if AUTOSCALE_SPRITES
+#if defined(AMIBERRY) && !defined(LIBRETRO)
+	// Native AutoCrop scans rendered pixels outside DIW itself. Keep sprites out
+	// of source geometry so real DIW changes remain distinguishable.
+	if (currprefs.gfx_auto_crop) {
+		return;
+	}
+#endif
 	if (diwfirstword_total > internal_pixel_cnt && internal_pixel_cnt > (48 << RES_MAX)) {
 		diwfirstword_total = internal_pixel_cnt;
 	}

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -676,6 +676,8 @@ static int stored_left_start, stored_top_start, stored_width, stored_height;
 #ifdef AMIBERRY
 static bool autoscale_sprite_left_edge;
 static bool autoscale_sprite_right_edge;
+static int autoscale_sprite_zero_firstword = 30000;
+static int autoscale_sprite_zero_lastword;
 #endif
 
 static void update_diwfirstword_total(const int firstword)
@@ -715,10 +717,63 @@ int get_autoscale_sprite_horizontal_edges(void)
 	return edges;
 }
 
+static void get_autoscale_horizontal_limits(const int firstword, const int lastword,
+	int* left, int* right)
+{
+	const int skip = denise_hdelay << (RES_MAX + 1);
+	int diwfirst = firstword + skip;
+	int diwlast = lastword + skip;
+	if (!firstword || !lastword) {
+		diwfirst = ddffirstword_total << (RES_MAX + 1);
+		diwlast = ddflastword_total << (RES_MAX + 1);
+	}
+
+	if (doublescan <= 0 && !programmedmode
+		&& currprefs.gfx_overscanmode < OVERSCANMODE_EXTREME) {
+		const int min = 92 << RES_MAX;
+		const int max = 460 << RES_MAX;
+		diwfirst = std::max(diwfirst, min);
+		diwlast = std::min(diwlast, max);
+	}
+
+	int x = diwfirst - (hdisplay_left_border << (RES_MAX + 1)) + (1 << RES_MAX);
+	const int width = (diwlast - diwfirst) >> hresolution_inv;
+	x >>= hresolution_inv;
+	x = std::max(x, 0);
+	*left = x;
+	*right = x + width;
+}
+
+int get_autoscale_sprite_zero_horizontal_edges(int* left, int* right)
+{
+	if (!left || !right) {
+		return 0;
+	}
+
+	int source_left;
+	int source_right;
+	get_autoscale_horizontal_limits(diwfirstword_total, diwlastword_total,
+		&source_left, &source_right);
+	get_autoscale_horizontal_limits(
+		std::min(diwfirstword_total, autoscale_sprite_zero_firstword),
+		std::max(diwlastword_total, autoscale_sprite_zero_lastword), left, right);
+
+	int edges = 0;
+	if (*left < source_left) {
+		edges |= AUTOSCALE_SPRITE_EDGE_LEFT;
+	}
+	if (*right > source_right) {
+		edges |= AUTOSCALE_SPRITE_EDGE_RIGHT;
+	}
+	return edges;
+}
+
 void reset_autoscale_sprite_horizontal_edges(void)
 {
 	autoscale_sprite_left_edge = false;
 	autoscale_sprite_right_edge = false;
+	autoscale_sprite_zero_firstword = 30000;
+	autoscale_sprite_zero_lastword = 0;
 }
 #endif
 
@@ -4643,6 +4698,23 @@ static void autoscale_sprites(void)
 #endif
 }
 
+#ifdef AMIBERRY
+static void track_autoscale_sprite_zero(void)
+{
+#if AUTOSCALE_SPRITES
+	// Sprite 0 remains excluded from autoscale_sprites(), but native AutoCrop
+	// needs its would-be edge to distinguish pointer motion from raster content.
+	if (internal_pixel_cnt > (48 << RES_MAX)
+		&& internal_pixel_cnt < (448 << RES_MAX)) {
+		autoscale_sprite_zero_firstword = std::min(
+			autoscale_sprite_zero_firstword, internal_pixel_cnt);
+		autoscale_sprite_zero_lastword = std::max(
+			autoscale_sprite_zero_lastword, internal_pixel_cnt);
+	}
+#endif
+}
+#endif
+
 static void get_shres_spr_pix(uae_u32 sv0, uae_u32 sv1, uae_u32 *dpix0, uae_u32 *dpix1)
 {
 	uae_u16 v;
@@ -4695,6 +4767,9 @@ static uae_u32 denise_render_sprites_aga(int add)
 	uae_u32 v = 0;
 	uae_u32 d = 0;
 	bool asp = false;
+#ifdef AMIBERRY
+	bool sprite_zero_autoscale = false;
+#endif
 	int sidx = 0;
 	while (dprspts[sidx]) {
 		struct denise_spr *sp = dprspts[sidx];
@@ -4714,6 +4789,12 @@ static uae_u32 denise_render_sprites_aga(int add)
 				d |= 1 << num;
 			} else if (num > 0) {
 				asp = true;
+#ifdef AMIBERRY
+			} else {
+				const uae_u32 render_mask = magic_sprite_mask & debug_sprite_mask & 3;
+				sprite_zero_autoscale = ((render_mask & 1) && sp->dataas64)
+					|| ((render_mask & 2) && sp->databs64);
+#endif
 			}
 			sp->pix = ((sp->dataas64 >> 63) & 1) << 0;
 			sp->pix |= ((sp->databs64 >> 63) & 1) << 1;
@@ -4735,6 +4816,11 @@ static uae_u32 denise_render_sprites_aga(int add)
 		// only sprites 1-7
 		autoscale_sprites();
 	}
+#ifdef AMIBERRY
+	if (sprite_zero_autoscale && !denise_blank_active && !sprites_hidden) {
+		track_autoscale_sprite_zero();
+	}
+#endif
 	return v;
 }
 

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -4574,11 +4574,9 @@ static void autoscale_sprites(void)
 {
 #if AUTOSCALE_SPRITES
 #if defined(AMIBERRY) && !defined(LIBRETRO)
-	// Native AutoCrop scans rendered pixels outside DIW itself. Keep sprites out
-	// of source geometry so real DIW changes remain distinguishable.
-	if (currprefs.gfx_auto_crop) {
-		return;
-	}
+	// Native AutoCrop scans rendered pixels outside DIW itself, so suppress only
+	// horizontal sprite expansion and retain vertical sprite bounds.
+	if (!currprefs.gfx_auto_crop) {
 #endif
 	if (diwfirstword_total > internal_pixel_cnt && internal_pixel_cnt > (48 << RES_MAX)) {
 		diwfirstword_total = internal_pixel_cnt;
@@ -4586,6 +4584,9 @@ static void autoscale_sprites(void)
 	if (diwlastword_total < internal_pixel_cnt && internal_pixel_cnt < (448 << RES_MAX)) {
 		diwlastword_total = internal_pixel_cnt;
 	}
+#if defined(AMIBERRY) && !defined(LIBRETRO)
+	}
+#endif
 	if (this_line->linear_vpos < plffirstline_total) {
 		plffirstline_total = this_line->linear_vpos;
 	}

--- a/src/include/drawing.h
+++ b/src/include/drawing.h
@@ -137,6 +137,7 @@ enum
 	AUTOSCALE_SPRITE_EDGE_RIGHT = 2
 };
 extern int get_autoscale_sprite_horizontal_edges(void);
+extern int get_autoscale_sprite_zero_horizontal_edges(int* left, int* right);
 extern void reset_autoscale_sprite_horizontal_edges(void);
 #endif
 

--- a/src/include/drawing.h
+++ b/src/include/drawing.h
@@ -130,6 +130,16 @@ extern int get_vertical_visible_height(bool);
 extern void get_mode_blanking_limits(int *phbstop, int *phbstrt, int *pvbstop, int *pvbstrt);
 extern void notice_resolution_seen(int res, bool lace);
 
+#ifdef AMIBERRY
+enum
+{
+	AUTOSCALE_SPRITE_EDGE_LEFT = 1,
+	AUTOSCALE_SPRITE_EDGE_RIGHT = 2
+};
+extern int get_autoscale_sprite_horizontal_edges(void);
+extern void reset_autoscale_sprite_horizontal_edges(void);
+#endif
+
 /* Finally, stuff that shouldn't really be shared.  */
 
 #define IHF_SCROLLLOCK 0

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
 
@@ -46,6 +47,21 @@ static inline int amiberry_auto_crop_rect_right(const AmiberryAutoCropRect& rect
 static inline int amiberry_auto_crop_rect_bottom(const AmiberryAutoCropRect& rect)
 {
 	return rect.y + rect.h;
+}
+
+static inline bool amiberry_auto_crop_rect_within_horizontal_tolerance(
+	const AmiberryAutoCropRect& previous, const AmiberryAutoCropRect& current,
+	const int tolerance)
+{
+	if (tolerance < 0 || previous.w <= 0 || previous.h <= 0
+		|| current.w <= 0 || current.h <= 0
+		|| previous.y != current.y || previous.h != current.h) {
+		return false;
+	}
+
+	return std::abs(previous.x - current.x) <= tolerance
+		&& std::abs(amiberry_auto_crop_rect_right(previous)
+			- amiberry_auto_crop_rect_right(current)) <= tolerance;
 }
 
 static inline bool amiberry_auto_crop_rect_contains(const AmiberryAutoCropRect& rect,

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -70,6 +70,20 @@ static inline bool amiberry_auto_crop_rect_within_horizontal_tolerance(
 					>= amiberry_auto_crop_rect_right(previous)));
 }
 
+static inline bool amiberry_auto_crop_should_preserve_horizontal_jitter(
+	const AmiberryAutoCropRect& previous_source,
+	const AmiberryAutoCropRect& current_source,
+	const AmiberryAutoCropRect& previous_visible,
+	const AmiberryAutoCropRect& current_visible, const int tolerance)
+{
+	return previous_source.x == current_source.x
+		&& previous_source.y == current_source.y
+		&& previous_source.w == current_source.w
+		&& previous_source.h == current_source.h
+		&& amiberry_auto_crop_rect_within_horizontal_tolerance(
+			previous_visible, current_visible, tolerance);
+}
+
 static inline bool amiberry_auto_crop_rect_contains(const AmiberryAutoCropRect& rect,
 	const int x, const int y)
 {

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -74,12 +74,24 @@ static inline bool amiberry_auto_crop_should_preserve_horizontal_jitter(
 	const AmiberryAutoCropRect& previous_source,
 	const AmiberryAutoCropRect& current_source,
 	const AmiberryAutoCropRect& previous_visible,
-	const AmiberryAutoCropRect& current_visible, const int tolerance)
+	const AmiberryAutoCropRect& current_visible,
+	const bool current_source_left_is_sprite,
+	const bool current_source_right_is_sprite, const int tolerance)
 {
-	return previous_source.x == current_source.x
+	const bool source_unchanged = previous_source.x == current_source.x
 		&& previous_source.y == current_source.y
 		&& previous_source.w == current_source.w
-		&& previous_source.h == current_source.h
+		&& previous_source.h == current_source.h;
+	const bool left_changed = previous_source.x != current_source.x;
+	const bool right_changed = amiberry_auto_crop_rect_right(previous_source)
+		!= amiberry_auto_crop_rect_right(current_source);
+	const bool source_sprite_jitter =
+		amiberry_auto_crop_rect_within_horizontal_tolerance(
+			previous_source, current_source, tolerance)
+		&& (!left_changed || current_source_left_is_sprite)
+		&& (!right_changed || current_source_right_is_sprite);
+
+	return (source_unchanged || source_sprite_jitter)
 		&& amiberry_auto_crop_rect_within_horizontal_tolerance(
 			previous_visible, current_visible, tolerance);
 }

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -14,6 +14,13 @@ struct AmiberryAutoCropRect {
 	int h;
 };
 
+struct AmiberryAutoCropHorizontalEvidence {
+	int left;
+	int right;
+	bool left_valid;
+	bool right_valid;
+};
+
 struct AmiberryAutoCropPixelBuffer {
 	const uint8_t* pixels;
 	int width;
@@ -127,6 +134,57 @@ static inline bool amiberry_auto_crop_should_preserve_horizontal_jitter(
 		if (!source_right_changed || source_expands != visible_expands
 			|| (source_expands && current_visible_right != current_source_right)
 			|| (!source_expands && previous_visible_right != previous_source_right)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static inline bool amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+	const AmiberryAutoCropRect& previous_source,
+	const AmiberryAutoCropRect& current_source,
+	const AmiberryAutoCropRect& previous_visible,
+	const AmiberryAutoCropRect& current_visible,
+	const AmiberryAutoCropHorizontalEvidence& previous_sprite_zero,
+	const AmiberryAutoCropHorizontalEvidence& current_sprite_zero,
+	const int tolerance)
+{
+	if (previous_source.x != current_source.x
+		|| previous_source.y != current_source.y
+		|| previous_source.w != current_source.w
+		|| previous_source.h != current_source.h
+		|| !amiberry_auto_crop_rect_within_horizontal_tolerance(
+			previous_visible, current_visible, tolerance)) {
+		return false;
+	}
+
+	const int source_right = amiberry_auto_crop_rect_right(current_source);
+	const int previous_visible_right = amiberry_auto_crop_rect_right(previous_visible);
+	const int current_visible_right = amiberry_auto_crop_rect_right(current_visible);
+	const bool left_changed = previous_visible.x != current_visible.x;
+	const bool right_changed = previous_visible_right != current_visible_right;
+	if (!left_changed && !right_changed) {
+		return false;
+	}
+
+	if (left_changed) {
+		const bool expands = current_visible.x < previous_visible.x;
+		const AmiberryAutoCropHorizontalEvidence& evidence = expands
+			? current_sprite_zero : previous_sprite_zero;
+		const int visible_left = expands ? current_visible.x : previous_visible.x;
+		if (!evidence.left_valid || evidence.left >= current_source.x
+			|| evidence.left != visible_left) {
+			return false;
+		}
+	}
+	if (right_changed) {
+		const bool expands = current_visible_right > previous_visible_right;
+		const AmiberryAutoCropHorizontalEvidence& evidence = expands
+			? current_sprite_zero : previous_sprite_zero;
+		const int visible_right = expands ? current_visible_right : previous_visible_right;
+		if (!evidence.right_valid || evidence.right <= source_right
+			|| evidence.right != visible_right) {
 			return false;
 		}
 	}

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -78,20 +78,23 @@ static inline bool amiberry_auto_crop_should_preserve_horizontal_jitter(
 	const bool current_source_left_is_sprite,
 	const bool current_source_right_is_sprite, const int tolerance)
 {
-	const bool source_unchanged = previous_source.x == current_source.x
-		&& previous_source.y == current_source.y
-		&& previous_source.w == current_source.w
-		&& previous_source.h == current_source.h;
-	const bool left_changed = previous_source.x != current_source.x;
-	const bool right_changed = amiberry_auto_crop_rect_right(previous_source)
+	const bool source_left_changed = previous_source.x != current_source.x;
+	const bool source_right_changed = amiberry_auto_crop_rect_right(previous_source)
 		!= amiberry_auto_crop_rect_right(current_source);
-	const bool source_sprite_jitter =
-		amiberry_auto_crop_rect_within_horizontal_tolerance(
-			previous_source, current_source, tolerance)
-		&& (!left_changed || current_source_left_is_sprite)
-		&& (!right_changed || current_source_right_is_sprite);
+	const bool visible_left_changed = previous_visible.x != current_visible.x;
+	const bool visible_right_changed = amiberry_auto_crop_rect_right(previous_visible)
+		!= amiberry_auto_crop_rect_right(current_visible);
 
-	return (source_unchanged || source_sprite_jitter)
+	return (source_left_changed || source_right_changed)
+		&& (!source_left_changed || current_source_left_is_sprite)
+		&& (!source_right_changed || current_source_right_is_sprite)
+		&& (!visible_left_changed || (current_source_left_is_sprite
+			&& current_visible.x == current_source.x))
+		&& (!visible_right_changed || (current_source_right_is_sprite
+			&& amiberry_auto_crop_rect_right(current_visible)
+				== amiberry_auto_crop_rect_right(current_source)))
+		&& amiberry_auto_crop_rect_within_horizontal_tolerance(
+			previous_source, current_source, tolerance)
 		&& amiberry_auto_crop_rect_within_horizontal_tolerance(
 			previous_visible, current_visible, tolerance);
 }

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -61,7 +61,13 @@ static inline bool amiberry_auto_crop_rect_within_horizontal_tolerance(
 
 	return std::abs(previous.x - current.x) <= tolerance
 		&& std::abs(amiberry_auto_crop_rect_right(previous)
-			- amiberry_auto_crop_rect_right(current)) <= tolerance;
+			- amiberry_auto_crop_rect_right(current)) <= tolerance
+		&& ((previous.x <= current.x
+				&& amiberry_auto_crop_rect_right(previous)
+					>= amiberry_auto_crop_rect_right(current))
+			|| (current.x <= previous.x
+				&& amiberry_auto_crop_rect_right(current)
+					>= amiberry_auto_crop_rect_right(previous)));
 }
 
 static inline bool amiberry_auto_crop_rect_contains(const AmiberryAutoCropRect& rect,

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -75,28 +75,63 @@ static inline bool amiberry_auto_crop_should_preserve_horizontal_jitter(
 	const AmiberryAutoCropRect& current_source,
 	const AmiberryAutoCropRect& previous_visible,
 	const AmiberryAutoCropRect& current_visible,
+	const bool previous_source_left_is_sprite,
+	const bool previous_source_right_is_sprite,
 	const bool current_source_left_is_sprite,
 	const bool current_source_right_is_sprite, const int tolerance)
 {
-	const bool source_left_changed = previous_source.x != current_source.x;
-	const bool source_right_changed = amiberry_auto_crop_rect_right(previous_source)
-		!= amiberry_auto_crop_rect_right(current_source);
-	const bool visible_left_changed = previous_visible.x != current_visible.x;
-	const bool visible_right_changed = amiberry_auto_crop_rect_right(previous_visible)
-		!= amiberry_auto_crop_rect_right(current_visible);
+	if (!amiberry_auto_crop_rect_within_horizontal_tolerance(
+		previous_source, current_source, tolerance)
+		|| !amiberry_auto_crop_rect_within_horizontal_tolerance(
+			previous_visible, current_visible, tolerance)) {
+		return false;
+	}
 
-	return (source_left_changed || source_right_changed)
-		&& (!source_left_changed || current_source_left_is_sprite)
-		&& (!source_right_changed || current_source_right_is_sprite)
-		&& (!visible_left_changed || (current_source_left_is_sprite
-			&& current_visible.x == current_source.x))
-		&& (!visible_right_changed || (current_source_right_is_sprite
-			&& amiberry_auto_crop_rect_right(current_visible)
-				== amiberry_auto_crop_rect_right(current_source)))
-		&& amiberry_auto_crop_rect_within_horizontal_tolerance(
-			previous_source, current_source, tolerance)
-		&& amiberry_auto_crop_rect_within_horizontal_tolerance(
-			previous_visible, current_visible, tolerance);
+	const int previous_source_right = amiberry_auto_crop_rect_right(previous_source);
+	const int current_source_right = amiberry_auto_crop_rect_right(current_source);
+	const int previous_visible_right = amiberry_auto_crop_rect_right(previous_visible);
+	const int current_visible_right = amiberry_auto_crop_rect_right(current_visible);
+	const bool source_left_changed = previous_source.x != current_source.x;
+	const bool source_right_changed = previous_source_right != current_source_right;
+	if (!source_left_changed && !source_right_changed) {
+		return false;
+	}
+
+	if (source_left_changed) {
+		const bool expands = current_source.x < previous_source.x;
+		if ((expands && !current_source_left_is_sprite)
+			|| (!expands && !previous_source_left_is_sprite)) {
+			return false;
+		}
+	}
+	if (source_right_changed) {
+		const bool expands = current_source_right > previous_source_right;
+		if ((expands && !current_source_right_is_sprite)
+			|| (!expands && !previous_source_right_is_sprite)) {
+			return false;
+		}
+	}
+
+	if (previous_visible.x != current_visible.x) {
+		const bool source_expands = current_source.x < previous_source.x;
+		const bool visible_expands = current_visible.x < previous_visible.x;
+		if (!source_left_changed || source_expands != visible_expands
+			|| (source_expands && current_visible.x != current_source.x)
+			|| (!source_expands && previous_visible.x != previous_source.x)) {
+			return false;
+		}
+	}
+	if (previous_visible_right != current_visible_right) {
+		const bool source_expands = current_source_right > previous_source_right;
+		const bool visible_expands = current_visible_right > previous_visible_right;
+		if (!source_right_changed || source_expands != visible_expands
+			|| (source_expands && current_visible_right != current_source_right)
+			|| (!source_expands && previous_visible_right != previous_source_right)) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 static inline bool amiberry_auto_crop_rect_contains(const AmiberryAutoCropRect& rect,

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -136,6 +136,8 @@ struct AutoCropVisibleState {
 	int vres = 0;
 	uint32_t border_rgb = 0;
 	bool border_valid = false;
+	bool source_left_is_sprite = false;
+	bool source_right_is_sprite = false;
 	bool valid = false;
 };
 
@@ -294,9 +296,10 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 			<< std::clamp(hres, RES_LORES, RES_SUPERHIRES);
 		if (amiberry_auto_crop_should_preserve_horizontal_jitter(
 			previous_source, current_source, previous_rect, current_rect,
+			state.source_left_is_sprite, state.source_right_is_sprite,
 			source_left_is_sprite, source_right_is_sprite, tolerance)) {
-			// Hardware sprites can extend visible pixels a pixel or two beyond
-			// DIW as they reach a screen edge. Keep the previous final crop so
+			// Hardware sprites can move a crop edge by a pixel or two as they
+			// reach or leave a screen edge. Keep the previous final crop so
 			// pointer motion does not pan or resize the presentation.
 			visible_rect = state.visible_rect;
 			return;
@@ -317,6 +320,8 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 		state.vres = vres;
 		state.border_rgb = border_rgb;
 		state.border_valid = border_valid;
+		state.source_left_is_sprite = source_left_is_sprite;
+		state.source_right_is_sprite = source_right_is_sprite;
 		state.valid = true;
 		return;
 	}
@@ -327,6 +332,8 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 	visible_rect = auto_crop_rect_union(visible_rect, state.visible_rect);
 	clamp_auto_crop_rect(surface, visible_rect);
 	state.visible_rect = visible_rect;
+	state.source_left_is_sprite = source_left_is_sprite;
+	state.source_right_is_sprite = source_right_is_sprite;
 	if (border_valid) {
 		state.border_rgb = border_rgb;
 		state.border_valid = true;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -124,6 +124,7 @@ constexpr int auto_crop_wide_aspect_w = 21;
 constexpr int auto_crop_wide_aspect_h = 9;
 constexpr int auto_crop_shrink_stable_frames = 6;
 constexpr int auto_crop_min_outside_pixels = 16;
+constexpr int auto_crop_horizontal_jitter_tolerance = 2;
 
 struct AutoCropVisibleState {
 	const SDL_Surface* surface = nullptr;
@@ -266,14 +267,37 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 		return;
 	}
 
-	const bool source_changed = state.surface != surface
+	const bool presentation_changed = state.surface != surface
 		|| state.surface_w != surface->w
 		|| state.surface_h != surface->h
-		|| !auto_crop_rect_equals(state.source_rect, source_rect)
 		|| state.hres != hres
-		|| state.vres != vres
-		|| amiberry_auto_crop_border_state_changed(state.border_rgb, state.border_valid,
-			border_rgb, border_valid);
+		|| state.vres != vres;
+	const bool border_changed = amiberry_auto_crop_border_state_changed(
+		state.border_rgb, state.border_valid, border_rgb, border_valid);
+	if (!reset && state.valid && !presentation_changed && !border_changed) {
+		const AmiberryAutoCropRect previous_rect = {
+			state.visible_rect.x, state.visible_rect.y,
+			state.visible_rect.w, state.visible_rect.h
+		};
+		const AmiberryAutoCropRect current_rect = {
+			visible_rect.x, visible_rect.y, visible_rect.w, visible_rect.h
+		};
+		const int tolerance = auto_crop_horizontal_jitter_tolerance
+			<< std::clamp(hres, RES_LORES, RES_SUPERHIRES);
+		if (amiberry_auto_crop_rect_within_horizontal_tolerance(
+			previous_rect, current_rect, tolerance)) {
+			// Hardware sprites can extend the detected DIW by a pixel or two as
+			// they reach a screen edge. Keep the previous final crop so pointer
+			// motion does not pan or resize the presentation.
+			visible_rect = state.visible_rect;
+			state.source_rect = source_rect;
+			return;
+		}
+	}
+
+	const bool source_changed = presentation_changed
+		|| !auto_crop_rect_equals(state.source_rect, source_rect)
+		|| border_changed;
 	if (reset || source_changed || !state.valid) {
 		state = {};
 		state.surface = surface;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -258,6 +258,7 @@ static void expand_auto_crop_rect_to_visible_content(const SDL_Surface* surface,
 static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 	const SDL_Rect& source_rect, SDL_Rect& visible_rect, const int hres,
 	const int vres, const uint32_t border_rgb, const bool border_valid,
+	const bool source_left_is_sprite, const bool source_right_is_sprite,
 	AutoCropVisibleState& state, const bool reset)
 {
 	if (!surface || surface->w <= 0 || surface->h <= 0
@@ -293,7 +294,7 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 			<< std::clamp(hres, RES_LORES, RES_SUPERHIRES);
 		if (amiberry_auto_crop_should_preserve_horizontal_jitter(
 			previous_source, current_source, previous_rect, current_rect,
-			tolerance)) {
+			source_left_is_sprite, source_right_is_sprite, tolerance)) {
 			// Hardware sprites can extend visible pixels a pixel or two beyond
 			// DIW as they reach a screen edge. Keep the previous final crop so
 			// pointer motion does not pan or resize the presentation.
@@ -2120,6 +2121,7 @@ void auto_crop_image()
 		const int surface_h = surface ? surface->h : 0;
 		SDL_Rect crop_rect = { cx, cy, cw, ch };
 #ifndef LIBRETRO
+		const int sprite_horizontal_edges = get_autoscale_sprite_horizontal_edges();
 		clamp_auto_crop_rect(surface, crop_rect);
 		const SDL_Rect source_crop_rect = crop_rect;
 		// DIW/bitplane limits can exclude visible sprites or raster content.
@@ -2127,7 +2129,9 @@ void auto_crop_image()
 		// conservative minimum frame that keeps intentional black borders.
 		expand_auto_crop_rect_to_visible_content(surface, crop_rect, scan_state);
 		preserve_auto_crop_visible_content(surface, source_crop_rect, crop_rect,
-			hres, vres, scan_state.border_rgb, scan_state.border_valid, visible_state,
+			hres, vres, scan_state.border_rgb, scan_state.border_valid,
+			(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_LEFT) != 0,
+			(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_RIGHT) != 0, visible_state,
 			force_auto_crop || last_autocrop != currprefs.gfx_auto_crop);
 		cx = crop_rect.x;
 		cy = crop_rect.y;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -138,6 +138,7 @@ struct AutoCropVisibleState {
 	bool border_valid = false;
 	bool source_left_is_sprite = false;
 	bool source_right_is_sprite = false;
+	AmiberryAutoCropHorizontalEvidence sprite_zero{};
 	bool valid = false;
 };
 
@@ -261,6 +262,7 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 	const SDL_Rect& source_rect, SDL_Rect& visible_rect, const int hres,
 	const int vres, const uint32_t border_rgb, const bool border_valid,
 	const bool source_left_is_sprite, const bool source_right_is_sprite,
+	const AmiberryAutoCropHorizontalEvidence& sprite_zero,
 	AutoCropVisibleState& state, const bool reset)
 {
 	if (!surface || surface->w <= 0 || surface->h <= 0
@@ -297,7 +299,10 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 		if (amiberry_auto_crop_should_preserve_horizontal_jitter(
 			previous_source, current_source, previous_rect, current_rect,
 			state.source_left_is_sprite, state.source_right_is_sprite,
-			source_left_is_sprite, source_right_is_sprite, tolerance)) {
+			source_left_is_sprite, source_right_is_sprite, tolerance)
+			|| amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+				previous_source, current_source, previous_rect, current_rect,
+				state.sprite_zero, sprite_zero, tolerance)) {
 			// Hardware sprites can move a crop edge by a pixel or two as they
 			// reach or leave a screen edge. Keep the previous final crop so
 			// pointer motion does not pan or resize the presentation.
@@ -322,6 +327,7 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 		state.border_valid = border_valid;
 		state.source_left_is_sprite = source_left_is_sprite;
 		state.source_right_is_sprite = source_right_is_sprite;
+		state.sprite_zero = sprite_zero;
 		state.valid = true;
 		return;
 	}
@@ -334,6 +340,7 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 	state.visible_rect = visible_rect;
 	state.source_left_is_sprite = source_left_is_sprite;
 	state.source_right_is_sprite = source_right_is_sprite;
+	state.sprite_zero = sprite_zero;
 	if (border_valid) {
 		state.border_rgb = border_rgb;
 		state.border_valid = true;
@@ -2129,6 +2136,16 @@ void auto_crop_image()
 		SDL_Rect crop_rect = { cx, cy, cw, ch };
 #ifndef LIBRETRO
 		const int sprite_horizontal_edges = get_autoscale_sprite_horizontal_edges();
+		int sprite_zero_left = 0;
+		int sprite_zero_right = 0;
+		const int sprite_zero_edges = get_autoscale_sprite_zero_horizontal_edges(
+			&sprite_zero_left, &sprite_zero_right);
+		const AmiberryAutoCropHorizontalEvidence sprite_zero = {
+			sprite_zero_left,
+			sprite_zero_right,
+			(sprite_zero_edges & AUTOSCALE_SPRITE_EDGE_LEFT) != 0,
+			(sprite_zero_edges & AUTOSCALE_SPRITE_EDGE_RIGHT) != 0
+		};
 		clamp_auto_crop_rect(surface, crop_rect);
 		const SDL_Rect source_crop_rect = crop_rect;
 		// DIW/bitplane limits can exclude visible sprites or raster content.
@@ -2138,7 +2155,8 @@ void auto_crop_image()
 		preserve_auto_crop_visible_content(surface, source_crop_rect, crop_rect,
 			hres, vres, scan_state.border_rgb, scan_state.border_valid,
 			(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_LEFT) != 0,
-			(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_RIGHT) != 0, visible_state,
+			(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_RIGHT) != 0, sprite_zero,
+			visible_state,
 			force_auto_crop || last_autocrop != currprefs.gfx_auto_crop);
 		cx = crop_rect.x;
 		cy = crop_rect.y;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -275,6 +275,13 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 	const bool border_changed = amiberry_auto_crop_border_state_changed(
 		state.border_rgb, state.border_valid, border_rgb, border_valid);
 	if (!reset && state.valid && !presentation_changed && !border_changed) {
+		const AmiberryAutoCropRect previous_source = {
+			state.source_rect.x, state.source_rect.y,
+			state.source_rect.w, state.source_rect.h
+		};
+		const AmiberryAutoCropRect current_source = {
+			source_rect.x, source_rect.y, source_rect.w, source_rect.h
+		};
 		const AmiberryAutoCropRect previous_rect = {
 			state.visible_rect.x, state.visible_rect.y,
 			state.visible_rect.w, state.visible_rect.h
@@ -284,13 +291,13 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 		};
 		const int tolerance = auto_crop_horizontal_jitter_tolerance
 			<< std::clamp(hres, RES_LORES, RES_SUPERHIRES);
-		if (amiberry_auto_crop_rect_within_horizontal_tolerance(
-			previous_rect, current_rect, tolerance)) {
-			// Hardware sprites can extend the detected DIW by a pixel or two as
-			// they reach a screen edge. Keep the previous final crop so pointer
-			// motion does not pan or resize the presentation.
+		if (amiberry_auto_crop_should_preserve_horizontal_jitter(
+			previous_source, current_source, previous_rect, current_rect,
+			tolerance)) {
+			// Hardware sprites can extend visible pixels a pixel or two beyond
+			// DIW as they reach a screen edge. Keep the previous final crop so
+			// pointer motion does not pan or resize the presentation.
 			visible_rect = state.visible_rect;
-			state.source_rect = source_rect;
 			return;
 		}
 	}

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -396,6 +396,21 @@ static void test_horizontal_edge_jitter_tolerance()
 	expect_true(amiberry_auto_crop_rect_within_horizontal_tolerance(
 		stable, { 38, 24, 322, 200 }, 2),
 		"A two-pixel right sprite extension should keep the stable crop");
+	expect_true(amiberry_auto_crop_rect_within_horizontal_tolerance(
+		stable, { 37, 24, 322, 200 }, 2),
+		"A two-sided sprite expansion should keep the stable crop");
+	expect_true(amiberry_auto_crop_rect_within_horizontal_tolerance(
+		stable, { 39, 24, 318, 200 }, 2),
+		"A two-sided sprite contraction should keep the stable crop");
+	expect_true(!amiberry_auto_crop_rect_within_horizontal_tolerance(
+		stable, { 37, 24, 320, 200 }, 2),
+		"A one-pixel left crop translation must update the crop");
+	expect_true(!amiberry_auto_crop_rect_within_horizontal_tolerance(
+		stable, { 39, 24, 320, 200 }, 2),
+		"A one-pixel right crop translation must update the crop");
+	expect_true(!amiberry_auto_crop_rect_within_horizontal_tolerance(
+		stable, { 36, 24, 321, 200 }, 2),
+		"Mixed same-direction edge movement must update the crop");
 	expect_true(!amiberry_auto_crop_rect_within_horizontal_tolerance(
 		stable, { 35, 24, 323, 200 }, 2),
 		"A larger horizontal expansion must update the crop");

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -444,61 +444,107 @@ static void test_horizontal_edge_jitter_requires_sprite_source_attribution()
 	const AmiberryAutoCropRect source{ 38, 24, 320, 200 };
 	const AmiberryAutoCropRect stable{ 38, 24, 320, 200 };
 	const AmiberryAutoCropRect left_expanded{ 37, 24, 321, 200 };
-
-	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, source, stable, left_expanded, false, false, 2),
-		"An unchanged source must not hide a visible content expansion");
-	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, source, stable, left_expanded, true, false, 2),
-		"Sprite attribution must not hide a visible change when the source is unchanged");
-
 	const AmiberryAutoCropRect left_expanded_source{ 37, 24, 321, 200 };
+	const AmiberryAutoCropRect right_expanded_source{ 38, 24, 322, 200 };
+
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, source, stable, left_expanded,
+		true, false, false, false, 2),
+		"Previous sprite attribution must not hide a change when the source is unchanged");
+
 	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, left_expanded_source, stable, left_expanded, true, false, 2),
+		source, left_expanded_source, stable, left_expanded,
+		false, false, true, false, 2),
 		"An attributed left source extension should preserve the crop");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, left_expanded_source, stable, left_expanded, false, false, 2),
+		source, left_expanded_source, stable, left_expanded,
+		true, false, false, false, 2),
 		"An unattributed left source extension must reset stabilization");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, left_expanded_source, stable, left_expanded, false, true, 2),
+		source, left_expanded_source, stable, left_expanded,
+		false, false, false, true, 2),
 		"Right attribution must not cover a left source extension");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, left_expanded_source, stable, { 36, 24, 322, 200 }, true, false, 2),
+		source, left_expanded_source, stable, { 36, 24, 322, 200 },
+		false, false, true, false, 2),
 		"A pixel-scan extension beyond an attributed left source edge must update the crop");
 
-	const AmiberryAutoCropRect right_expanded_source{ 38, 24, 322, 200 };
 	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, right_expanded_source, stable, right_expanded_source, false, true, 2),
+		source, right_expanded_source, stable, right_expanded_source,
+		false, false, false, true, 2),
 		"An attributed right source extension should preserve the crop");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, right_expanded_source, stable, right_expanded_source, false, false, 2),
+		source, right_expanded_source, stable, right_expanded_source,
+		false, true, false, false, 2),
 		"An unattributed right source extension must reset stabilization");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, right_expanded_source, stable, right_expanded_source, true, false, 2),
+		source, right_expanded_source, stable, right_expanded_source,
+		false, false, true, false, 2),
 		"Left attribution must not cover a right source extension");
 
 	const AmiberryAutoCropRect both_expanded_source{ 37, 24, 323, 200 };
 	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, both_expanded_source, stable, both_expanded_source, true, true, 2),
+		source, both_expanded_source, stable, both_expanded_source,
+		false, false, true, true, 2),
 		"Two-sided source extensions should preserve the crop when both are attributed");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, both_expanded_source, stable, both_expanded_source, true, false, 2),
+		source, both_expanded_source, stable, both_expanded_source,
+		false, false, true, false, 2),
 		"Two-sided source extensions require right attribution");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, both_expanded_source, stable, both_expanded_source, false, true, 2),
+		source, both_expanded_source, stable, both_expanded_source,
+		false, false, false, true, 2),
 		"Two-sided source extensions require left attribution");
 
+	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
+		left_expanded_source, source, left_expanded, stable,
+		true, false, false, false, 2),
+		"A left source contraction should use the previous sprite attribution");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 37, 24, 320, 200 }, stable, left_expanded, true, true, 2),
+		left_expanded_source, source, left_expanded, stable,
+		false, false, false, false, 2),
+		"A left source contraction without previous attribution must update the crop");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		left_expanded_source, source, left_expanded, stable,
+		false, false, true, false, 2),
+		"Current attribution must not cover a left source contraction");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		left_expanded_source, source, left_expanded, stable,
+		false, true, false, false, 2),
+		"Previous right attribution must not cover a left source contraction");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		left_expanded_source, source, { 36, 24, 322, 200 }, stable,
+		true, false, false, false, 2),
+		"A scan-controlled previous left edge must not hide a source contraction");
+
+	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
+		right_expanded_source, source, right_expanded_source, stable,
+		false, true, false, false, 2),
+		"A right source contraction should use the previous sprite attribution");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		right_expanded_source, source, right_expanded_source, stable,
+		false, false, false, false, 2),
+		"A right source contraction without previous attribution must update the crop");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		right_expanded_source, source, right_expanded_source, stable,
+		true, false, false, false, 2),
+		"Previous left attribution must not cover a right source contraction");
+
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, { 37, 24, 320, 200 }, stable, left_expanded,
+		true, true, true, true, 2),
 		"A source translation must reset stabilization despite sprite attribution");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 38, 23, 320, 200 }, stable, left_expanded, true, true, 2),
+		source, { 38, 23, 320, 200 }, stable, left_expanded,
+		true, true, true, true, 2),
 		"A source y change must reset stabilization despite sprite attribution");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 38, 24, 320, 201 }, stable, left_expanded, true, true, 2),
+		source, { 38, 24, 320, 201 }, stable, left_expanded,
+		true, true, true, true, 2),
 		"A source height change must reset stabilization despite sprite attribution");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 35, 24, 323, 200 }, stable, { 35, 24, 323, 200 }, true, false, 2),
+		source, { 35, 24, 323, 200 }, stable, { 35, 24, 323, 200 },
+		false, false, true, false, 2),
 		"A source change beyond tolerance must reset stabilization");
 }
 

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -113,6 +113,26 @@ static void test_ignores_scattered_outside_pixels()
 	expect_eq(crop.h, 12, "Scattered pixels must not change crop height");
 }
 
+static void test_expands_to_visible_sprite_edge_content()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	std::vector<uint32_t> pixels(width * height, 0);
+	for (int y = 10; y < 18; y++) {
+		pixels[y * width + 6] = 0x00ffffffu;
+		pixels[y * width + 7] = 0x00ffffffu;
+	}
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 8, 8, 20, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, crop, state);
+
+	expect_true(changed, "A visible sprite strip outside DIW should expand the crop");
+	expect_eq(crop.x, 6, "The crop should include the sprite's left edge");
+	expect_eq(crop.w, 22, "The crop should preserve its right edge after sprite expansion");
+}
+
 static void test_keeps_crop_inside_non_black_border()
 {
 	constexpr int width = 40;
@@ -419,11 +439,35 @@ static void test_horizontal_edge_jitter_tolerance()
 		"A vertical crop change must not be treated as horizontal jitter");
 }
 
+static void test_horizontal_edge_jitter_requires_unchanged_source_geometry()
+{
+	const AmiberryAutoCropRect source{ 38, 24, 320, 200 };
+	const AmiberryAutoCropRect stable{ 38, 24, 320, 200 };
+	const AmiberryAutoCropRect expanded{ 36, 24, 322, 200 };
+
+	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, source, stable, expanded, 2),
+		"An unchanged source with a nested visible expansion should preserve the crop");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, { 37, 24, 320, 200 }, stable, expanded, 2),
+		"A source x change must reset horizontal jitter stabilization");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, { 38, 23, 320, 200 }, stable, expanded, 2),
+		"A source y change must reset horizontal jitter stabilization");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, { 38, 24, 321, 200 }, stable, expanded, 2),
+		"A source width change must reset horizontal jitter stabilization");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, { 38, 24, 320, 201 }, stable, expanded, 2),
+		"A source height change must reset horizontal jitter stabilization");
+}
+
 int main()
 {
 	test_expands_to_connected_visible_content();
 	test_ignores_distant_speck_when_content_expands();
 	test_ignores_scattered_outside_pixels();
+	test_expands_to_visible_sprite_edge_content();
 	test_keeps_crop_inside_non_black_border();
 	test_uniform_border_avoids_component_scan();
 	test_expands_past_non_black_border_for_real_content();
@@ -436,5 +480,6 @@ int main()
 	test_two_of_three_sides_is_not_border_confidence();
 	test_border_state_changes_reset_preserved_crop();
 	test_horizontal_edge_jitter_tolerance();
+	test_horizontal_edge_jitter_requires_unchanged_source_geometry();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -439,27 +439,61 @@ static void test_horizontal_edge_jitter_tolerance()
 		"A vertical crop change must not be treated as horizontal jitter");
 }
 
-static void test_horizontal_edge_jitter_requires_unchanged_source_geometry()
+static void test_horizontal_edge_jitter_requires_sprite_source_attribution()
 {
 	const AmiberryAutoCropRect source{ 38, 24, 320, 200 };
 	const AmiberryAutoCropRect stable{ 38, 24, 320, 200 };
 	const AmiberryAutoCropRect expanded{ 36, 24, 322, 200 };
 
 	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, source, stable, expanded, 2),
+		source, source, stable, expanded, false, false, 2),
 		"An unchanged source with a nested visible expansion should preserve the crop");
+
+	const AmiberryAutoCropRect left_expanded_source{ 37, 24, 321, 200 };
+	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, left_expanded_source, stable, expanded, true, false, 2),
+		"An attributed left source extension should preserve the crop");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 37, 24, 320, 200 }, stable, expanded, 2),
-		"A source x change must reset horizontal jitter stabilization");
+		source, left_expanded_source, stable, expanded, false, false, 2),
+		"An unattributed left source extension must reset stabilization");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 38, 23, 320, 200 }, stable, expanded, 2),
-		"A source y change must reset horizontal jitter stabilization");
+		source, left_expanded_source, stable, expanded, false, true, 2),
+		"Right attribution must not cover a left source extension");
+
+	const AmiberryAutoCropRect right_expanded_source{ 38, 24, 322, 200 };
+	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, right_expanded_source, stable, expanded, false, true, 2),
+		"An attributed right source extension should preserve the crop");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 38, 24, 321, 200 }, stable, expanded, 2),
-		"A source width change must reset horizontal jitter stabilization");
+		source, right_expanded_source, stable, expanded, false, false, 2),
+		"An unattributed right source extension must reset stabilization");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 38, 24, 320, 201 }, stable, expanded, 2),
-		"A source height change must reset horizontal jitter stabilization");
+		source, right_expanded_source, stable, expanded, true, false, 2),
+		"Left attribution must not cover a right source extension");
+
+	const AmiberryAutoCropRect both_expanded_source{ 37, 24, 323, 200 };
+	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, both_expanded_source, stable, expanded, true, true, 2),
+		"Two-sided source extensions should preserve the crop when both are attributed");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, both_expanded_source, stable, expanded, true, false, 2),
+		"Two-sided source extensions require right attribution");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, both_expanded_source, stable, expanded, false, true, 2),
+		"Two-sided source extensions require left attribution");
+
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, { 37, 24, 320, 200 }, stable, expanded, true, true, 2),
+		"A source translation must reset stabilization despite sprite attribution");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, { 38, 23, 320, 200 }, stable, expanded, true, true, 2),
+		"A source y change must reset stabilization despite sprite attribution");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, { 38, 24, 320, 201 }, stable, expanded, true, true, 2),
+		"A source height change must reset stabilization despite sprite attribution");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, { 35, 24, 323, 200 }, stable, expanded, true, false, 2),
+		"A source change beyond tolerance must reset stabilization");
 }
 
 int main()
@@ -480,6 +514,6 @@ int main()
 	test_two_of_three_sides_is_not_border_confidence();
 	test_border_state_changes_reset_preserved_crop();
 	test_horizontal_edge_jitter_tolerance();
-	test_horizontal_edge_jitter_requires_unchanged_source_geometry();
+	test_horizontal_edge_jitter_requires_sprite_source_attribution();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -443,56 +443,62 @@ static void test_horizontal_edge_jitter_requires_sprite_source_attribution()
 {
 	const AmiberryAutoCropRect source{ 38, 24, 320, 200 };
 	const AmiberryAutoCropRect stable{ 38, 24, 320, 200 };
-	const AmiberryAutoCropRect expanded{ 36, 24, 322, 200 };
+	const AmiberryAutoCropRect left_expanded{ 37, 24, 321, 200 };
 
-	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, source, stable, expanded, false, false, 2),
-		"An unchanged source with a nested visible expansion should preserve the crop");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, source, stable, left_expanded, false, false, 2),
+		"An unchanged source must not hide a visible content expansion");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, source, stable, left_expanded, true, false, 2),
+		"Sprite attribution must not hide a visible change when the source is unchanged");
 
 	const AmiberryAutoCropRect left_expanded_source{ 37, 24, 321, 200 };
 	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, left_expanded_source, stable, expanded, true, false, 2),
+		source, left_expanded_source, stable, left_expanded, true, false, 2),
 		"An attributed left source extension should preserve the crop");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, left_expanded_source, stable, expanded, false, false, 2),
+		source, left_expanded_source, stable, left_expanded, false, false, 2),
 		"An unattributed left source extension must reset stabilization");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, left_expanded_source, stable, expanded, false, true, 2),
+		source, left_expanded_source, stable, left_expanded, false, true, 2),
 		"Right attribution must not cover a left source extension");
+	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
+		source, left_expanded_source, stable, { 36, 24, 322, 200 }, true, false, 2),
+		"A pixel-scan extension beyond an attributed left source edge must update the crop");
 
 	const AmiberryAutoCropRect right_expanded_source{ 38, 24, 322, 200 };
 	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, right_expanded_source, stable, expanded, false, true, 2),
+		source, right_expanded_source, stable, right_expanded_source, false, true, 2),
 		"An attributed right source extension should preserve the crop");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, right_expanded_source, stable, expanded, false, false, 2),
+		source, right_expanded_source, stable, right_expanded_source, false, false, 2),
 		"An unattributed right source extension must reset stabilization");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, right_expanded_source, stable, expanded, true, false, 2),
+		source, right_expanded_source, stable, right_expanded_source, true, false, 2),
 		"Left attribution must not cover a right source extension");
 
 	const AmiberryAutoCropRect both_expanded_source{ 37, 24, 323, 200 };
 	expect_true(amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, both_expanded_source, stable, expanded, true, true, 2),
+		source, both_expanded_source, stable, both_expanded_source, true, true, 2),
 		"Two-sided source extensions should preserve the crop when both are attributed");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, both_expanded_source, stable, expanded, true, false, 2),
+		source, both_expanded_source, stable, both_expanded_source, true, false, 2),
 		"Two-sided source extensions require right attribution");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, both_expanded_source, stable, expanded, false, true, 2),
+		source, both_expanded_source, stable, both_expanded_source, false, true, 2),
 		"Two-sided source extensions require left attribution");
 
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 37, 24, 320, 200 }, stable, expanded, true, true, 2),
+		source, { 37, 24, 320, 200 }, stable, left_expanded, true, true, 2),
 		"A source translation must reset stabilization despite sprite attribution");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 38, 23, 320, 200 }, stable, expanded, true, true, 2),
+		source, { 38, 23, 320, 200 }, stable, left_expanded, true, true, 2),
 		"A source y change must reset stabilization despite sprite attribution");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 38, 24, 320, 201 }, stable, expanded, true, true, 2),
+		source, { 38, 24, 320, 201 }, stable, left_expanded, true, true, 2),
 		"A source height change must reset stabilization despite sprite attribution");
 	expect_true(!amiberry_auto_crop_should_preserve_horizontal_jitter(
-		source, { 35, 24, 323, 200 }, stable, expanded, true, false, 2),
+		source, { 35, 24, 323, 200 }, stable, { 35, 24, 323, 200 }, true, false, 2),
 		"A source change beyond tolerance must reset stabilization");
 }
 

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -548,6 +548,61 @@ static void test_horizontal_edge_jitter_requires_sprite_source_attribution()
 		"A source change beyond tolerance must reset stabilization");
 }
 
+static void test_sprite_zero_scan_jitter_requires_exact_edge_evidence()
+{
+	const AmiberryAutoCropRect source{ 38, 24, 320, 200 };
+	const AmiberryAutoCropRect stable{ 38, 24, 320, 200 };
+	const AmiberryAutoCropHorizontalEvidence no_evidence{ 0, 0, false, false };
+	const AmiberryAutoCropHorizontalEvidence left_evidence{ 37, 0, true, false };
+	const AmiberryAutoCropHorizontalEvidence right_evidence{ 0, 359, false, true };
+
+	expect_true(amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+		source, source, stable, { 37, 24, 321, 200 },
+		no_evidence, left_evidence, 2),
+		"A scan-only left expansion should use current sprite-0 evidence");
+	expect_true(amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+		source, source, { 37, 24, 321, 200 }, stable,
+		left_evidence, no_evidence, 2),
+		"A scan-only left contraction should use previous sprite-0 evidence");
+	expect_true(amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+		source, source, stable, { 38, 24, 321, 200 },
+		no_evidence, right_evidence, 2),
+		"A scan-only right expansion should use current sprite-0 evidence");
+	expect_true(amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+		source, source, { 38, 24, 321, 200 }, stable,
+		right_evidence, no_evidence, 2),
+		"A scan-only right contraction should use previous sprite-0 evidence");
+
+	expect_true(!amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+		source, source, stable, { 37, 24, 321, 200 },
+		no_evidence, no_evidence, 2),
+		"Arbitrary scan-only content must not be classified as sprite jitter");
+	expect_true(!amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+		source, source, stable, { 36, 24, 322, 200 },
+		no_evidence, left_evidence, 2),
+		"Scan content beyond the sprite-0 edge must update the crop");
+	expect_true(!amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+		source, source, stable, { 37, 24, 322, 200 },
+		no_evidence, left_evidence, 2),
+		"Every changed scan edge must have matching sprite-0 evidence");
+	expect_true(!amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+		source, source, stable, { 37, 23, 321, 201 },
+		no_evidence, left_evidence, 2),
+		"A vertical scan change must update the crop");
+	expect_true(!amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+		source, source, stable, { 37, 24, 320, 200 },
+		no_evidence, left_evidence, 2),
+		"A scan translation must update the crop");
+	expect_true(!amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+		source, { 37, 24, 321, 200 }, stable, { 37, 24, 321, 200 },
+		no_evidence, left_evidence, 2),
+		"A source geometry change must not use the scan-only path");
+	expect_true(!amiberry_auto_crop_should_preserve_sprite_zero_scan_jitter(
+		source, source, stable, { 37, 24, 321, 200 },
+		no_evidence, { 38, 0, true, false }, 2),
+		"Sprite-0 evidence inside the source must not hide scan content");
+}
+
 int main()
 {
 	test_expands_to_connected_visible_content();
@@ -567,5 +622,6 @@ int main()
 	test_border_state_changes_reset_preserved_crop();
 	test_horizontal_edge_jitter_tolerance();
 	test_horizontal_edge_jitter_requires_sprite_source_attribution();
+	test_sprite_zero_scan_jitter_requires_exact_edge_evidence();
 	return failures == 0 ? 0 : 1;
 }

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -383,6 +383,27 @@ static void test_border_state_changes_reset_preserved_crop()
 		second_color, false), "Ambiguous border samples must ignore stale colors");
 }
 
+static void test_horizontal_edge_jitter_tolerance()
+{
+	const AmiberryAutoCropRect stable{ 38, 24, 320, 200 };
+
+	expect_true(amiberry_auto_crop_rect_within_horizontal_tolerance(
+		stable, { 37, 24, 321, 200 }, 2),
+		"A one-pixel left sprite extension should keep the stable crop");
+	expect_true(amiberry_auto_crop_rect_within_horizontal_tolerance(
+		stable, { 36, 24, 322, 200 }, 2),
+		"A two-pixel left sprite extension should keep the stable crop");
+	expect_true(amiberry_auto_crop_rect_within_horizontal_tolerance(
+		stable, { 38, 24, 322, 200 }, 2),
+		"A two-pixel right sprite extension should keep the stable crop");
+	expect_true(!amiberry_auto_crop_rect_within_horizontal_tolerance(
+		stable, { 35, 24, 323, 200 }, 2),
+		"A larger horizontal expansion must update the crop");
+	expect_true(!amiberry_auto_crop_rect_within_horizontal_tolerance(
+		stable, { 38, 23, 320, 201 }, 2),
+		"A vertical crop change must not be treated as horizontal jitter");
+}
+
 int main()
 {
 	test_expands_to_connected_visible_content();
@@ -399,5 +420,6 @@ int main()
 	test_two_sided_color_is_not_perimeter_majority();
 	test_two_of_three_sides_is_not_border_confidence();
 	test_border_state_changes_reset_preserved_crop();
+	test_horizontal_edge_jitter_tolerance();
 	return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Fixes #2256.

Changes proposed in this pull request:
- Keep native AutoCrop stable when hardware mouse sprites extend the detected display bounds by one or two pixels, eliminating the apparent horizontal panning at the screen edges.
- Limit stabilization to horizontal-only changes within a resolution-scaled tolerance; larger geometry, vertical, surface, mode, and border changes continue to update immediately.
- Add regression coverage for left/right sprite extensions. The AutoCrop, graphics geometry, and libretro crop-policy tests pass, and the fix was confirmed locally in Barbarian (Psygnosis) through AmigaVision.

@midwan
