### PR TITLE
fix(filesys): keep regular host files non-executable

### DIFF
--- a/src/osdep/amiberry_filesys_permissions.h
+++ b/src/osdep/amiberry_filesys_permissions.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <sys/stat.h>
+#include <sys/types.h>
+
+inline mode_t amiberry_filesys_apply_protection_bits(
+	const mode_t host_mode,
+	const bool read_protected,
+	const bool write_protected,
+	const bool execute_protected)
+{
+	mode_t mode = host_mode;
+	const bool is_directory = S_ISDIR(host_mode);
+
+	mode = read_protected ? (mode & ~S_IRUSR) : (mode | S_IRUSR);
+	mode = write_protected ? (mode & ~S_IWUSR) : (mode | S_IWUSR);
+
+	if (is_directory) {
+		const mode_t execute_bits = S_IXUSR | S_IXGRP | S_IXOTH;
+		mode = execute_protected ? (mode & ~execute_bits) : (mode | execute_bits);
+	} else if (execute_protected) {
+		// Amiga executability is metadata, not a request to make every host file
+		// a native executable. Preserve existing execute bits unless protection
+		// explicitly removes them.
+		mode &= ~(S_IXUSR | S_IXGRP | S_IXOTH);
+	}
+
+	if (mode & S_IRUSR) {
+		mode |= S_IRGRP | S_IROTH;
+	}
+
+	return mode;
+}

--- a/src/osdep/fsdb_host.cpp
+++ b/src/osdep/fsdb_host.cpp
@@ -31,6 +31,7 @@
 #include "fsdb.h"
 #include "zfile.h"
 #include "fsdb_host.h"
+#include "amiberry_filesys_permissions.h"
 #include "uae.h"
 
 enum
@@ -807,25 +808,13 @@ int fsdb_set_file_attrs(a_inode* aino)
             return host_errno_to_dos_errno(err);
         }
 
-        // Calculate new mode based on Amiga flags
-        // Note: In Amiga, protection bits are inverted (set = denied)
-        const uae_u32 mask = aino->amigaos_mode;
-        int mode = statbuf.st_mode;
-
-        // Update user permissions
-        mode = (mask & A_FIBF_READ) ? (mode & ~S_IRUSR) : (mode | S_IRUSR);
-        mode = (mask & A_FIBF_WRITE) ? (mode & ~S_IWUSR) : (mode | S_IWUSR);
-        mode = (mask & A_FIBF_EXECUTE) ? (mode & ~S_IXUSR) : (mode | S_IXUSR);
-
-        // Add group/other read permissions if user can read
-        if (mode & S_IRUSR) {
-            mode |= (S_IRGRP | S_IROTH);
-        }
-
-        // Add group/other execute permissions if user can execute
-        if (mode & S_IXUSR) {
-            mode |= (S_IXGRP | S_IXOTH);
-        }
+		// Amiga protection bits are inverted: set means access is denied.
+		const uae_u32 mask = aino->amigaos_mode;
+		const mode_t mode = amiberry_filesys_apply_protection_bits(
+			statbuf.st_mode,
+			(mask & A_FIBF_READ) != 0,
+			(mask & A_FIBF_WRITE) != 0,
+			(mask & A_FIBF_EXECUTE) != 0);
 
 		// Apply new permissions
 		if (chmod(path_utf8.c_str(), mode) != 0) {

--- a/tests/filesys_permissions_test.cpp
+++ b/tests/filesys_permissions_test.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "amiberry_filesys_permissions.h"
+
+static int failures;
+
+static void expect_mode(const mode_t actual, const mode_t expected, const char* message)
+{
+	if ((actual & 07777) != expected) {
+		std::cerr << message << ": expected 0" << std::oct << expected
+			<< ", got 0" << (actual & 07777) << std::dec << '\n';
+		failures++;
+	}
+}
+
+static void test_new_regular_file_is_not_executable()
+{
+	const mode_t mode = amiberry_filesys_apply_protection_bits(
+		S_IFREG | 0640, false, false, false);
+	expect_mode(mode, 0644, "new regular file must use normal data-file permissions");
+}
+
+static void test_new_directory_remains_searchable()
+{
+	const mode_t mode = amiberry_filesys_apply_protection_bits(
+		S_IFDIR | 0755, false, false, false);
+	expect_mode(mode, 0755, "new directory must retain execute/search permissions");
+}
+
+static void test_existing_regular_file_execute_bits_are_preserved()
+{
+	const mode_t mode = amiberry_filesys_apply_protection_bits(
+		S_IFREG | 0750, false, false, false);
+	expect_mode(mode, 0754, "existing host executable must retain its execute bits");
+}
+
+static void test_execute_protection_clears_regular_file_execute_bits()
+{
+	const mode_t mode = amiberry_filesys_apply_protection_bits(
+		S_IFREG | 0755, false, false, true);
+	expect_mode(mode, 0644, "execute protection must remove host execute bits");
+}
+
+static void test_execute_protection_clears_directory_search_bits()
+{
+	const mode_t mode = amiberry_filesys_apply_protection_bits(
+		S_IFDIR | 0755, false, false, true);
+	expect_mode(mode, 0644, "execute protection must remove directory search bits");
+}
+
+int main()
+{
+	test_new_regular_file_is_not_executable();
+	test_new_directory_remains_searchable();
+	test_existing_regular_file_execute_bits_are_preserved();
+	test_execute_protection_clears_regular_file_execute_bits();
+	test_execute_protection_clears_directory_search_bits();
+	return failures == 0 ? 0 : 1;
+}

--- a/tests/test_filesys_permissions.sh
+++ b/tests/test_filesys_permissions.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+cxx=${CXX:-c++}
+out="${TMPDIR:-/tmp}/filesys_permissions_test.$$"
+trap 'rm -f "$out"' EXIT
+
+"$cxx" -std=c++17 -Wall -Wextra -Werror -Isrc/osdep -o "$out" tests/filesys_permissions_test.cpp
+"$out"


### PR DESCRIPTION
Fixes #2259.

Changes proposed in this pull request:
- Keep new regular files created through directory-backed filesystems non-executable on the host (`0644` with the standard umask), while directories remain searchable (`0755`).
- Preserve execute bits on existing host executables unless Amiga execute protection explicitly removes them; Amiga protection metadata remains authoritative inside the emulator.
- Add focused regression coverage for new files, directories, existing executables, and explicit execute protection. The focused test and warnings-enabled Linux release build pass, and the production source compiles with the llvm-mingw Windows release configuration.
