### PR TITLE
fix: prevent heap corruption when switching between RTG and native modes

### DIFF
--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -1188,12 +1188,23 @@ void unlockscr(struct vidbuffer* vb, int y_start, int y_end)
 			if (surface && clamped_y_end >= surface->h) {
 				clamped_y_end = surface->h - 1;
 			}
-			
+
+			// Clamp width to the current surface width as well.  width_allocated
+			// is set by lockscr from the surface that was current at lock time; if
+			// the surface has since been recreated (e.g. RTG→native switch in
+			// doInit), width_allocated may still reflect the old, larger surface.
+			// An unclamped dirty_rect.w feeds SDL_UpdateTexture / glTexSubImage2D
+			// which read past the end of the new surface's pixel buffer.
+			int clamped_w = vb->width_allocated;
+			if (surface && clamped_w > surface->w) {
+				clamped_w = surface->w;
+			}
+
 			if (clamped_y_end >= y_start) {
 				SDL_Rect dirty_rect;
 				dirty_rect.x = 0;
 				dirty_rect.y = y_start;
-				dirty_rect.w = vb->width_allocated;
+				dirty_rect.w = clamped_w;
 				dirty_rect.h = clamped_y_end - y_start + 1;
 
 				add_dirty_rect(mon, dirty_rect);

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -468,6 +468,14 @@ void close_windows(struct AmigaMonitor* mon, const bool force_destroy_fullwindow
 		reset_sound();
 
 #ifdef AMIBERRY
+	// Reset drawbuffer state that may point into the surface pixel buffer
+	// before destroying the surface (see doInit for the full explanation).
+	avidinfo->drawbuffer.bufmem = nullptr;
+	avidinfo->drawbuffer.width_allocated = 0;
+	avidinfo->drawbuffer.height_allocated = 0;
+	avidinfo->drawbuffer.rowbytes = 0;
+	avidinfo->drawbuffer.locked = false;
+
 	if (mon->monitor_id == 0) {
 		SDL_DestroySurface(amiga_surface);
 		amiga_surface = nullptr;
@@ -1251,6 +1259,22 @@ bool doInit(AmigaMonitor* mon)
 	{
 		if (surface_ref)
 		{
+			// The drawbuffer's vram_buffer mode stores bufmem/width_allocated/
+			// height_allocated/rowbytes as direct references into the surface's
+			// pixel buffer (set by lockscr).  Reset those fields before freeing
+			// the surface so no stale pointers or dimensions survive the
+			// reallocation.  Without this, a subsequent flush_clear_screen or
+			// unlockscr dirty-rect calculation can use the old (larger)
+			// dimensions against the new (smaller) surface, overflowing the
+			// pixel buffer and corrupting heap metadata — the
+			// "free(): invalid next size" crash when switching between RTG
+			// (e.g. ZZ9000) and native PAL modes (issue #2266).
+			avidinfo->drawbuffer.bufmem = nullptr;
+			avidinfo->drawbuffer.width_allocated = 0;
+			avidinfo->drawbuffer.height_allocated = 0;
+			avidinfo->drawbuffer.rowbytes = 0;
+			avidinfo->drawbuffer.locked = false;
+
 			SDL_DestroySurface(surface_ref);
 			surface_ref = nullptr;
 		}

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -5572,6 +5572,23 @@ static void copyrow(int monid, uae_u8 *src, uae_u8 *dst, int x, int y, int width
 		return;
 	}
 
+	// Guard against writing past the destination buffer.  vidinfo->maxwidth
+	// and maxheight are set by gfx_lock_picasso2 from the current surface
+	// dimensions.  If the RTG board's internal mode (state->Width/Height)
+	// is larger than the surface — e.g. during a mode switch where the
+	// surface hasn't been recreated yet — clamp the write to the surface
+	// bounds to prevent heap corruption (issue #2266).
+	if (vidinfo->maxwidth > 0 && dx + width > vidinfo->maxwidth) {
+		width = vidinfo->maxwidth - dx;
+		if (width <= 0) {
+			return;
+		}
+		endx = x + width;
+	}
+	if (vidinfo->maxheight > 0 && dy >= vidinfo->maxheight) {
+		return;
+	}
+
 	uae_u8 *src2 = src + y * srcbytesperrow;
 	uae_u8 *dst2 = dst + dy * dstbytesperrow;
 


### PR DESCRIPTION
## Bug Description

When switching between ZZ9000 (RTG) and native PAL modes using LAmiga-M / LAmiga-N, Amiberry crashes with `free(): invalid next size (normal)` in `SDL_DestroySurface` called from `doInit` (`gfx_window.cpp:1254`).

```
51-901 [104653 001-000/309]:
window already open (0x0 1952x1216)
free(): invalid next size (normal)

Thread 1 "amiberry" received signal SIGABRT, Aborted.
#0  __pthread_kill_implementation
#7  SDL_DestroySurface_REAL
#8  doInit at gfx_window.cpp:1254
#9  open_windows at gfx_window.cpp:324
#10 gfx_set_picasso_state at amiberry_gfx.cpp:1574
#11 check_prefs_picasso at drawing.cpp:2328
#12 device_check_config at devices.cpp:225
#13 vsync_handle_check at drawing.cpp:2391
```

Fixes #2266

## Root Cause

The crash is heap corruption detected when freeing the SDL surface's pixel buffer. The corruption occurs *before* `doInit` calls `SDL_DestroySurface` — something writes past the end of the surface's pixel buffer, overwriting adjacent heap chunk metadata.

The drawbuffer (`vidbuffer`) operates in `vram_buffer` mode, where `lockscr` stores direct references into the surface's pixel buffer:
```cpp
vb->bufmem = surface->pixels;
vb->rowbytes = surface->pitch;
vb->width_allocated = surface->w;
vb->height_allocated = surface->h;
```

When switching from RTG (e.g. 1920×1080) back to native PAL (e.g. 720×576), `doInit` destroys the old surface and creates a new, smaller one. However, the drawbuffer's `width_allocated`/`height_allocated`/`bufmem` fields still reflect the **old** surface dimensions. A subsequent `flush_clear_screen` or `unlockscr` dirty-rect calculation uses these stale dimensions against the new surface, causing a buffer overflow that corrupts heap metadata.

Similarly, `copyrow` in `picasso96.cpp` (used by the ZZ9000 driver's `fb_copyrow`) writes pixel data using `vidinfo->maxwidth`/`maxheight` bounds from `gfx_lock_picasso2`, but the RTG board's internal mode dimensions can be larger than the surface during mode transitions before the surface is recreated.

## Fix

This PR adds three defensive fixes:

1. **Reset drawbuffer state before `SDL_DestroySurface`** in both `doInit` and `close_windows` (`gfx_window.cpp`). Clear `bufmem`, `width_allocated`, `height_allocated`, `rowbytes`, and `locked` so no stale pointers or dimensions survive the surface reallocation.

2. **Clamp dirty_rect width in `unlockscr`** (`amiberry_gfx.cpp`). Previously only the dirty-rect height was clamped to `surface->h`; the width was left as `vb->width_allocated` which could be larger than `surface->w` after a surface recreation. The unclamped width feeds `SDL_UpdateTexture` / `glTexSubImage2D`, causing reads past the pixel buffer.

3. **Add bounds checking in `copyrow`** (`picasso96.cpp`). Clamp the write width to `vidinfo->maxwidth` and check `dy < vidinfo->maxheight` before writing. This prevents the ZZ9000 driver from writing past the destination buffer when its internal mode is larger than the host surface during mode switches.

## How to Verify

1. Add a ZZ9000 Z3 board to the configuration
2. Copy `ZZ9000.card` into `AROS:Libs/Picasso96/`
3. Boot AROS with a ZZ9000 mode on the Workbench
4. Run P96CTS PAL 320x200x8
5. While it runs, switch back and forth several times with LAmiga-M / LAmiga-N
6. Amiberry should no longer crash with `free(): invalid next size`

## Test Plan

- [x] Build succeeds (Windows x64, llvm-mingw + vcpkg)
- [ ] Manual verification of the fix with AROS + ZZ9000
- [ ] Verify OS3.x RTG switching still works (regression check)

## Risk Assessment

Low — the changes add defensive nulling and bounds clamping before deallocation and during pixel copies. They do not change the surface allocation strategy, the rendering pipeline, or any timing. The worst case if the fix is wrong is a blank frame during mode switch (safe), not a crash.