### PR TITLE
fix string/char type mismatches

### DIFF
--- a/src/calc.cpp
+++ b/src/calc.cpp
@@ -499,7 +499,7 @@ static bool execution_order(const TCHAR *input, double *outval, TCHAR *outstring
     int i;
 	bool ok = false;
 
-    vals[0] = 0;
+    vals[0] = _T('\0');
 	// While there are input tokens left
     while(strpos < strend)  {
 
@@ -593,7 +593,7 @@ static bool execution_order(const TCHAR *input, double *outval, TCHAR *outstring
 					*outval = val;
                 if (outstring) {
                     if (vals[0] && countof(vals) > maxlen && _tcslen(vals) >= maxlen) {
-                        vals[maxlen] = 0;
+                        vals[maxlen] = _T('\0');
                     }
                     _tcscpy(outstring, vals[0] ? vals : _T(""));
                 }

--- a/src/include/uae/string.h
+++ b/src/include/uae/string.h
@@ -123,7 +123,7 @@
 #define uaetcslen SDL_strlen
 #endif
 
-static size_t uae_tcslcpy(char *dst, const TCHAR *src, size_t size)
+static size_t uae_tcslcpy(TCHAR *dst, const TCHAR *src, size_t size)
 {
 	if (size == 0) {
 		return 0;


### PR DESCRIPTION
Fix string/char type mismatches that I noticed while working on my last fix. This should theoretically be zero functional change -- given that `TCHAR` and `char` must have been the same size for platforms and architectures Amiberry gets built for/on -- but it should clarify the code.

@midwan
