### PR TITLE
fix(gfx): keep autocrop stable across interlaced border changes

### DIFF
--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -30,20 +30,51 @@ struct AmiberryAutoCropPixelBuffer {
 	uint32_t rgb_mask;
 };
 
+// Interlaced fields only redraw every other scanline, so a change of the Amiga
+// border color leaves the previous generation of it woven into the rows of the
+// other field. Both colors are border for as long as that weave lasts.
+struct AmiberryAutoCropBorderColors {
+	uint32_t rgb[2];
+	int count;
+};
+
+static inline bool amiberry_auto_crop_border_matches(
+	const AmiberryAutoCropBorderColors& border, const uint32_t rgb)
+{
+	return (border.count > 0 && border.rgb[0] == rgb)
+		|| (border.count > 1 && border.rgb[1] == rgb);
+}
+
+static inline AmiberryAutoCropBorderColors amiberry_auto_crop_single_border(
+	const uint32_t rgb)
+{
+	return { { rgb, rgb }, 1 };
+}
+
 struct AmiberryAutoCropScanState {
 	std::vector<uint8_t> visited;
 	std::vector<int> pending;
 	std::vector<uint32_t> border_samples;
-	uint32_t border_rgb = 0;
-	bool border_valid = false;
+	std::vector<uint32_t> border_field_samples[2];
+	AmiberryAutoCropBorderColors border{};
+	// The last perimeter-detected border, kept so an interlaced scan can still
+	// recognize the generation the other field was drawn with.
+	AmiberryAutoCropBorderColors previous_border{};
 };
 
 static inline bool amiberry_auto_crop_border_state_changed(
-	const uint32_t previous_rgb, const bool previous_valid,
-	const uint32_t current_rgb, const bool current_valid)
+	const AmiberryAutoCropBorderColors& previous,
+	const AmiberryAutoCropBorderColors& current)
 {
-	return previous_valid != current_valid
-		|| (current_valid && previous_rgb != current_rgb);
+	if (previous.count != current.count) {
+		return true;
+	}
+	for (int i = 0; i < current.count; i++) {
+		if (previous.rgb[i] != current.rgb[i]) {
+			return true;
+		}
+	}
+	return false;
 }
 
 static inline int amiberry_auto_crop_rect_right(const AmiberryAutoCropRect& rect)
@@ -279,9 +310,46 @@ static inline void amiberry_auto_crop_get_outside_regions(
 	regions[3] = { 0, bottom, buffer.width, buffer.height - bottom };
 }
 
+// Woven is a template parameter so the far more common single-color border
+// keeps one comparison per pixel in this scan's hottest loop.
+template<bool Woven>
+static inline size_t amiberry_auto_crop_count_region_pixels(
+	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& region,
+	const uint32_t first_rgb, const uint32_t second_rgb)
+{
+	size_t visible_pixels = 0;
+	const int region_bottom = amiberry_auto_crop_rect_bottom(region);
+	const int region_right = amiberry_auto_crop_rect_right(region);
+	if (buffer.bytes_per_pixel == static_cast<int>(sizeof(uint32_t))) { // Vectorized SDL path.
+		for (int y = region.y; y < region_bottom; y++) {
+			const uint8_t* pixel = buffer.pixels + y * buffer.pitch
+				+ region.x * sizeof(uint32_t);
+			for (int x = 0; x < region.w; x++, pixel += sizeof(uint32_t)) {
+				uint32_t value;
+				std::memcpy(&value, pixel, sizeof(value));
+				value &= buffer.rgb_mask;
+				visible_pixels += Woven
+					? (value != first_rgb && value != second_rgb)
+					: (value != first_rgb);
+			}
+		}
+	} else {
+		for (int y = region.y; y < region_bottom; y++) {
+			for (int x = region.x; x < region_right; x++) {
+				const uint32_t value = amiberry_auto_crop_read_pixel(buffer, x, y)
+					& buffer.rgb_mask;
+				visible_pixels += Woven
+					? (value != first_rgb && value != second_rgb)
+					: (value != first_rgb);
+			}
+		}
+	}
+	return visible_pixels;
+}
+
 static inline size_t amiberry_auto_crop_count_region_visible_pixels(
 	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& region,
-	const uint32_t border_rgb)
+	const AmiberryAutoCropBorderColors& border)
 {
 	if (!amiberry_auto_crop_buffer_valid(buffer)
 		|| region.x < 0 || region.y < 0 || region.w <= 0 || region.h <= 0
@@ -290,39 +358,25 @@ static inline size_t amiberry_auto_crop_count_region_visible_pixels(
 		return 0;
 	}
 
-	size_t visible_pixels = 0;
-	const int region_bottom = amiberry_auto_crop_rect_bottom(region);
-	if (buffer.bytes_per_pixel == static_cast<int>(sizeof(uint32_t))) { // Vectorized SDL path.
-		for (int y = region.y; y < region_bottom; y++) {
-			const uint8_t* pixel = buffer.pixels + y * buffer.pitch
-				+ region.x * sizeof(uint32_t);
-			for (int x = 0; x < region.w; x++, pixel += sizeof(uint32_t)) {
-				uint32_t value;
-				std::memcpy(&value, pixel, sizeof(value));
-				visible_pixels += (value & buffer.rgb_mask) != border_rgb;
-			}
-		}
-	} else {
-		for (int y = region.y; y < region_bottom; y++) {
-			for (int x = region.x; x < amiberry_auto_crop_rect_right(region); x++) {
-				visible_pixels += (amiberry_auto_crop_read_pixel(buffer, x, y)
-					& buffer.rgb_mask) != border_rgb;
-			}
-		}
-	}
-	return visible_pixels;
+	// No border color at all still leaves every pixel visible.
+	const uint32_t first_rgb = border.count > 0 ? border.rgb[0] : ~0u;
+	return border.count > 1
+		? amiberry_auto_crop_count_region_pixels<true>(
+			buffer, region, first_rgb, border.rgb[1])
+		: amiberry_auto_crop_count_region_pixels<false>(
+			buffer, region, first_rgb, first_rgb);
 }
 
 static inline size_t amiberry_auto_crop_count_visible_pixels(
 	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& crop,
-	const uint32_t border_rgb)
+	const AmiberryAutoCropBorderColors& border)
 {
 	AmiberryAutoCropRect regions[4];
 	amiberry_auto_crop_get_outside_regions(buffer, crop, regions);
 	size_t visible_pixels = 0;
 	for (const auto& region : regions) {
 		visible_pixels += amiberry_auto_crop_count_region_visible_pixels(
-			buffer, region, border_rgb);
+			buffer, region, border);
 	}
 	return visible_pixels;
 }
@@ -330,7 +384,7 @@ static inline size_t amiberry_auto_crop_count_visible_pixels(
 static inline bool amiberry_auto_crop_stabilize_vertical_transition(
 	const AmiberryAutoCropPixelBuffer& buffer, const int min_visible_pixels,
 	const AmiberryAutoCropRect& previous, AmiberryAutoCropRect& current,
-	const uint32_t border_rgb, const int tolerance)
+	const AmiberryAutoCropBorderColors& border, const int tolerance)
 {
 	if (!amiberry_auto_crop_buffer_valid(buffer)
 		|| tolerance < 0
@@ -362,7 +416,7 @@ static inline bool amiberry_auto_crop_stabilize_vertical_transition(
 		const size_t required = std::min(area,
 			static_cast<size_t>(std::max(1, min_visible_pixels)));
 		return amiberry_auto_crop_count_region_visible_pixels(
-			buffer, strip, border_rgb) < required;
+			buffer, strip, border) < required;
 	};
 
 	if (bottom_growth > 0) {
@@ -444,31 +498,62 @@ static inline bool amiberry_auto_crop_detect_surface_background_color(
 static inline bool amiberry_auto_crop_detect_border_color(
 	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& crop,
 	const uint32_t background_rgb, const bool background_valid,
-	AmiberryAutoCropScanState& state)
+	const bool interlaced, AmiberryAutoCropScanState& state)
 {
-	state.border_samples.clear();
-	state.border_valid = false;
+	state.border = {};
 	const int right = amiberry_auto_crop_rect_right(crop);
 	const int bottom = amiberry_auto_crop_rect_bottom(crop);
 	const int horizontal_step = std::max(1, crop.w / 64);
-	const int vertical_step = std::max(1, crop.h / 64);
-	uint32_t side_rgb[4];
+	// An odd step keeps a sampled column crossing both interlaced fields, so a
+	// woven border cannot hide one of its two colors from the vote below.
+	const int vertical_step = std::max(1, crop.h / 64) | 1;
+	// A side that weaves two fields contributes both of their colors.
+	uint32_t side_rgb[8];
+	uint32_t woven_rgb[8];
 	int sampled_sides = 0;
 	int side_color_count = 0;
 	const auto sample_side = [&](const int x, const int y, const int dx, const int dy,
 		const int length, const int step) {
+		state.border_samples.clear();
+		state.border_field_samples[0].clear();
+		state.border_field_samples[1].clear();
 		for (int offset = 0; offset < length; offset += step) {
-			state.border_samples.push_back(amiberry_auto_crop_read_pixel(
-				buffer, x + dx * offset, y + dy * offset) & buffer.rgb_mask);
+			const int sample_y = y + dy * offset;
+			const uint32_t rgb = amiberry_auto_crop_read_pixel(
+				buffer, x + dx * offset, sample_y) & buffer.rgb_mask;
+			state.border_samples.push_back(rgb);
+			state.border_field_samples[sample_y & 1].push_back(rgb);
 		}
 		uint32_t dominant_rgb;
 		sampled_sides++;
 		const size_t dominant_count = amiberry_auto_crop_find_dominant_color(
 			state.border_samples.data(), state.border_samples.size(), dominant_rgb);
 		if (dominant_count * 4 >= state.border_samples.size() * 3) {
+			woven_rgb[side_color_count] = dominant_rgb;
 			side_rgb[side_color_count++] = dominant_rgb;
+			return;
 		}
-		state.border_samples.clear();
+		if (!interlaced) {
+			return;
+		}
+		// Only a strict scanline alternation is an interlaced border weave.
+		// Content hugging the crop covers a run of lines, not every other one.
+		uint32_t field_rgb[2];
+		for (int field = 0; field < 2; field++) {
+			const std::vector<uint32_t>& samples = state.border_field_samples[field];
+			const size_t count = amiberry_auto_crop_find_dominant_color(
+				samples.data(), samples.size(), field_rgb[field]);
+			if (count == 0 || count * 4 < samples.size() * 3) {
+				return;
+			}
+		}
+		if (field_rgb[0] == field_rgb[1]) {
+			return;
+		}
+		for (int field = 0; field < 2; field++) {
+			woven_rgb[side_color_count] = field_rgb[!field];
+			side_rgb[side_color_count++] = field_rgb[field];
+		}
 	};
 
 	if (crop.y > 0) {
@@ -485,19 +570,44 @@ static inline bool amiberry_auto_crop_detect_border_color(
 	}
 
 	if (sampled_sides >= 2) {
-		uint32_t most_common;
-		const size_t most_common_sides = amiberry_auto_crop_find_dominant_color(
-			side_rgb, side_color_count, most_common);
-		// Give each side one vote and require 75% confidence before hiding it.
-		if (most_common_sides * 4 >= static_cast<size_t>(sampled_sides) * 3) {
-			state.border_rgb = most_common;
-			state.border_valid = true;
+		// Give each side one vote per color it contributes and require 75%
+		// confidence before hiding it.
+		for (int i = 0; i < side_color_count && state.border.count < 2; i++) {
+			const uint32_t candidate = side_rgb[i];
+			if (amiberry_auto_crop_border_matches(state.border, candidate)) {
+				continue;
+			}
+			size_t votes = 0;
+			for (int j = 0; j < side_color_count; j++) {
+				votes += side_rgb[j] == candidate;
+			}
+			if (votes * 4 >= static_cast<size_t>(sampled_sides) * 3) {
+				state.border.rgb[state.border.count++] = candidate;
+			}
+		}
+		// A confirmed border color carries its weave partner: the other field
+		// still shows the generation it was drawn with.
+		for (int i = 0; i < side_color_count && state.border.count == 1; i++) {
+			if (woven_rgb[i] != side_rgb[i]
+				&& amiberry_auto_crop_border_matches(state.border, side_rgb[i])) {
+				state.border.rgb[state.border.count++] = woven_rgb[i];
+			}
+		}
+		if (state.border.count > 0) {
+			// Keep the pair ordered so a field flip is not a border change.
+			if (state.border.count > 1 && state.border.rgb[1] < state.border.rgb[0]) {
+				std::swap(state.border.rgb[0], state.border.rgb[1]);
+			}
+			state.previous_border = state.border;
 			return true;
 		}
 	}
 	// One or ambiguous sides may be content; fall back to the cleared surface.
-	state.border_rgb = background_rgb;
-	state.border_valid = background_valid;
+	// Nothing was learned about the border, so no generation is worth carrying.
+	state.previous_border = {};
+	if (background_valid) {
+		state.border = amiberry_auto_crop_single_border(background_rgb);
+	}
 	return background_valid;
 }
 
@@ -505,7 +615,7 @@ template<bool MatchColor>
 static inline size_t amiberry_auto_crop_flood_region(
 	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& crop,
 	const int start_x, const int start_y, AmiberryAutoCropScanState& state,
-	const uint32_t rgb, AmiberryAutoCropRect* bounds)
+	const AmiberryAutoCropBorderColors& colors, AmiberryAutoCropRect* bounds)
 {
 	if (amiberry_auto_crop_rect_contains(crop, start_x, start_y)) {
 		return 0;
@@ -516,8 +626,8 @@ static inline size_t amiberry_auto_crop_flood_region(
 	}
 	const auto pixel_matches = [&](const int x, const int y) {
 		const int index = y * buffer.width + x;
-		const bool matches = ((amiberry_auto_crop_read_pixel(
-			buffer, x, y) & buffer.rgb_mask) == rgb) == MatchColor;
+		const bool matches = amiberry_auto_crop_border_matches(colors,
+			amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask) == MatchColor;
 		if (!matches) {
 			if constexpr (!MatchColor) {
 				state.visited[index] = 1;
@@ -615,9 +725,11 @@ static inline size_t amiberry_auto_crop_exclude_surface_background(
 	// Exclude only edge-connected regions of the cleared surface color so
 	// enclosed pixels of the same color can still be real Amiga content.
 	size_t excluded_pixels = 0;
+	const AmiberryAutoCropBorderColors background =
+		amiberry_auto_crop_single_border(background_rgb);
 	const auto exclude_from = [&](const int x, const int y) {
 		excluded_pixels += amiberry_auto_crop_flood_region<true>(
-			buffer, crop, x, y, state, background_rgb, nullptr);
+			buffer, crop, x, y, state, background, nullptr);
 	};
 
 	for (int x = 0; x < buffer.width; x++) {
@@ -633,9 +745,11 @@ static inline size_t amiberry_auto_crop_exclude_surface_background(
 
 static inline bool amiberry_auto_crop_expand_to_visible_content(
 	const AmiberryAutoCropPixelBuffer& buffer, const int min_outside_pixels,
-	AmiberryAutoCropRect& crop, AmiberryAutoCropScanState& state)
+	const bool interlaced, AmiberryAutoCropRect& crop,
+	AmiberryAutoCropScanState& state)
 {
-	state.border_valid = false;
+	const AmiberryAutoCropBorderColors carried_border = state.previous_border;
+	state.border = {};
 	if (!amiberry_auto_crop_buffer_valid(buffer)
 		|| crop.w <= 0 || crop.h <= 0
 		|| crop.x < 0 || crop.y < 0
@@ -648,14 +762,22 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 	const bool background_valid = amiberry_auto_crop_detect_surface_background_color(
 		buffer, crop, background_rgb);
 	if (!amiberry_auto_crop_detect_border_color(
-		buffer, crop, background_rgb, background_valid, state)) {
+		buffer, crop, background_rgb, background_valid, interlaced, state)) {
 		return false;
 	}
-	const uint32_t border_rgb = state.border_rgb;
+	// The perimeter can be settled while the overscan further out still holds
+	// the border of the field before it. Interlace only ever weaves those two
+	// generations, so carrying the previous one covers what sampling cannot see.
+	for (int i = 0; interlaced && i < carried_border.count && state.border.count < 2; i++) {
+		if (!amiberry_auto_crop_border_matches(state.border, carried_border.rgb[i])) {
+			state.border.rgb[state.border.count++] = carried_border.rgb[i];
+		}
+	}
+	const AmiberryAutoCropBorderColors border = state.border;
 	const size_t required_pixels = static_cast<size_t>(std::max(1, min_outside_pixels));
 	// Count first so border-only frames bypass flood-fill and scratch-buffer clearing.
 	const size_t visible_pixels = amiberry_auto_crop_count_visible_pixels(
-		buffer, crop, border_rgb);
+		buffer, crop, border);
 	if (visible_pixels < required_pixels) {
 		return false;
 	}
@@ -663,7 +785,7 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 	state.visited.assign(pixel_count, 0);
 	state.pending.clear();
 	size_t excluded_pixels = 0;
-	if (background_valid && background_rgb != border_rgb) {
+	if (background_valid && !amiberry_auto_crop_border_matches(border, background_rgb)) {
 		excluded_pixels = amiberry_auto_crop_exclude_surface_background(
 			buffer, crop, background_rgb, state);
 	}
@@ -682,14 +804,14 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 				if (state.visited[start_index]) {
 					continue;
 				}
-				if ((amiberry_auto_crop_read_pixel(buffer, x, y)
-					& buffer.rgb_mask) == border_rgb) {
+				if (amiberry_auto_crop_border_matches(border,
+					amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
 					state.visited[start_index] = 1;
 					continue;
 				}
 				AmiberryAutoCropRect component;
 				const size_t component_pixels = amiberry_auto_crop_flood_region<false>(
-					buffer, crop, x, y, state, border_rgb, &component);
+					buffer, crop, x, y, state, border, &component);
 				if (component_pixels < required_pixels) {
 					continue;
 				}

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -138,8 +138,7 @@ struct AutoCropVisibleState {
 	SDL_Rect visible_rect{};
 	int hres = 0;
 	int vres = 0;
-	uint32_t border_rgb = 0;
-	bool border_valid = false;
+	AmiberryAutoCropBorderColors border{};
 	bool source_left_is_sprite = false;
 	bool source_right_is_sprite = false;
 	AmiberryAutoCropHorizontalEvidence sprite_zero{};
@@ -253,7 +252,7 @@ static bool get_auto_crop_pixel_buffer(const SDL_Surface* surface,
 }
 
 static void expand_auto_crop_rect_to_visible_content(const SDL_Surface* surface,
-	SDL_Rect& rect, AmiberryAutoCropScanState& scan_state)
+	SDL_Rect& rect, const bool interlaced, AmiberryAutoCropScanState& scan_state)
 {
 	clamp_auto_crop_rect(surface, rect);
 	if (rect.w <= 0 || rect.h <= 0) {
@@ -266,14 +265,14 @@ static void expand_auto_crop_rect_to_visible_content(const SDL_Surface* surface,
 	}
 	AmiberryAutoCropRect visible_rect = { rect.x, rect.y, rect.w, rect.h };
 	if (amiberry_auto_crop_expand_to_visible_content(buffer,
-		auto_crop_min_outside_pixels, visible_rect, scan_state)) {
+		auto_crop_min_outside_pixels, interlaced, visible_rect, scan_state)) {
 		rect = { visible_rect.x, visible_rect.y, visible_rect.w, visible_rect.h };
 	}
 }
 
 static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 	const SDL_Rect& source_rect, SDL_Rect& visible_rect, const int hres,
-	const int vres, const uint32_t border_rgb, const bool border_valid,
+	const int vres, const AmiberryAutoCropBorderColors& border,
 	const bool source_left_is_sprite, const bool source_right_is_sprite,
 	const AmiberryAutoCropHorizontalEvidence& sprite_zero,
 	AutoCropVisibleState& state, const bool reset)
@@ -291,7 +290,7 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 		|| state.hres != hres
 		|| state.vres != vres;
 	const bool border_changed = amiberry_auto_crop_border_state_changed(
-		state.border_rgb, state.border_valid, border_rgb, border_valid);
+		state.border, border);
 	if (!reset && state.valid && !presentation_changed && !border_changed) {
 		const AmiberryAutoCropRect previous_source = {
 			state.source_rect.x, state.source_rect.y,
@@ -320,10 +319,10 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 			return;
 		}
 		if (auto_crop_rect_equals(state.source_rect, source_rect)
-			&& border_valid && get_auto_crop_pixel_buffer(surface, buffer)
+			&& border.count > 0 && get_auto_crop_pixel_buffer(surface, buffer)
 			&& amiberry_auto_crop_stabilize_vertical_transition(
 				buffer, auto_crop_min_outside_pixels, previous_rect, current_rect,
-				border_rgb, vertical_tolerance)) {
+				border, vertical_tolerance)) {
 			visible_rect = { current_rect.x, current_rect.y,
 				current_rect.w, current_rect.h };
 			state.visible_rect = visible_rect;
@@ -359,8 +358,7 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 		state.visible_rect = visible_rect;
 		state.hres = hres;
 		state.vres = vres;
-		state.border_rgb = border_rgb;
-		state.border_valid = border_valid;
+		state.border = border;
 		state.source_left_is_sprite = source_left_is_sprite;
 		state.source_right_is_sprite = source_right_is_sprite;
 		state.sprite_zero = sprite_zero;
@@ -377,9 +375,8 @@ static void preserve_auto_crop_visible_content(const SDL_Surface* surface,
 	state.source_left_is_sprite = source_left_is_sprite;
 	state.source_right_is_sprite = source_right_is_sprite;
 	state.sprite_zero = sprite_zero;
-	if (border_valid) {
-		state.border_rgb = border_rgb;
-		state.border_valid = true;
+	if (border.count > 0) {
+		state.border = border;
 	}
 }
 
@@ -2276,9 +2273,12 @@ void auto_crop_image()
 			// DIW/bitplane limits can exclude visible sprites or raster content.
 			// Preserve real pixels outside those limits without restoring the
 			// conservative minimum frame that keeps intentional black borders.
-			expand_auto_crop_rect_to_visible_content(surface, crop_rect, scan_state);
+			// Only a line-doubled interlaced buffer weaves two fields together.
+			const bool interlaced = interlace_seen > 0 && vres > VRES_NONDOUBLE;
+			expand_auto_crop_rect_to_visible_content(surface, crop_rect, interlaced,
+				scan_state);
 			preserve_auto_crop_visible_content(surface, source_crop_rect, crop_rect,
-				hres, vres, scan_state.border_rgb, scan_state.border_valid,
+				hres, vres, scan_state.border,
 				(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_LEFT) != 0,
 				(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_RIGHT) != 0, sprite_zero,
 				visible_state,

--- a/tests/autocrop_benchmark.cpp
+++ b/tests/autocrop_benchmark.cpp
@@ -73,7 +73,7 @@ static AmiberryAutoCropRect scan_frame(AutoCropScenario& scenario)
 {
 	AmiberryAutoCropRect crop = scenario.source;
 	amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(scenario), 16, crop, scenario.state);
+		make_buffer(scenario), 16, false, crop, scenario.state);
 	return crop;
 }
 
@@ -111,7 +111,8 @@ static bool reference_outputs_match()
 	const AmiberryAutoCropRect previous{ 40, 17, 640, 200 };
 	AmiberryAutoCropRect current{ 40, 17, 640, 207 };
 	if (!amiberry_auto_crop_stabilize_vertical_transition(
-		make_buffer(transition), 16, previous, current, 0, 8)
+		make_buffer(transition), 16, previous, current,
+		amiberry_auto_crop_single_border(0), 8)
 		|| !rect_equals(current, { 40, 24, 640, 200 })) {
 		return false;
 	}

--- a/tests/autocrop_helpers_test.cpp
+++ b/tests/autocrop_helpers_test.cpp
@@ -65,7 +65,7 @@ static void test_expands_to_connected_visible_content()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 6, 8, 20, 12 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(changed, "Crop should expand to connected content below it");
 	expect_eq(crop.x, 6, "Crop x should stay anchored");
@@ -85,7 +85,7 @@ static void test_ignores_distant_speck_when_content_expands()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 6, 8, 20, 12 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(changed, "Connected lower content should still expand the crop");
 	expect_eq(crop.x, 6, "A distant speck must not move the crop left edge");
@@ -106,7 +106,7 @@ static void test_ignores_scattered_outside_pixels()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 6, 8, 20, 12 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(!changed, "Scattered outside pixels must not expand the crop");
 	expect_eq(crop.w, 20, "Scattered pixels must not change crop width");
@@ -125,7 +125,7 @@ static void test_preserves_diagonally_connected_content()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 20, 8, 10, 12 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(changed,
 		"Eight-neighbor scanning must keep diagonal content in one component");
@@ -152,7 +152,7 @@ static void test_crop_separates_outside_components()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 15, 10, 10, 10 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(!changed,
 		"The crop must not connect two individually sub-threshold components");
@@ -173,7 +173,7 @@ static void test_expands_to_visible_sprite_edge_content()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 8, 8, 20, 20 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(changed, "A visible sprite strip outside DIW should expand the crop");
 	expect_eq(crop.x, 6, "The crop should include the sprite's left edge");
@@ -191,11 +191,11 @@ static void test_keeps_crop_inside_non_black_border()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(!changed, "A non-black border must not expand the hardware crop");
-	expect_true(state.border_valid, "A consistent non-black border should be detected");
-	expect_eq(state.border_rgb, border_color, "Detected border color should match the perimeter");
+	expect_true(state.border.count > 0, "A consistent non-black border should be detected");
+	expect_eq(state.border.rgb[0], border_color, "Detected border color should match the perimeter");
 	expect_eq(crop.x, 8, "Outer black surface edge must not move the crop left");
 	expect_eq(crop.y, 8, "Outer black surface edge must not move the crop top");
 	expect_eq(crop.w, 24, "Outer black surface edge must not widen the crop");
@@ -212,12 +212,12 @@ static void test_uniform_border_avoids_component_scan()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(!changed, "A uniform border must not expand the crop");
 	expect_true(state.visited.empty(), "A uniform border should bypass component scanning");
-	expect_true(state.border_valid, "A uniform non-black border should be detected");
-	expect_eq(state.border_rgb, border_color, "Uniform border color should be preserved");
+	expect_true(state.border.count > 0, "A uniform non-black border should be detected");
+	expect_eq(state.border.rgb[0], border_color, "Uniform border color should be preserved");
 
 	std::vector<uint16_t> pixels_16(width * height, 0xaaaau);
 	const AmiberryAutoCropPixelBuffer buffer_16 {
@@ -226,7 +226,7 @@ static void test_uniform_border_avoids_component_scan()
 	};
 	state = {};
 	crop = { 8, 8, 24, 20 };
-	expect_true(!amiberry_auto_crop_expand_to_visible_content(buffer_16, 16, crop, state),
+	expect_true(!amiberry_auto_crop_expand_to_visible_content(buffer_16, 16, false, crop, state),
 		"A 16-bit uniform border must not expand the crop");
 	expect_true(state.visited.empty(), "A 16-bit uniform border should use the fast path");
 }
@@ -247,7 +247,7 @@ static void test_expands_past_non_black_border_for_real_content()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(changed, "Connected content should expand through a non-black border");
 	expect_eq(crop.x, 8, "Bottom-only content should keep the crop x origin");
@@ -272,7 +272,7 @@ static void test_preserves_content_reaching_surface_edge()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(changed, "Content reaching the surface edge should expand the crop");
 	expect_eq(crop.x, 8, "Edge-reaching bottom content should keep the crop x origin");
@@ -293,7 +293,7 @@ static void test_chooses_background_outside_origin_anchored_crop()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 0, 0, 24, 20 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(!changed, "An in-crop origin pixel must not become the surface background");
 	expect_eq(crop.x, 0, "Origin-anchored crop must keep its x origin");
@@ -315,11 +315,11 @@ static void test_one_sided_uniform_content_is_not_border()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 0, 0, width, 20 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(changed, "Uniform content on the only outside edge must remain visible");
-	expect_true(state.border_valid, "Outside corners should provide a fallback background");
-	expect_eq(state.border_rgb, 0u, "One-sided content must not become the border color");
+	expect_true(state.border.count > 0, "Outside corners should provide a fallback background");
+	expect_eq(state.border.rgb[0], 0u, "One-sided content must not become the border color");
 	expect_eq(crop.x, 0, "Full-width content must keep the crop x origin");
 	expect_eq(crop.y, 0, "Content below the crop must keep its y origin");
 	expect_eq(crop.w, width, "Full-width content must keep the crop width");
@@ -339,11 +339,11 @@ static void test_ambiguous_perimeter_preserves_content()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 4, 0, 32, 20 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(changed, "Content on an ambiguous perimeter must remain visible");
-	expect_true(state.border_valid, "Ambiguous perimeter should use surface background");
-	expect_eq(state.border_rgb, 0u, "Ambiguous content must not become the border color");
+	expect_true(state.border.count > 0, "Ambiguous perimeter should use surface background");
+	expect_eq(state.border.rgb[0], 0u, "Ambiguous content must not become the border color");
 	expect_eq(crop.x, 4, "Lower content must keep the crop x origin");
 	expect_eq(crop.y, 0, "Top-aligned crop must keep its y origin");
 	expect_eq(crop.w, 32, "Lower content must keep the crop width");
@@ -365,11 +365,11 @@ static void test_mixed_perimeter_keeps_non_black_border()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(changed, "Content on one side should expand a non-black border crop");
-	expect_true(state.border_valid, "Other sides should confirm the non-black border");
-	expect_eq(state.border_rgb, border_color,
+	expect_true(state.border.count > 0, "Other sides should confirm the non-black border");
+	expect_eq(state.border.rgb[0], border_color,
 		"One content side must not replace the non-black border color");
 	expect_eq(crop.x, 8, "Mixed perimeter content must keep the crop x origin");
 	expect_eq(crop.y, 8, "Mixed perimeter content must keep the crop y origin");
@@ -397,11 +397,11 @@ static void test_two_sided_color_is_not_perimeter_majority()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(changed, "A two-of-four side color must remain visible content");
-	expect_true(state.border_valid, "Split perimeter should use surface background");
-	expect_eq(state.border_rgb, 0u, "A perimeter plurality must not become border color");
+	expect_true(state.border.count > 0, "Split perimeter should use surface background");
+	expect_eq(state.border.rgb[0], 0u, "A perimeter plurality must not become border color");
 	expect_eq(crop.x, 7, "Visible left edge should expand the crop left");
 	expect_eq(crop.y, 7, "Visible top edge should expand the crop upward");
 	expect_eq(crop.w, 26, "Visible side edges should expand the crop width");
@@ -422,32 +422,140 @@ static void test_two_of_three_sides_is_not_border_confidence()
 	AmiberryAutoCropScanState state;
 	AmiberryAutoCropRect crop{ 0, 8, 24, 20 };
 	const bool changed = amiberry_auto_crop_expand_to_visible_content(
-		make_buffer(pixels, width, height), 16, crop, state);
+		make_buffer(pixels, width, height), 16, false, crop, state);
 
 	expect_true(changed, "A two-of-three side color must remain visible content");
-	expect_true(state.border_valid, "Low-confidence perimeter should use surface background");
-	expect_eq(state.border_rgb, 0u, "Two-of-three agreement must not become border color");
+	expect_true(state.border.count > 0, "Low-confidence perimeter should use surface background");
+	expect_eq(state.border.rgb[0], 0u, "Two-of-three agreement must not become border color");
 	expect_eq(crop.x, 0, "Left-aligned crop must keep its x origin");
 	expect_eq(crop.y, 7, "Visible top edge should expand the crop upward");
 	expect_eq(crop.w, 24, "Horizontal content must keep the crop width");
 	expect_eq(crop.h, 22, "Visible top and bottom edges should expand crop height");
 }
 
+static void test_interlaced_border_weave_is_not_content()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t previous_field = 0x00100810u;
+	constexpr uint32_t current_field = 0x00100c14u;
+	std::vector<uint32_t> pixels(width * height, 0);
+	// An interlaced display only redraws every other scanline per field, so a
+	// change of the Amiga border color leaves two generations of it woven into
+	// alternate rows. Both are border, not visible content.
+	for (int y = 2; y < height - 2; y++) {
+		for (int x = 2; x < width - 2; x++) {
+			pixels[y * width + x] = (y & 1) ? current_field : previous_field;
+		}
+	}
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, true, crop, state);
+
+	expect_true(!changed, "An interlaced border weave must not expand the crop");
+	expect_eq(state.border.count, 2, "Both woven generations must count as border");
+	expect_eq(crop.x, 8, "A woven border must keep the crop x origin");
+	expect_eq(crop.y, 8, "A woven border must keep the crop y origin");
+	expect_eq(crop.w, 24, "A woven border must keep the crop width");
+	expect_eq(crop.h, 20, "A woven border must keep the crop height");
+
+	AmiberryAutoCropScanState progressive;
+	AmiberryAutoCropRect progressive_crop{ 8, 8, 24, 20 };
+	expect_true(amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, false, progressive_crop, progressive),
+		"A progressive scan must still treat alternating rows as content");
+}
+
+static void test_settled_perimeter_carries_the_previous_field_border()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t previous_field = 0x00100810u;
+	constexpr uint32_t current_field = 0x00100c14u;
+	const AmiberryAutoCropRect crop{ 8, 12, 24, 20 };
+	// The rows next to the crop settle on the current border a field before the
+	// overscan further out does, so the weave is invisible to perimeter samples.
+	std::vector<uint32_t> pixels(width * height, 0);
+	for (int y = 2; y < height - 2; y++) {
+		for (int x = 2; x < width - 2; x++) {
+			pixels[y * width + x] = y >= crop.y - 4 && y < crop.y + crop.h + 4
+				? current_field
+				: ((y & 1) ? current_field : previous_field);
+		}
+	}
+
+	AmiberryAutoCropScanState state;
+	state.previous_border = amiberry_auto_crop_single_border(previous_field);
+	AmiberryAutoCropRect carried = crop;
+	expect_true(!amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, true, carried, state),
+		"The previous field's border must not expand an interlaced crop");
+	expect_eq(carried.y, crop.y, "A carried border must keep the crop y origin");
+	expect_eq(carried.h, crop.h, "A carried border must keep the crop height");
+
+	AmiberryAutoCropScanState unrelated;
+	unrelated.previous_border = amiberry_auto_crop_single_border(0x00ff0000u);
+	AmiberryAutoCropRect expanded = crop;
+	expect_true(amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, true, expanded, unrelated),
+		"An unrelated stale border must not hide the woven overscan");
+}
+
+static void test_edge_content_run_is_not_an_interlaced_border()
+{
+	constexpr int width = 40;
+	constexpr int height = 40;
+	constexpr uint32_t border_color = 0x00100810u;
+	constexpr uint32_t content_color = 0x0000ff00u;
+	std::vector<uint32_t> pixels(width * height, 0);
+	add_colored_border(pixels, width, height, border_color);
+	// Content hugging one edge covers a contiguous run of scanlines instead of
+	// alternating ones, so it must not be mistaken for the other field.
+	for (int y = 12; y < 24; y++) {
+		for (int x = 6; x < 8; x++) {
+			pixels[y * width + x] = content_color;
+		}
+	}
+
+	AmiberryAutoCropScanState state;
+	AmiberryAutoCropRect crop{ 8, 8, 24, 20 };
+	const bool changed = amiberry_auto_crop_expand_to_visible_content(
+		make_buffer(pixels, width, height), 16, false, crop, state);
+
+	expect_true(changed, "Contiguous edge content must still expand the crop");
+	expect_eq(crop.x, 6, "Visible left edge content should expand the crop left");
+	expect_eq(crop.y, 8, "Left edge content must keep the crop y origin");
+	expect_eq(crop.w, 26, "Visible left edge content should widen the crop");
+	expect_eq(crop.h, 20, "Left edge content must keep the crop height");
+}
+
 static void test_border_state_changes_reset_preserved_crop()
 {
 	constexpr uint32_t first_color = 0x00112233u;
 	constexpr uint32_t second_color = 0x00445566u;
+	const AmiberryAutoCropBorderColors none{};
+	const AmiberryAutoCropBorderColors first =
+		amiberry_auto_crop_single_border(first_color);
+	const AmiberryAutoCropBorderColors second =
+		amiberry_auto_crop_single_border(second_color);
+	const AmiberryAutoCropBorderColors woven{ { first_color, second_color }, 2 };
 
-	expect_true(amiberry_auto_crop_border_state_changed(first_color, true,
-		first_color, false), "Losing a valid border must reset preserved crop bounds");
-	expect_true(amiberry_auto_crop_border_state_changed(first_color, false,
-		first_color, true), "Detecting a valid border must reset preserved crop bounds");
-	expect_true(amiberry_auto_crop_border_state_changed(first_color, true,
-		second_color, true), "Changing border color must reset preserved crop bounds");
-	expect_true(!amiberry_auto_crop_border_state_changed(first_color, true,
-		first_color, true), "An unchanged valid border must preserve crop bounds");
-	expect_true(!amiberry_auto_crop_border_state_changed(first_color, false,
-		second_color, false), "Ambiguous border samples must ignore stale colors");
+	expect_true(amiberry_auto_crop_border_state_changed(first, none),
+		"Losing a valid border must reset preserved crop bounds");
+	expect_true(amiberry_auto_crop_border_state_changed(none, first),
+		"Detecting a valid border must reset preserved crop bounds");
+	expect_true(amiberry_auto_crop_border_state_changed(first, second),
+		"Changing border color must reset preserved crop bounds");
+	expect_true(amiberry_auto_crop_border_state_changed(first, woven),
+		"Gaining a woven second border color must reset preserved crop bounds");
+	expect_true(!amiberry_auto_crop_border_state_changed(first, first),
+		"An unchanged valid border must preserve crop bounds");
+	expect_true(!amiberry_auto_crop_border_state_changed(woven, woven),
+		"An unchanged woven border must preserve crop bounds");
+	expect_true(!amiberry_auto_crop_border_state_changed(none, none),
+		"Ambiguous border samples must ignore stale colors");
 }
 
 static void test_horizontal_edge_jitter_tolerance()
@@ -695,7 +803,7 @@ static void test_vertical_transition_replaces_displaced_border_without_resizing(
 
 	AmiberryAutoCropRect expanded{ 4, 4, 12, 10 };
 	expect_true(amiberry_auto_crop_stabilize_vertical_transition(
-		make_buffer(pixels, width, height), 16, previous, expanded, 0, 2),
+		make_buffer(pixels, width, height), 16, previous, expanded, amiberry_auto_crop_single_border(0), 2),
 		"New bottom content should replace a border strip without resizing");
 	expect_eq(expanded.y, 6,
 		"The stable crop should move down to follow the new content");
@@ -704,7 +812,7 @@ static void test_vertical_transition_replaces_displaced_border_without_resizing(
 
 	AmiberryAutoCropRect raw_union{ 4, 4, 12, 10 };
 	expect_true(amiberry_auto_crop_stabilize_vertical_transition(
-		make_buffer(pixels, width, height), 16, expanded, raw_union, 0, 2),
+		make_buffer(pixels, width, height), 16, expanded, raw_union, amiberry_auto_crop_single_border(0), 2),
 		"A repeated raw union should ignore the revealed border above the stable crop");
 	expect_eq(raw_union.y, 6,
 		"Repeated scan frames should retain the translated origin");
@@ -726,7 +834,7 @@ static void test_vertical_transition_keeps_genuine_two_edge_content()
 	}
 
 	expect_true(!amiberry_auto_crop_stabilize_vertical_transition(
-		make_buffer(pixels, width, height), 16, previous, expanded, 0, 2),
+		make_buffer(pixels, width, height), 16, previous, expanded, amiberry_auto_crop_single_border(0), 2),
 		"Visible pixels at both old and new edges must allow a real crop expansion");
 	expect_eq(expanded.y, 4,
 		"A genuine expansion should retain its original top edge");
@@ -777,6 +885,9 @@ int main()
 	test_mixed_perimeter_keeps_non_black_border();
 	test_two_sided_color_is_not_perimeter_majority();
 	test_two_of_three_sides_is_not_border_confidence();
+	test_interlaced_border_weave_is_not_content();
+	test_settled_perimeter_carries_the_previous_field_border();
+	test_edge_content_run_is_not_an_interlaced_border();
 	test_border_state_changes_reset_preserved_crop();
 	test_horizontal_edge_jitter_tolerance();
 	test_horizontal_edge_jitter_requires_sprite_source_attribution();


### PR DESCRIPTION
Fixes #2269

## Problem

AutoCrop classifies everything outside the hardware (DIW/bitplane) crop against a **single** border colour, detected by sampling one-pixel-wide lines just outside that crop (top/bottom rows, left/right columns) and requiring 75% of the sides to agree.

An interlaced, line-doubled buffer only redraws every other scanline per field, so every change of the Amiga border colour leaves **two generations of it woven onto alternate rows**. That breaks the scan in two separate ways:

1. **Woven perimeter** — each sampled row sees one field while the sampled columns see an even mix of both, so no colour reaches the side vote. Detection falls back to the cleared surface colour (black) and the entire Amiga border is counted as visible content.
2. **Settled perimeter, woven overscan** — the rows next to the crop can settle on the current colour while the overscan further out still weaves. All four sides agree, yet dozens of full-width single-row components on alternate lines still expand the crop.

Either way the crop jumps to nearly the whole surface for a frame. Anything that shifts colour 0 while interlaced does this repeatedly — an NTSC interlaced animation in ViewTek triggers it every few fields, and it is also what makes the unfolding base image in Alien Breed II (#2269) re-layout continuously.

## Fix

Model the border as a **set of up to two colours** instead of one:

* A side whose samples split *strictly by scanline parity* into two uniform colours contributes both. Content hugging the crop covers a contiguous run of lines rather than every other one, so it is not mistaken for a weave.
* A colour confirmed by the side vote carries its weave partner.
* The previous field's perimeter colour is carried forward, so a settled perimeter still covers a woven overscan.
* Columns are sampled with an odd vertical step so they always cross both fields.

All of it is gated on an interlaced line-doubled buffer (`interlace_seen > 0 && vres > VRES_NONDOUBLE`), so progressive displays keep their previous behaviour exactly.

## Testing

* New helper tests: a woven border must not expand the crop, contiguous edge content still must, and a carried border must not hide unrelated overscan content.
* `tests/test_autocrop_helpers.sh`, `tests/test_libretro_crop_policy.sh` and `tests/test_gfx_geometry.sh` all pass.
* `tests/autocrop_benchmark.cpp` reference checksum unchanged; timings are back at baseline (`autocrop_ns_per_frame` 290,625 vs 300,601 ns, i.e. ~291 µs vs ~301 µs per frame) after templating the counting loop so the single-colour path keeps one comparison per pixel.
* Real runs against a 720x360 NTSC interlaced animation: before, the crop oscillated between `736x366+2+56` and `752x483+0+2` continuously; after, it settles at `736x366+2+56` within the first 0.15 s and does not change again across ~10,600 emulated fields.
* Alien Breed II (#2269) verified by hand.
* Desktop (CMake, Windows) and libretro core builds are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
