### PR TITLE
fix(android): keep captured mouse absolute so physical mouse moves

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -79,6 +79,7 @@
 #include "gui_handling_platform.h"
 #include "gui/gui_handling.h"
 #include "on_screen_joystick.h"
+#include "amiberry_mouse_capture.h"
 #include "imgui_osk.h"
 #ifdef __ANDROID__
 #include "android_touch_mouse.h"
@@ -1618,8 +1619,14 @@ static bool apply_mouse_capture_grabs(AmigaMonitor* mon)
 	// SDL hides the cursor when Relative mode is enabled.
 	// This means that the RTG hardware sprite will no longer be shown,
 	// unless it's configured to use Virtual Mouse (absolute movement).
+	constexpr bool capture_platform_is_android =
+#ifdef __ANDROID__
+		true;
+#else
+		false;
+#endif
 	bool relative_ok = true;
-	if (!currprefs.input_tablet) {
+	if (amiberry_capture_uses_relative_mouse_mode(capture_platform_is_android, currprefs.input_tablet)) {
 		relative_ok = SDL_SetWindowRelativeMouseMode(mon->amiga_window, true);
 		if (!relative_ok) {
 			write_log("SDL_SetWindowRelativeMouseMode(true) failed on monitor %d: %s\n",

--- a/src/osdep/amiberry_mouse_capture.h
+++ b/src/osdep/amiberry_mouse_capture.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// Decides whether mouse capture should put the SDL window into relative mouse
+// mode.
+//
+// Desktop platforms want it: capture there means "confine the pointer and
+// deliver unbounded relative motion", which SDL honors end to end.
+//
+// Android must not request it. Android delivers physical-mouse motion as
+// absolute hover events (ACTION_HOVER_MOVE), and SDL silently drops absolute
+// motion while a window is flagged for relative mode (SDL_PrivateSendMouseMotion
+// in SDL 3.4.x). Pointer capture, SDL's relative-mode backend there, is not
+// guaranteed to engage (API 24-25 has none; API 26+ can deny or lose it on
+// DeX, ChromeOS, TV boxes and focus transitions). Requesting relative mode
+// therefore leaves a physical mouse with working buttons and a frozen emulated
+// pointer. Keeping the window absolute lets SDL compute xrel/yrel deltas from
+// the hover position, which handle_mouse_motion_event() feeds to the emulated
+// mouse. Touch gestures are unaffected either way: they bypass SDL mouse
+// events through the android_touch_mouse recognizer.
+//
+// input_tablet carries the uae_prefs tablet-mode value (TABLET_OFF == 0,
+// TABLET_MOUSEHACK, TABLET_REAL). Any tablet/mousehack mode keeps the window
+// absolute because it needs pointer coordinates.
+inline bool amiberry_capture_uses_relative_mouse_mode(const bool platform_is_android,
+	const int input_tablet)
+{
+	if (input_tablet != 0)
+		return false;
+	return !platform_is_android;
+}

--- a/tests/mouse_capture_mode_test.cpp
+++ b/tests/mouse_capture_mode_test.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+
+#include "amiberry_mouse_capture.h"
+
+// Mirror of the uae_prefs tablet-mode values (src/include/options.h); kept
+// local so this test compiles standalone like the other osdep unit tests.
+constexpr int k_tablet_off = 0;
+constexpr int k_tablet_mousehack = 1;
+constexpr int k_tablet_real = 2;
+
+static int failures;
+
+static void expect_eq(const bool actual, const bool expected, const char* message)
+{
+	if (actual != expected) {
+		std::cerr << message << ": expected " << expected << ", got " << actual << '\n';
+		failures++;
+	}
+}
+
+int main()
+{
+	// Regression: Android must never request relative mouse mode while the
+	// mouse is captured. Android delivers physical-mouse motion as absolute
+	// hover events, and SDL drops absolute motion while a window is in
+	// relative mode, leaving the buttons working but the emulated pointer
+	// frozen. Touch gestures are unaffected either way: they bypass SDL mouse
+	// events through the android_touch_mouse recognizer.
+	expect_eq(amiberry_capture_uses_relative_mouse_mode(true, k_tablet_off), false,
+		"Android capture must keep the window in absolute mode");
+	expect_eq(amiberry_capture_uses_relative_mouse_mode(true, k_tablet_mousehack), false,
+		"Android capture must stay absolute with mousehack mode");
+	expect_eq(amiberry_capture_uses_relative_mouse_mode(true, k_tablet_real), false,
+		"Android capture must stay absolute with real-tablet mode");
+
+	// Desktop platforms honor the captured-relative contract (all motion
+	// events arrive relative), so capture keeps requesting relative mode.
+	expect_eq(amiberry_capture_uses_relative_mouse_mode(false, k_tablet_off), true,
+		"Desktop capture without tablet mode must request relative mode");
+	expect_eq(amiberry_capture_uses_relative_mouse_mode(false, k_tablet_mousehack), false,
+		"Mousehack mode must keep the window absolute on desktop");
+	expect_eq(amiberry_capture_uses_relative_mouse_mode(false, k_tablet_real), false,
+		"Real-tablet mode must keep the window absolute on desktop");
+
+	return failures == 0 ? 0 : 1;
+}

--- a/tests/test_mouse_capture_mode.sh
+++ b/tests/test_mouse_capture_mode.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cxx="${CXX:-c++}"
+out="${TMPDIR:-/tmp}/mouse_capture_mode_test.$$"
+trap 'rm -f "$out"' EXIT
+
+"$cxx" -std=c++17 -Wall -Wextra -Werror \
+	-Isrc/osdep \
+	-o "$out" \
+	tests/mouse_capture_mode_test.cpp
+"$out"


### PR DESCRIPTION
A connected physical mouse on Android could click (left/right buttons worked) but could not move the emulated pointer. Mouse capture no longer puts the SDL window into relative mode on Android, so physical-mouse motion reaches the emulator again.

Changes proposed in this pull request:
- Skip the `SDL_SetWindowRelativeMouseMode(true)` request when capturing on Android (`apply_mouse_capture_grabs`); SDL computes `xrel/yrel` deltas from the absolute hover position, which `handle_mouse_motion_event()` already feeds to the emulated mouse.
- Extract the capture/relative-mode decision into `amiberry_mouse_capture.h` so the platform contract is explicit and unit-testable.
- Add `tests/mouse_capture_mode_test.cpp` (runner: `tests/test_mouse_capture_mode.sh`): Android never requests relative mode, desktop keeps requesting it when no tablet mode is active, and tablet modes stay absolute everywhere.

Why: Android delivers physical-mouse motion as absolute hover events, and SDL 3.4 silently discards absolute motion while a window is flagged for relative mode. The relative-mode request that capture made froze motion on arrival, while button events (which SDL does not filter) kept working. Touch trackpad gestures are untouched — they never use SDL mouse events (android_touch_mouse recognizer).

Trade-off: without pointer capture, deltas pause while the host cursor sits pinned at a screen edge (normal Android behavior for non-captured apps). Before, motion was dead for good on any device where pointer capture does not engage (API 24-25, DeX, ChromeOS, TV boxes).

Validation: `src/osdep/amiberry.cpp` compiles for the Android arm64-v8a target with the app's NDK toolchain; `tests/test_mouse_capture_mode.sh`, `test_android_touch_mouse.sh`, `test_fullscreen_mode.sh`, `test_on_screen_joystick_capture.sh`, and `test_input_hotplug.sh` pass. On-device verification with a physical mouse is still needed
