### PR TITLE
feat(gfx): detect GL capabilities at runtime with graceful fallback

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -43,6 +43,17 @@ if (USE_OPENGL)
         else()
             find_package(OpenGL REQUIRED)
             target_link_libraries(${PROJECT_NAME} PRIVATE OpenGL::GL)
+            if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+                # ES fallback tier (context ladder modes 4/5 in gfx_window.cpp):
+                # last-resort GLES 3.0 context for hosts whose only hardware
+                # driver is GLES. No extra link-time dependency — SDL loads
+                # libGLESv2 via EGL and glvnd dispatches our direct GL entry
+                # calls to the current context. Linux/FreeBSD only: Windows/
+                # macOS have no GLES driver story (ANGLE breaks opengl32
+                # stub dispatch).
+                target_compile_definitions(${PROJECT_NAME} PRIVATE AMIBERRY_GLES_FALLBACK)
+                message(STATUS "OpenGL ES fallback tier enabled (GLES 3.0 context retry on desktop GL failure)")
+            endif()
         endif()
     else()
         target_link_libraries(${PROJECT_NAME} PRIVATE GLESv3 EGL)

--- a/cmake/SourceFiles.cmake
+++ b/cmake/SourceFiles.cmake
@@ -247,6 +247,8 @@ set(SOURCE_FILES
         src/osdep/gl_platform.cpp
         src/osdep/external_shader.cpp
         src/osdep/shader_preset.cpp
+        src/osdep/gl_capability_classify.cpp
+        src/osdep/crt_gpu_allowlist.cpp
         src/osdep/amiberry_gui.cpp
         src/osdep/amiberry_mem.cpp
         src/osdep/amiberry_serial.cpp

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -585,6 +585,7 @@ void apply_auto_crop_policy(const SDL_Surface* surface, SDL_Rect& rect,
 
 static int dx = 0, dy = 0;
 const char* sdl_video_driver;
+bool gl_renderer_demoted = false;
 bool kmsdrm_detected = false;
 bool no_wm_detected = false;
 

--- a/src/osdep/amiberry_gfx.h
+++ b/src/osdep/amiberry_gfx.h
@@ -209,6 +209,9 @@ AmiberryGuiGuardedInputResult amiberry_gui_guarded_input_apply(
 
 extern SDL_DisplayMode sdl_mode;
 extern const char* sdl_video_driver;
+// True when GL context creation failed at runtime and the SDL software
+// renderer took over (see gfx_window.cpp doInit). Diagnostics surface it.
+extern bool gl_renderer_demoted;
 extern SDL_Cursor* normalcursor;
 
 extern void sortdisplays();

--- a/src/osdep/crt_gpu_allowlist.cpp
+++ b/src/osdep/crt_gpu_allowlist.cpp
@@ -1,0 +1,27 @@
+/*
+ * crt_gpu_allowlist.cpp - CRT shader quality GPU classification
+ *
+ * Copyright 2026 Dimitris Panokostas
+ */
+
+#include "crt_gpu_allowlist.h"
+
+#include <cstring>
+
+bool crt_gpu_supports_full_crt(const char* renderer)
+{
+	if (renderer == nullptr || renderer[0] == '\0')
+		return false;
+	if (strstr(renderer, "V3D 7"))
+		return true; /* RPi5 */
+	if (strstr(renderer, "Mali-G"))
+		return true; /* Bifrost and later */
+	if (strncmp(renderer, "Apple", 5) == 0)
+		return true; /* Apple A/M-series (iOS) */
+	if (strstr(renderer, "Adreno (TM) 6") || strstr(renderer, "Adreno (TM) 7")
+		|| strstr(renderer, "Adreno (TM) 8"))
+		return true;
+	if (strstr(renderer, "Tegra"))
+		return true; /* Shield-class Tegra */
+	return false;
+}

--- a/src/osdep/crt_gpu_allowlist.h
+++ b/src/osdep/crt_gpu_allowlist.h
@@ -1,0 +1,17 @@
+#pragma once
+
+/*
+ * crt_gpu_allowlist.h - CRT shader quality GPU classification
+ *
+ * Classifies a GL_RENDERER string as capable of the full-quality CRT shaders
+ * (vs the simplified low-power path used by crtemu). Pure string logic with
+ * no GL/SDL dependencies so it is unit-testable without a GL context.
+ *
+ * Copyright 2026 Dimitris Panokostas
+ */
+
+// Returns true when the GL_RENDERER string is a known-capable ES GPU family
+// (RPi5 V3D 7.x, Mali-G and later, Apple A/M-series, Adreno 6xx+, Tegra).
+// Unknown, empty, or low-power GPUs (VideoCore, Mali-4xx/T-xxx, Adreno
+// 3xx-5xx, PowerVR) return false and keep the simplified shader path.
+bool crt_gpu_supports_full_crt(const char* renderer);

--- a/src/osdep/crtemu.h
+++ b/src/osdep/crtemu.h
@@ -238,7 +238,7 @@ struct crtemu_t {
 	unsigned int last_present_format;
 	unsigned int last_present_type;
 	CRTEMU_GLint texture_filter; // GL_NEAREST or GL_LINEAR for NONE mode
-	bool is_mobile_gpu; // True for GLES/VideoCore - enables mobile optimizations
+	bool is_mobile_gpu; // True on low-power GPUs (per the GL_RENDERER allowlist or force_mobile) - selects simplified shader variants
 
 	CRTEMU_GLint loc_blur_blur;
 	CRTEMU_GLint loc_blur_texture;
@@ -348,6 +348,8 @@ struct crtemu_t {
 #endif
 
 
+#include "crt_gpu_allowlist.h"
+
 static CRTEMU_GLuint crtemu_internal_build_shader( crtemu_t* crtemu, char const* vs_source_in, char const* fs_source_in ) {
 #ifdef CRTEMU_REPORT_SHADER_ERRORS
 	char error_message[ 1024 ];
@@ -357,11 +359,6 @@ static CRTEMU_GLuint crtemu_internal_build_shader( crtemu_t* crtemu, char const*
     const char* gl_ver_str = (const char*)glGetString(GL_VERSION);
     bool is_gles = gl_ver_str && (strstr(gl_ver_str, "OpenGL ES") || strstr(gl_ver_str, "OpenGL ES-CM"));
 
-    // Detect mobile GPU (GLES indicates mobile/embedded GPU like VideoCore on RPI)
-    // This enables performance optimizations like mediump precision and reduced blur
-    if (is_gles && !crtemu->is_mobile_gpu) {
-        crtemu->is_mobile_gpu = true;
-    }
 
     // Check for Core Profile (Desktop GL >= 3.2 usually implied by Core)
     // We can also check specific version numbers if needed.
@@ -1837,10 +1834,21 @@ crtemu_t* crtemu_create( crtemu_type_t type, void* memctx, bool force_mobile ) {
 	crtemu->last_present_height = 0;
 	crtemu->texture_filter = CRTEMU_GL_LINEAR; // Default to linear filtering for NONE mode
 
-	// Detect mobile GPU (GLES) BEFORE shader compilation so mobile variants are selected
-	// force_mobile allows UI override for testing or when auto-detection fails
+	// Detect low-power GPU BEFORE shader compilation so the simplified
+	// variants are selected. force_mobile allows a UI override for testing
+	// or when auto-detection fails. ES contexts use the GL_RENDERER
+	// capability allowlist so capable hardware (RPi5, modern Adreno /
+	// Mali-G / Apple) gets the full-quality shaders.
 	const char* gl_ver = (const char*)glGetString(GL_VERSION);
-	crtemu->is_mobile_gpu = force_mobile || (gl_ver && strstr(gl_ver, "OpenGL ES") != nullptr);
+	const bool is_gles_context = gl_ver && strstr(gl_ver, "OpenGL ES") != nullptr;
+	if (force_mobile) {
+		crtemu->is_mobile_gpu = true;
+	} else if (is_gles_context) {
+		const char* gl_renderer = (const char*)glGetString(GL_RENDERER);
+		crtemu->is_mobile_gpu = !crt_gpu_supports_full_crt(gl_renderer);
+	} else {
+		crtemu->is_mobile_gpu = false;
+	}
 
 #ifndef CRTEMU_SDL
 

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -1213,6 +1213,7 @@ bool doInit(AmigaMonitor* mon)
 					 * its window-reuse early return, never calling
 					 * create_platform_renderer — leaving the demoted
 					 * SDLRenderer without an SDL_Renderer (black screen). */
+					gl_renderer_demoted = true;
 					close_windows(mon, true);
 					if (mon->monitor_id > 0) {
 						mon->renderer = create_sdl_renderer();

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -53,6 +53,8 @@
 #include "renderer_factory.h"
 #ifdef USE_OPENGL
 #include "opengl_renderer.h"
+// create_sdl_renderer() (renderer_factory.h) supplies the runtime
+// GL-to-SDL demotion target used below in doInit.
 #endif
 #ifdef USE_VULKAN
 #include "vulkan_renderer.h"
@@ -1114,14 +1116,12 @@ bool doInit(AmigaMonitor* mon)
 				int ctx_attempts = 0;
 				bool ctx_success = false;
 
-				/* Modes 0..3:
-				 *   0 = preferred  : GL 3.3 Core, RGBA8, no depth/stencil
-				 *   1 = legacy     : GL 2.1 Compat, RGBA8, no depth/stencil
-				 *   2 = minimal-3.3: GL 3.3 Core, only DOUBLEBUFFER set
-				 *   3 = minimal-2.1: GL 2.1 Compat, only DOUBLEBUFFER set
-				 * Modes 2/3 exist for drivers with a narrow pixel-format set
-				 * (e.g. Mesa3D d3d12 on Windows ARM64 VMs). */
-				constexpr int max_ctx_modes = 4;
+				/* Modes 0..5 — see the ladder comment in
+				 * set_opengl_attributes() for the full mapping:
+				 *   0/1 = preferred/alternative API with RGBA8 hints
+				 *   2/3 = minimal-attribute retries of modes 0/1
+				 *   4/5 = GLES 3.0 fallback tier (AMIBERRY_GLES_FALLBACK) */
+				constexpr int max_ctx_modes = 6;
 				while (ctx_attempts < max_ctx_modes && !ctx_success) {
 					/* Refresh the renderer pointer at the top of every
 					 * iteration.  A previous failed create_windows() may
@@ -1189,7 +1189,7 @@ bool doInit(AmigaMonitor* mon)
 				}
 
 				if (!ctx_success) {
-					write_log("All renderer context attempts failed for monitor %d. Aborting doInit.\n", mon->monitor_id);
+					write_log("All renderer context attempts failed for monitor %d.\n", mon->monitor_id);
 #if defined(_WIN32)
 					write_log("HINT: If running inside a VM (VMware/Parallels/Hyper-V) without an OpenGL ICD,\n");
 					write_log("HINT: try the Mesa3D 'llvmpipe' build (mesa-llvmpipe-arm64 from\n");
@@ -1198,7 +1198,43 @@ bool doInit(AmigaMonitor* mon)
 					write_log("HINT: standard pixel-format set that SDL accepts; mesa-d3d12 trades that\n");
 					write_log("HINT: for hardware acceleration but exposes a much narrower format set.\n");
 #endif
-					return false;
+#ifdef USE_OPENGL
+					/* Last resort: swap in the SDL software renderer so hosts
+					 * without any usable GL driver (e.g. VMs stuck on the GDI
+					 * Generic GL 1.1 implementation) still run, degrading to
+					 * the scaler path instead of aborting. The window is
+					 * recreated without SDL_WINDOW_OPENGL; the GUI follows
+					 * automatically because it probes the renderer type via
+					 * dynamic_cast (emu_has_opengl in main_window.cpp). */
+					write_log("Demoting monitor %d to the SDL software renderer after GL context failure.\n",
+						mon->monitor_id);
+					/* Force-destroy the window: it still carries the
+					 * SDL_WINDOW_OPENGL flag and create_windows() would take
+					 * its window-reuse early return, never calling
+					 * create_platform_renderer — leaving the demoted
+					 * SDLRenderer without an SDL_Renderer (black screen). */
+					close_windows(mon, true);
+					if (mon->monitor_id > 0) {
+						mon->renderer = create_sdl_renderer();
+					} else {
+						g_renderer = create_sdl_renderer();
+					}
+					if (create_windows(mon)) {
+						renderer = get_renderer(mon->monitor_id);
+						/* The window-reuse path (e.g. start-minimized) can
+						 * still skip platform renderer creation — create it
+						 * explicitly and treat a missing SDL_Renderer as
+						 * failure instead of a silent black screen. */
+						if (renderer && !mon->amiga_renderer) {
+							renderer->create_platform_renderer(mon);
+						}
+						ctx_success = renderer != nullptr && mon->amiga_renderer != nullptr;
+					}
+#endif
+					if (!ctx_success) {
+						write_log("Aborting doInit for monitor %d.\n", mon->monitor_id);
+						return false;
+					}
 				}
 			}
 		} else {
@@ -1378,38 +1414,75 @@ bool doInit(AmigaMonitor* mon)
 	const char* drv = SDL_GetCurrentVideoDriver();
 	write_log(_T("SDL video driver: %hs\n"), drv ? drv : "unknown");
 
-	// Detect GLES-only drivers (e.g., KMSDRM on Raspberry Pi)
-#ifdef __ANDROID__
+	// Detect GLES-only systems: Android and iOS are GLES-only by platform;
+	// KMSDRM (Raspberry Pi and other SBCs on console Linux) has no desktop
+	// GL; USE_GLES3 builds link GLES exclusively and must request ES under
+	// any window system, not just KMSDRM.
+#if defined(__ANDROID__) || defined(AMIBERRY_IOS) || defined(USE_GLES3)
 	const bool likely_gles_only = true;
 #else
 	const bool likely_gles_only = (drv && (strcmp(drv, "KMSDRM") == 0));
 #endif
 
-	/* Mode 0 / 1 -> request a GL 3.3 Core context with sensible RGBA8
-	 * pixel-format hints.  Mode 2 / 3 -> retry with the bare minimum
-	 * (just the GL version + DOUBLEBUFFER), so a driver with a narrow
-	 * pixel-format set (e.g. Mesa3D d3d12 on Windows ARM64 VMs, which
-	 * does not expose a format with the 16-bit depth / RGBA8 / alpha
-	 * combination SDL would otherwise enforce) still has a chance. */
-	const bool minimal_attrs = (mode >= 2);
-	const bool legacy_profile = (mode == 1) || (mode == 3);
+	/* Context request ladder, selected by `mode`:
+	 *   0 = preferred          : GL 3.3 Core (desktop) / GLES 3.0 (ES-only)
+	 *   1 = alternative        : GL 2.1 Compat (desktop) / GLES 3.0 minimal (ES-only)
+	 *   2 = preferred minimal  : mode 0 API, only DOUBLEBUFFER set
+	 *   3 = alternative minimal: mode 1 API, only DOUBLEBUFFER set
+	 *   4 = ES fallback        : GLES 3.0 full hints
+	 *   5 = ES fallback minimal: GLES 3.0, only DOUBLEBUFFER
+	 * Modes 2/3 exist for drivers with a narrow pixel-format set (e.g. Mesa3D
+	 * d3d12 on Windows ARM64 VMs). Modes 4/5 (AMIBERRY_GLES_FALLBACK builds
+	 * only) are the last resort for X11/Wayland hosts whose only hardware
+	 * driver is GLES — SDL loads libGLESv2 via EGL at runtime, so no extra
+	 * link-time dependency is needed. Unsupported modes return false and the
+	 * caller advances to the next attempt. */
+	enum class GlApiRequest { Core, Legacy, Es3 };
+	GlApiRequest api;
+	if (likely_gles_only) {
+		if (mode <= 1) {
+			api = GlApiRequest::Es3;
+		} else {
+			return false;
+		}
+	} else {
+#ifdef AMIBERRY_GLES_FALLBACK
+		constexpr bool es_fallback_tier = true;
+#else
+		constexpr bool es_fallback_tier = false;
+#endif
+		if (es_fallback_tier && (mode == 4 || mode == 5)) {
+			api = GlApiRequest::Es3;
+		} else if (mode == 0 || mode == 2) {
+			api = GlApiRequest::Core;
+		} else if (mode == 1 || mode == 3) {
+			api = GlApiRequest::Legacy;
+		} else {
+			return false;
+		}
+	}
 
-	if (legacy_profile) {
+	// Matches the ladder above: ES-only mode 1 is the minimal retry; desktop
+	// modes 2/3/5 are the minimal-attribute retries.
+	const bool minimal_attrs = likely_gles_only ? (mode == 1)
+		: (mode == 2 || mode == 3 || mode == 5);
+
+	if (api == GlApiRequest::Es3) {
+		// GLES-only systems (e.g. Raspberry Pi with KMSDRM): GLES 3.0
+		write_log(_T("Requesting OpenGL ES 3.0 context (mode=%d, minimal=%d)...\n"),
+			mode, minimal_attrs ? 1 : 0);
+		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+	} else if (api == GlApiRequest::Legacy) {
 		write_log(_T("Requesting OpenGL 2.1 Compatibility context (mode=%d, minimal=%d)...\n"),
 			mode, minimal_attrs ? 1 : 0);
 		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, 0);
 		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
 		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
 		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
-	} else if (likely_gles_only) {
-		// GLES-only systems (e.g., Raspberry Pi with KMSDRM): Try GLES 3.0
-		write_log(_T("Requesting OpenGL ES 3.0 context (GLES-only driver detected, mode=%d, minimal=%d)...\n"),
-			mode, minimal_attrs ? 1 : 0);
-		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
-		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 	} else {
-		// Desktop OpenGL (x86, x86_64, ARM desktops, macOS): Try Core Profile 3.3
+		// Desktop OpenGL (x86, x86_64, ARM desktops, macOS): Core Profile 3.3
 		write_log(_T("Requesting OpenGL 3.3 Core context (mode=%d, minimal=%d)...\n"),
 			mode, minimal_attrs ? 1 : 0);
 		success &= SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);

--- a/src/osdep/gl_capability_classify.cpp
+++ b/src/osdep/gl_capability_classify.cpp
@@ -1,0 +1,59 @@
+/*
+ * gl_capability_classify.cpp - pure GL capability classification
+ *
+ * Copyright 2026 Dimitris Panokostas
+ */
+
+#include "gl_capability_classify.h"
+
+#include <cstdlib>
+#include <cstring>
+
+GlCapabilities classify_gl_capabilities(const char* gl_version, const char* gl_extensions)
+{
+	GlCapabilities caps = {};
+
+	if (gl_version == nullptr)
+		return caps;
+
+	caps.is_gles = (strstr(gl_version, "OpenGL ES") != nullptr);
+	{
+		const char* v = gl_version;
+		while (*v && (*v < '0' || *v > '9')) v++;
+		if (*v) {
+			caps.major = atoi(v);
+			while (*v && *v != '.') v++;
+			if (*v == '.') {
+				v++;
+				caps.minor = atoi(v);
+			}
+		}
+	}
+
+	const auto version_at_least = [&caps](int major, int minor) {
+		return caps.major > major || (caps.major == major && caps.minor >= minor);
+	};
+
+	if (caps.is_gles) {
+		const auto has_ext = [gl_extensions](const char* name) {
+			return gl_extensions && strstr(gl_extensions, name) != nullptr;
+		};
+		caps.clamp_to_border = version_at_least(3, 2)
+			|| has_ext("GL_EXT_texture_border_clamp")
+			|| has_ext("GL_OES_texture_border_clamp");
+		caps.rgba16f_renderable = version_at_least(3, 2)
+			|| has_ext("GL_EXT_color_buffer_half_float")
+			|| has_ext("GL_EXT_color_buffer_float");
+		// ES has no GL_FRAMEBUFFER_SRGB toggle; sRGB write conversion is
+		// automatic for sRGB-format attachments.
+		caps.framebuffer_srgb = false;
+	} else {
+		// Desktop: border-color wrap has been core since GL 1.3 and float
+		// renderability since 3.0; the context ladder only obtains GL >= 2.1.
+		caps.clamp_to_border = true;
+		caps.rgba16f_renderable = version_at_least(3, 0);
+		caps.framebuffer_srgb = version_at_least(3, 0);
+	}
+
+	return caps;
+}

--- a/src/osdep/gl_capability_classify.h
+++ b/src/osdep/gl_capability_classify.h
@@ -1,0 +1,31 @@
+#pragma once
+
+/*
+ * gl_capability_classify.h - pure GL capability classification
+ *
+ * Maps GL_VERSION / GL_EXTENSIONS strings to the feature bits the renderer
+ * gates on (border-color wrap, sRGB write toggle, RGBA16F renderability).
+ * No GL or SDL dependencies so it compiles standalone for unit tests.
+ *
+ * Copyright 2026 Dimitris Panokostas
+ */
+
+struct GlCapabilities {
+	bool is_gles = false;
+	int major = 0;
+	int minor = 0;
+	// GL_CLAMP_TO_BORDER is usable (desktop: core since GL 1.3; ES >= 3.2 or
+	// the border-clamp extension).
+	bool clamp_to_border = false;
+	// The desktop GL_FRAMEBUFFER_SRGB enable/disable toggle exists
+	// (desktop GL >= 3.0). ES converts automatically with no toggle.
+	bool framebuffer_srgb = false;
+	// RGBA16F is usable as a color-renderable FBO attachment (desktop
+	// >= 3.0, ES >= 3.2, or EXT_color_buffer_half_float/float on ES 3.x).
+	bool rgba16f_renderable = false;
+};
+
+// Classifies capability bits from the GL_VERSION string and (ES only) the
+// GL_EXTENSIONS string. Both may be nullptr; a null version yields a zeroed
+// snapshot. Pure function — no GL calls.
+GlCapabilities classify_gl_capabilities(const char* gl_version, const char* gl_extensions);

--- a/src/osdep/gl_platform.cpp
+++ b/src/osdep/gl_platform.cpp
@@ -145,6 +145,36 @@ bool gl_platform_init()
 }
 #endif // __ANDROID__
 
+const GlCapabilities& get_gl_capabilities()
+{
+	static GlCapabilities cached = {};
+	static bool initialized = false;
+
+	if (initialized)
+		return cached;
+
+	const char* gl_ver_str = (const char*)glGetString(GL_VERSION);
+	if (gl_ver_str == nullptr) {
+		// No current context (or a broken driver): return a zeroed snapshot
+		// WITHOUT latching, so a later call with a live context re-probes.
+		static const GlCapabilities empty = {};
+		return empty;
+	}
+	cached = classify_gl_capabilities(
+		gl_ver_str,
+		(const char*)glGetString(GL_EXTENSIONS));
+
+	write_log("GL capabilities: %s %d.%d (clamp_to_border=%d framebuffer_srgb=%d rgba16f_renderable=%d)\n",
+		cached.is_gles ? "GLES" : "GL",
+		cached.major, cached.minor,
+		cached.clamp_to_border ? 1 : 0,
+		cached.framebuffer_srgb ? 1 : 0,
+		cached.rgba16f_renderable ? 1 : 0);
+
+	initialized = true;
+	return cached;
+}
+
 const GlShaderPreambles& get_gl_shader_preambles()
 {
 	static GlShaderPreambles cached = {};
@@ -153,26 +183,12 @@ const GlShaderPreambles& get_gl_shader_preambles()
 	if (initialized)
 		return cached;
 
-	const char* gl_ver_str = (const char*)glGetString(GL_VERSION);
-	bool is_gles = gl_ver_str && (strstr(gl_ver_str, "OpenGL ES") != nullptr);
-	int major = 0, minor = 0;
-	if (gl_ver_str) {
-		const char* v = gl_ver_str;
-		while (*v && (*v < '0' || *v > '9')) v++;
-		if (*v) {
-			major = atoi(v);
-			while (*v && *v != '.') v++;
-			if (*v == '.') {
-				v++;
-				minor = atoi(v);
-			}
-		}
-	}
+	const GlCapabilities& caps = get_gl_capabilities();
 
-	if (is_gles && major >= 3) {
+	if (caps.is_gles && caps.major >= 3) {
 		cached.vs = "#version 300 es\nprecision mediump float;\n#define attribute in\n#define varying out\n";
 		cached.fs = "#version 300 es\nprecision mediump float;\nprecision mediump int;\n#define varying in\n#define texture2D texture\n#define gl_FragColor outFragColor\nout vec4 outFragColor;\n";
-	} else if (!is_gles && (major > 3 || (major == 3 && minor >= 2))) {
+	} else if (!caps.is_gles && (caps.major > 3 || (caps.major == 3 && caps.minor >= 2))) {
 		cached.vs = "#version 330 core\n#define attribute in\n#define varying out\n";
 		cached.fs = "#version 330 core\nprecision mediump int;\n#define varying in\n#define texture2D texture\n#define gl_FragColor outFragColor\nout vec4 outFragColor;\n";
 	} else {

--- a/src/osdep/gl_platform.cpp
+++ b/src/osdep/gl_platform.cpp
@@ -147,10 +147,15 @@ bool gl_platform_init()
 
 const GlCapabilities& get_gl_capabilities()
 {
+	// Cache per GL context, not per process: a context change (per-monitor
+	// ladder results can mix desktop GL and the GLES fallback tier, demotion
+	// cycles recreate contexts) can change the API class, so re-probe when
+	// the current context differs from the one this snapshot came from.
 	static GlCapabilities cached = {};
-	static bool initialized = false;
+	static SDL_GLContext cached_context = nullptr;
 
-	if (initialized)
+	const SDL_GLContext current_context = SDL_GL_GetCurrentContext();
+	if (current_context != nullptr && current_context == cached_context)
 		return cached;
 
 	const char* gl_ver_str = (const char*)glGetString(GL_VERSION);
@@ -163,6 +168,7 @@ const GlCapabilities& get_gl_capabilities()
 	cached = classify_gl_capabilities(
 		gl_ver_str,
 		(const char*)glGetString(GL_EXTENSIONS));
+	cached_context = current_context;
 
 	write_log("GL capabilities: %s %d.%d (clamp_to_border=%d framebuffer_srgb=%d rgba16f_renderable=%d)\n",
 		cached.is_gles ? "GLES" : "GL",
@@ -171,16 +177,18 @@ const GlCapabilities& get_gl_capabilities()
 		cached.framebuffer_srgb ? 1 : 0,
 		cached.rgba16f_renderable ? 1 : 0);
 
-	initialized = true;
 	return cached;
 }
 
 const GlShaderPreambles& get_gl_shader_preambles()
 {
+	// Same per-context key as get_gl_capabilities(): a context change can
+	// switch the GLSL profile, so the preambles follow the live context.
 	static GlShaderPreambles cached = {};
-	static bool initialized = false;
+	static SDL_GLContext cached_context = nullptr;
 
-	if (initialized)
+	const SDL_GLContext current_context = SDL_GL_GetCurrentContext();
+	if (current_context != nullptr && current_context == cached_context)
 		return cached;
 
 	const GlCapabilities& caps = get_gl_capabilities();
@@ -196,7 +204,7 @@ const GlShaderPreambles& get_gl_shader_preambles()
 		cached.fs = "#version 120\n";
 	}
 
-	initialized = true;
+	cached_context = current_context;
 	return cached;
 }
 

--- a/src/osdep/gl_platform.h
+++ b/src/osdep/gl_platform.h
@@ -117,6 +117,12 @@ extern PFNGLGENERATEMIPMAPPROC glp_GenerateMipmap;
 #endif // __ANDROID__
 
 // GL format constants that may not be defined on all platforms
+#ifndef GL_HALF_FLOAT
+#define GL_HALF_FLOAT 0x140B
+#endif
+#ifndef GL_CLAMP_TO_BORDER
+#define GL_CLAMP_TO_BORDER 0x812D
+#endif
 #ifndef GL_RGBA16F
 #define GL_RGBA16F 0x881A
 #endif
@@ -151,6 +157,17 @@ struct GlShaderPreambles {
 // profile (macOS) and GLES 3.0 (Android/RPi). Must be called after GL context
 // creation. Thread-safe for reads after first call.
 const GlShaderPreambles& get_gl_shader_preambles();
+
+// Runtime GL capability snapshot for the current context. Detected once per
+// process from GL_VERSION and the ES extension string, so feature
+// gates (float framebuffers, border-color wrap, sRGB write toggles) follow
+// the actual driver instead of platform compile-time guesses. Must be called
+// after GL context creation. Thread-safe for reads after first call.
+// The GlCapabilities struct and its pure classifier live in
+// gl_capability_classify.h so they are unit-testable without a GL context.
+#include "gl_capability_classify.h"
+
+const GlCapabilities& get_gl_capabilities();
 
 #endif // USE_OPENGL
 

--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -1734,8 +1734,11 @@ void amiberry_gui_init()
 		ImGui_ImplSDL3_InitForOpenGL(mon->gui_window, ctx);
 		// Pass nullptr so the backend auto-picks "#version 300 es" when
 		// IMGUI_IMPL_OPENGL_ES3 is defined (Pi/GLES build) and "#version 130"
-		// on desktop GL.
-		ImGui_ImplOpenGL3_Init(nullptr);
+		// on desktop GL. A desktop build whose GL context fell back to the
+		// runtime GLES tier (ladder modes 4/5) also needs the ES version
+		// string — the desktop default does not compile on a GLES context.
+		ImGui_ImplOpenGL3_Init(
+			get_gl_capabilities().is_gles ? "#version 300 es" : nullptr);
 	} else
 #endif
 	{

--- a/src/osdep/imgui/about.cpp
+++ b/src/osdep/imgui/about.cpp
@@ -7,8 +7,13 @@
 #include "fsdb_host.h"
 #include "amiberry_update.h"
 #include "target.h"
-#include <SDL3_image/SDL_image.h>
+#include "irenderer.h"
+#ifdef USE_OPENGL
+#include "opengl_renderer.h"
+#include "gl_platform.h"
+#endif
 #include "gui/amiberry_logo_png_data.h"
+#include <SDL3_image/SDL_image.h>
 
 #include <string>
 #include <thread>
@@ -309,11 +314,41 @@ void render_panel_about()
 	ImGui::Spacing();
 
 	ImGui::Indent(10.0f);
-
 	ImGui::TextUnformatted(get_version_string().c_str());
 	ImGui::TextUnformatted(get_copyright_notice().c_str());
 	ImGui::TextUnformatted(get_sdl_version_string().c_str());
 	ImGui::Text("SDL video driver: %s", sdl_video_driver ? sdl_video_driver : "unknown");
+
+#ifdef USE_OPENGL
+	if (const auto* gl_renderer = get_opengl_renderer(); gl_renderer && gl_renderer->has_context()) {
+		const GLRuntimeInfo& info = gl_renderer->get_gl_runtime_info();
+		if (info.valid) {
+			const GlCapabilities& caps = get_gl_capabilities();
+			ImGui::Text("Graphics backend: %s %d.%d", caps.is_gles ? "OpenGL ES" : "OpenGL",
+				caps.major, caps.minor);
+			ImGui::Text("GPU: %s", info.renderer.c_str());
+			ImGui::Text("GL vendor: %s", info.vendor.c_str());
+			ImGui::Text("GLSL version: %s", info.glsl_version.c_str());
+			ImGui::Text("GL capabilities: border-clamp %s, sRGB write %s, float FBO %s",
+				caps.clamp_to_border ? "yes" : "no",
+				caps.framebuffer_srgb ? "yes" : "no",
+				caps.rgba16f_renderable ? "yes" : "no");
+		} else {
+			ImGui::TextUnformatted("Graphics backend: OpenGL (driver info unavailable)");
+		}
+	} else if (gl_renderer_demoted) {
+		ImGui::TextUnformatted("Graphics backend: SDL software renderer (GL unavailable - demoted)");
+	} else {
+		// USE_OPENGL build with no live GL context: either the GUI opened
+		// before emulation started (g_renderer not created yet) or the
+		// context is torn down between runs.
+		ImGui::TextUnformatted("Graphics backend: OpenGL (context not initialized)");
+	}
+#elif defined(USE_VULKAN)
+	ImGui::TextUnformatted("Graphics backend: Vulkan (experimental)");
+#else
+	ImGui::TextUnformatted("Graphics backend: SDL software renderer");
+#endif
 
 	ImGui::Spacing();
 	ImGui::Separator();

--- a/src/osdep/on_screen_joystick.cpp
+++ b/src/osdep/on_screen_joystick.cpp
@@ -853,9 +853,13 @@ void on_screen_joystick_init(SDL_Renderer* renderer)
 	btn2_surface = create_button_surface(BTN2_OUTER, BTN2_INNER, BTN2_HIGHLIGHT);
 	btnkb_surface = create_kb_button_surface();
 
-#ifndef USE_OPENGL
-	// Create SDL textures from surfaces (only when using SDL renderer)
+#if defined(USE_OPENGL)
+	// GL builds pass a null renderer (OpenGLRenderer owns no SDL_Renderer);
+	// a non-null renderer means we are on the SDL path — either a no-GL
+	// build or a USE_OPENGL build that demoted to SDLRenderer at runtime —
+	// so create the SDL textures whenever one is available.
 	if (renderer) {
+#endif
 		if (stick_base_surface) {
 			stick_base_tex = SDL_CreateTextureFromSurface(renderer, stick_base_surface);
 			if (stick_base_tex) SDL_SetTextureBlendMode(stick_base_tex, SDL_BLENDMODE_BLEND);
@@ -876,6 +880,7 @@ void on_screen_joystick_init(SDL_Renderer* renderer)
 			btnkb_tex = SDL_CreateTextureFromSurface(renderer, btnkb_surface);
 			if (btnkb_tex) SDL_SetTextureBlendMode(btnkb_tex, SDL_BLENDMODE_BLEND);
 		}
+#if defined(USE_OPENGL)
 	}
 #endif
 

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -140,9 +140,15 @@ bool OpenGLRenderer::init_context(SDL_Window* window)
 		return false;
 	}
 
+	const char* gl_vendor = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
 	const char* renderer = reinterpret_cast<const char*>(glGetString(GL_RENDERER));
 	const char* version  = reinterpret_cast<const char*>(glGetString(GL_VERSION));
 	const char* sl_ver   = reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION));
+	m_gl_info.vendor = gl_vendor ? gl_vendor : "";
+	m_gl_info.renderer = renderer ? renderer : "";
+	m_gl_info.version = version ? version : "";
+	m_gl_info.glsl_version = sl_ver ? sl_ver : "";
+	m_gl_info.valid = (renderer != nullptr && version != nullptr);
 	write_log(_T("OpenGL Renderer: %hs\n"), renderer ? renderer : "unknown");
 	write_log(_T("OpenGL Version:  %hs\n"), version ? version : "unknown");
 	write_log(_T("GLSL Version:    %hs\n"), sl_ver ? sl_ver : "unknown");

--- a/src/osdep/opengl_renderer.h
+++ b/src/osdep/opengl_renderer.h
@@ -23,10 +23,22 @@
 struct crtemu_t;
 class ShaderPreset;
 
+// GL runtime identity captured at context creation. Cached as strings so
+// diagnostics (About panel, support reports) can show them without a
+// current GL context.
+struct GLRuntimeInfo {
+	std::string vendor;      // GL_VENDOR
+	std::string renderer;    // GL_RENDERER
+	std::string version;     // GL_VERSION
+	std::string glsl_version; // GL_SHADING_LANGUAGE_VERSION
+	bool valid = false;
+};
+
 struct ShaderParameterCache {
 	std::string shader_name;
 	std::vector<ShaderParameter> parameters;
 };
+
 
 // Shader lifecycle and caching state (owned by OpenGLRenderer)
 struct ShaderState {
@@ -139,6 +151,12 @@ public:
 	// Access the GL context for ImGui GUI integration
 	SDL_GLContext get_gl_context() const;
 
+	// GL runtime info captured at context creation (GL_RENDERER /
+	// GL_VERSION / GL_SHADING_LANGUAGE_VERSION). Cached as strings so the
+	// About panel and diagnostics can show them without a current GL
+	// context. vendor is GL_VENDOR.
+	const GLRuntimeInfo& get_gl_runtime_info() const { return m_gl_info; }
+
 	// Access shader state for filter.cpp parameter editing
 	ShaderState& shader_state();
 	const ShaderState& shader_state() const;
@@ -159,6 +177,9 @@ private:
 	GLOverlayState m_overlay;
 	bool m_integer_scaling = false; // Integer scaling for native Amiga modes (scaling_method == 2)
 	bool m_stretch_to_fill = false; // Fill the render area, ignoring aspect (scaling_method == 3)
+
+	// GL identity captured at context creation (About panel / diagnostics)
+	GLRuntimeInfo m_gl_info;
 
 	// Cached GL pixel format info (resolved once from pixel_format, reused per frame)
 	struct GLFormatInfo {

--- a/src/osdep/renderer_factory.cpp
+++ b/src/osdep/renderer_factory.cpp
@@ -11,9 +11,13 @@
 #include "vulkan_renderer.h"
 #elif defined(USE_OPENGL)
 #include "opengl_renderer.h"
-#else
-#include "sdl_renderer.h"
 #endif
+#include "sdl_renderer.h"
+
+std::unique_ptr<IRenderer> create_sdl_renderer()
+{
+	return std::make_unique<SDLRenderer>();
+}
 
 std::unique_ptr<IRenderer> create_renderer()
 {
@@ -22,6 +26,6 @@ std::unique_ptr<IRenderer> create_renderer()
 #elif defined(USE_OPENGL)
 	return std::make_unique<OpenGLRenderer>();
 #else
-	return std::make_unique<SDLRenderer>();
+	return create_sdl_renderer();
 #endif
 }

--- a/src/osdep/renderer_factory.h
+++ b/src/osdep/renderer_factory.h
@@ -16,3 +16,8 @@
 // - USE_OPENGL defined: returns OpenGLRenderer
 // - Otherwise: returns SDLRenderer
 std::unique_ptr<IRenderer> create_renderer();
+
+// Creates the SDL software renderer backend. Used as the primary renderer in
+// no-GL builds and as the runtime demotion target when GL context creation
+// fails in USE_OPENGL builds (see gfx_window.cpp).
+std::unique_ptr<IRenderer> create_sdl_renderer();

--- a/src/osdep/sdl_renderer.cpp
+++ b/src/osdep/sdl_renderer.cpp
@@ -9,8 +9,9 @@
 
 #include "sysdeps.h"
 
-#ifndef USE_OPENGL
-
+// SDL software renderer backend. Compiled in every configuration (it only
+// depends on SDL3 + irenderer.h): primary renderer in no-GL builds and the
+// runtime GL-to-SDL demotion target in USE_OPENGL builds (gfx_window.cpp).
 #include "options.h"
 #include "xwin.h"
 #include "picasso96.h"
@@ -402,7 +403,7 @@ bool SDLRenderer::render_frame(int monid, int mode, int immediate)
 			static_cast<float>(sly - (mon->statusline_surface->h - led_h)),
 			static_cast<float>(mon->statusline_surface->w), static_cast<float>(mon->statusline_surface->h) };
 		int lw = 0, lh = 0;
-		SDL_LogicalPresentation lmode = SDL_LOGICAL_PRESENTATION_DISABLED;
+		SDL_RendererLogicalPresentation lmode = SDL_LOGICAL_PRESENTATION_DISABLED;
 		SDL_GetRenderLogicalPresentation(mon->amiga_renderer, &lw, &lh, &lmode);
 		SDL_SetRenderLogicalPresentation(mon->amiga_renderer, 0, 0, SDL_LOGICAL_PRESENTATION_DISABLED);
 		SDL_RenderTexture(mon->amiga_renderer, mon->statusline_texture, nullptr, &dst_osd);
@@ -528,4 +529,3 @@ void SDLRenderer::close_hwnds_cleanup(AmigaMonitor* mon)
 }
 
 #endif // AMIBERRY
-#endif // !USE_OPENGL

--- a/src/osdep/sdl_renderer.cpp
+++ b/src/osdep/sdl_renderer.cpp
@@ -403,7 +403,7 @@ bool SDLRenderer::render_frame(int monid, int mode, int immediate)
 			static_cast<float>(sly - (mon->statusline_surface->h - led_h)),
 			static_cast<float>(mon->statusline_surface->w), static_cast<float>(mon->statusline_surface->h) };
 		int lw = 0, lh = 0;
-		SDL_RendererLogicalPresentation lmode = SDL_LOGICAL_PRESENTATION_DISABLED;
+		auto lmode = SDL_LOGICAL_PRESENTATION_DISABLED;
 		SDL_GetRenderLogicalPresentation(mon->amiga_renderer, &lw, &lh, &lmode);
 		SDL_SetRenderLogicalPresentation(mon->amiga_renderer, 0, 0, SDL_LOGICAL_PRESENTATION_DISABLED);
 		SDL_RenderTexture(mon->amiga_renderer, mon->statusline_texture, nullptr, &dst_osd);

--- a/src/osdep/sdl_renderer.h
+++ b/src/osdep/sdl_renderer.h
@@ -8,8 +8,9 @@
  * Copyright 2026 Dimitris Panokostas
  */
 
-#ifndef USE_OPENGL
-
+// SDL software renderer backend. Compiled in every configuration (it only
+// depends on SDL3 + irenderer.h): primary renderer in no-GL builds and the
+// runtime GL-to-SDL demotion target in USE_OPENGL builds (gfx_window.cpp).
 #include "irenderer.h"
 #include <SDL3/SDL.h>
 
@@ -79,5 +80,3 @@ private:
 };
 
 SDLRenderer* get_sdl_renderer();
-
-#endif // !USE_OPENGL

--- a/src/osdep/shader_preset.cpp
+++ b/src/osdep/shader_preset.cpp
@@ -20,6 +20,24 @@
 
 extern SDL_PixelFormat pixel_format;
 
+namespace {
+
+// Enable/disable sRGB write conversion for the current framebuffer. No-op on
+// GLES, where conversion is automatic for sRGB-format attachments and the
+// GL_FRAMEBUFFER_SRGB toggle does not exist (it is force-defined in
+// gl_platform.h only so the code compiles there).
+void set_framebuffer_srgb_enabled(bool enabled)
+{
+	if (get_gl_capabilities().framebuffer_srgb) {
+		if (enabled)
+			glEnable(GL_FRAMEBUFFER_SRGB);
+		else
+			glDisable(GL_FRAMEBUFFER_SRGB);
+	}
+}
+
+}
+
 ShaderPreset::ShaderPreset() = default;
 
 ShaderPreset::~ShaderPreset()
@@ -129,7 +147,11 @@ GLenum ShaderPreset::wrap_mode_to_gl(WrapMode mode)
 {
 	switch (mode) {
 	case WrapMode::Repeat: return GL_REPEAT;
-	case WrapMode::ClampToBorder: return GL_CLAMP_TO_EDGE; // GL_CLAMP_TO_BORDER may not be available on GLES
+	// GL_CLAMP_TO_BORDER needs the border-color wrap to be exposed by the
+	// context (desktop >= 3.2, ES >= 3.2, or the border-clamp extension);
+	// otherwise fall back to edge clamping.
+	case WrapMode::ClampToBorder: return get_gl_capabilities().clamp_to_border
+		? GL_CLAMP_TO_BORDER : GL_CLAMP_TO_EDGE;
 	case WrapMode::MirroredRepeat: return GL_MIRRORED_REPEAT;
 	default: return GL_CLAMP_TO_EDGE;
 	}
@@ -645,47 +667,96 @@ bool ShaderPreset::create_pass_fbo(int pass_index, int input_w, int input_h,
 		pass.output_texture = 0;
 	}
 
-	// Create output texture
-	glGenTextures(1, &pass.output_texture);
-	glBindTexture(GL_TEXTURE_2D, pass.output_texture);
-
-	// Choose internal format
-	GLenum internal_format = GL_RGBA;
-	if (pass.config.float_framebuffer)
-		internal_format = GL_RGBA16F;
-	else if (pass.config.srgb_framebuffer)
-		internal_format = GL_SRGB8_ALPHA8;
-
-	glTexImage2D(GL_TEXTURE_2D, 0, internal_format, out_w, out_h, 0,
-		GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-
-	// Filtering
-	GLenum filter = pass.config.filter_linear ? GL_LINEAR : GL_NEAREST;
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
-
-	// Wrap mode
-	GLenum wrap = wrap_mode_to_gl(pass.config.wrap_mode);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap);
-
-	// Create FBO
-	glGenFramebuffers(1, &pass.fbo);
-	glBindFramebuffer(GL_FRAMEBUFFER, pass.fbo);
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
-		GL_TEXTURE_2D, pass.output_texture, 0);
-
-	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-	if (status != GL_FRAMEBUFFER_COMPLETE) {
-		error_message_ = "FBO incomplete for pass " + std::to_string(pass_index)
-			+ " (status: " + std::to_string(status) + ", size: "
-			+ std::to_string(out_w) + "x" + std::to_string(out_h) + ")";
-		write_log("%s\n", error_message_.c_str());
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
-		return false;
+	// Internal-format candidates: the requested format first, then a plain
+	// RGBA8 fallback so a preset still loads when the driver rejects float or
+	// sRGB renderability (checked via glCheckFramebufferStatus rather than
+	// trusting extension strings alone). Float formats require GL_HALF_FLOAT
+	// as the upload type; GL_RGBA/GL_UNSIGNED_BYTE with GL_RGBA16F is invalid
+	// per spec and fails on strict drivers.
+	const GlCapabilities& caps = get_gl_capabilities();
+	GLenum formats[2] = { GL_RGBA, GL_RGBA };
+	int format_count = 1;
+	if (pass.config.float_framebuffer) {
+		if (caps.rgba16f_renderable) {
+			formats[0] = GL_RGBA16F;
+			formats[1] = GL_RGBA;
+			format_count = 2;
+		}
+	} else if (pass.config.srgb_framebuffer) {
+		formats[0] = GL_SRGB8_ALPHA8;
+		formats[1] = GL_RGBA;
+		format_count = 2;
 	}
 
+	// Create output texture
+	glGenTextures(1, &pass.output_texture);
+
+	// Create FBO (reused across format attempts)
+	glGenFramebuffers(1, &pass.fbo);
+
+	bool fbo_complete = false;
+	GLenum chosen_format = GL_RGBA;
+	// Filter/wrap are persistent texture-object state (not reset by
+	// glTexImage2D), so they are set once after a complete format is chosen.
+	for (int attempt = 0; attempt < format_count && !fbo_complete; attempt++) {
+		glBindTexture(GL_TEXTURE_2D, pass.output_texture);
+		const GLenum type = (formats[attempt] == GL_RGBA16F) ? GL_HALF_FLOAT : GL_UNSIGNED_BYTE;
+		glTexImage2D(GL_TEXTURE_2D, 0, formats[attempt], out_w, out_h, 0,
+			GL_RGBA, type, nullptr);
+
+		glBindFramebuffer(GL_FRAMEBUFFER, pass.fbo);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+			GL_TEXTURE_2D, pass.output_texture, 0);
+
+		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+		if (status == GL_FRAMEBUFFER_COMPLETE) {
+			fbo_complete = true;
+			chosen_format = formats[attempt];
+			if (attempt > 0) {
+				write_log("Shader preset pass %d: requested format 0x%04X incomplete, "
+					"downgraded to fallback 0x%04X\n",
+					pass_index, static_cast<unsigned>(formats[0]),
+					static_cast<unsigned>(chosen_format));
+			}
+		} else if (attempt + 1 < format_count) {
+			write_log("Shader preset pass %d: FBO incomplete for format 0x%04X "
+				"(status 0x%04X), retrying with fallback format\n",
+				pass_index, static_cast<unsigned>(formats[attempt]),
+				static_cast<unsigned>(status));
+		} else {
+			error_message_ = "FBO incomplete for pass " + std::to_string(pass_index)
+				+ " (status: " + std::to_string(status) + ", size: "
+				+ std::to_string(out_w) + "x" + std::to_string(out_h) + ")";
+			write_log("%s\n", error_message_.c_str());
+		}
+	}
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	if (!fbo_complete) {
+		// Delete the failed objects and reset the cached state so the
+		// same-size early-return above can never validate an incomplete
+		// FBO on a later call (succeed at size A -> fail at B -> request A).
+		if (pass.fbo != 0) {
+			glDeleteFramebuffers(1, &pass.fbo);
+			pass.fbo = 0;
+		}
+		if (pass.output_texture != 0) {
+			if (glIsTexture(pass.output_texture))
+				glDeleteTextures(1, &pass.output_texture);
+			pass.output_texture = 0;
+		}
+		pass.output_width = 0;
+		pass.output_height = 0;
+		pass.output_internal_format = GL_RGBA;
+		return false;
+	}
+	glBindTexture(GL_TEXTURE_2D, pass.output_texture);
+	const GLenum filter = pass.config.filter_linear ? GL_LINEAR : GL_NEAREST;
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+	const GLenum wrap = wrap_mode_to_gl(pass.config.wrap_mode);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap);
+	pass.output_internal_format = chosen_format;
 	pass.output_width = out_w;
 	pass.output_height = out_h;
 	return true;
@@ -868,7 +939,7 @@ bool ShaderPreset::run_flip_pass(int width, int height)
 	glViewport(0, 0, width, height);
 	// Flip pass never uses sRGB framebuffer encoding — the frame is already
 	// in its target color space.
-	glDisable(GL_FRAMEBUFFER_SRGB);
+	set_framebuffer_srgb_enabled(false);
 
 	glUseProgram(flip_program_);
 	glActiveTexture(GL_TEXTURE0);
@@ -1166,18 +1237,17 @@ void ShaderPreset::render(const unsigned char* pixels, int width, int height, in
 		if (is_last) {
 			glBindFramebuffer(GL_FRAMEBUFFER, target_framebuffer);
 			glViewport(viewport_x, viewport_y, viewport_w, viewport_h);
-			glDisable(GL_FRAMEBUFFER_SRGB);
+			set_framebuffer_srgb_enabled(false);
 		} else {
 			glBindFramebuffer(GL_FRAMEBUFFER, pass.fbo);
 			glViewport(0, 0, output_w, output_h);
 			// Enable sRGB encoding when writing to sRGB framebuffers.
 			// This ensures proper linear-to-sRGB conversion on write,
 			// matching the sRGB-to-linear decode that happens on read.
-			if (pass.config.srgb_framebuffer) {
-				glEnable(GL_FRAMEBUFFER_SRGB);
-			} else {
-				glDisable(GL_FRAMEBUFFER_SRGB);
-			}
+			// The actual (possibly downgraded) format decides, not the
+			// preset request. GLES converts automatically; the helper is a
+			// no-op there.
+			set_framebuffer_srgb_enabled(pass.output_internal_format == GL_SRGB8_ALPHA8);
 			glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 			glClear(GL_COLOR_BUFFER_BIT);
 		}
@@ -1210,7 +1280,7 @@ void ShaderPreset::render(const unsigned char* pixels, int width, int height, in
 	}
 
 	// Cleanup
-	glDisable(GL_FRAMEBUFFER_SRGB);
+	set_framebuffer_srgb_enabled(false);
 	glBindVertexArray(0);
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/src/osdep/shader_preset.h
+++ b/src/osdep/shader_preset.h
@@ -56,6 +56,10 @@ struct ShaderPass {
 	std::unique_ptr<ExternalShader> shader;
 	GLuint fbo = 0;
 	GLuint output_texture = 0;
+	// Internal format actually allocated for output_texture (may differ from
+	// the requested float/sRGB format after the FBO-completeness fallback in
+	// create_pass_fbo).
+	GLenum output_internal_format = GL_RGBA;
 	int output_width = 0;
 	int output_height = 0;
 };

--- a/tests/crt_gpu_allowlist_test.cpp
+++ b/tests/crt_gpu_allowlist_test.cpp
@@ -1,0 +1,62 @@
+#include <iostream>
+
+#include "crt_gpu_allowlist.h"
+
+namespace {
+
+int failures;
+
+void expect_full(const char* renderer)
+{
+	if (!crt_gpu_supports_full_crt(renderer)) {
+		std::cerr << "expected full-quality CRT path for renderer \"" << renderer << "\"\n";
+		failures++;
+	}
+}
+
+void expect_simplified(const char* renderer)
+{
+	if (crt_gpu_supports_full_crt(renderer)) {
+		std::cerr << "expected simplified CRT path for renderer \"" << renderer << "\"\n";
+		failures++;
+	}
+}
+
+} // namespace
+
+int main()
+{
+	// Unknown / empty / null stay on the simplified path (fail-safe).
+	expect_simplified(nullptr);
+	expect_simplified("");
+	expect_simplified("unknown gpu");
+	expect_simplified("llvmpipe (LLVM 19.1.7, 256 bits)");
+
+	// Capable families.
+	expect_full("V3D 7.1.0");              // RPi5
+	expect_full("Mali-G52 (Panfrost)");    // Bifrost
+	expect_full("Mali-G610 (Panfrost)");   // Valhall
+	expect_full("Apple A15 GPU");
+	expect_full("Apple M2 GPU");
+	expect_full("Adreno (TM) 640");
+	expect_full("Adreno (TM) 730");
+	expect_full("Adreno (TM) 830");
+	expect_full("NVIDIA Tegra X1 (nvgpu)");
+
+	// Low-power / older families stay simplified.
+	expect_simplified("V3D 4.2.14-stellar");  // RPi4 VideoCore
+	expect_simplified("Mali-450 MP2");        // Utgard
+	expect_simplified("Mali-T860");           // Midgard
+	expect_full("Mali-G71");                  // Bifrost (G-prefix match)
+	expect_simplified("Adreno (TM) 540");
+	expect_simplified("Adreno (TM) 308");
+	expect_simplified("PowerVR Rogue GE8320");
+	expect_simplified("VideoCore IV HW");
+
+	if (failures > 0) {
+		std::cerr << failures << " crt_gpu_allowlist failure(s)\n";
+		return 1;
+	}
+	std::cout << "crt_gpu_allowlist: all checks passed\n";
+	return 0;
+}

--- a/tests/gl_capability_classify_test.cpp
+++ b/tests/gl_capability_classify_test.cpp
@@ -1,0 +1,94 @@
+#include <iostream>
+#include <string>
+
+#include "gl_capability_classify.h"
+
+namespace {
+
+int failures;
+
+void expect(bool condition, const std::string& message)
+{
+	if (!condition) {
+		std::cerr << message << '\n';
+		failures++;
+	}
+}
+
+GlCapabilities check(const char* version, const char* extensions, const std::string& label)
+{
+	const GlCapabilities caps = classify_gl_capabilities(version, extensions);
+	expect(caps.major >= 0 && caps.minor >= 0, label + ": negative version fields");
+	return caps;
+}
+
+} // namespace
+
+int main()
+{
+	// Null / empty inputs yield a zeroed snapshot.
+	const GlCapabilities none = check(nullptr, nullptr, "null version");
+	expect(!none.is_gles && none.major == 0 && none.minor == 0, "null version: zeroed");
+	expect(!none.clamp_to_border && !none.framebuffer_srgb && !none.rgba16f_renderable,
+		"null version: all features off");
+
+	// Desktop GL 4.6 core (typical Windows/Linux driver).
+	const GlCapabilities desk46 = check("4.6.0 NVIDIA 566.36", nullptr, "desktop 4.6");
+	expect(!desk46.is_gles && desk46.major == 4 && desk46.minor == 6, "desktop 4.6: parsed");
+	expect(desk46.clamp_to_border && desk46.framebuffer_srgb && desk46.rgba16f_renderable,
+		"desktop 4.6: all features on");
+
+	// Desktop GL 3.3 core (macOS ceiling, common fallback tier).
+	const GlCapabilities desk33 = check("3.3 (Core Profile) Mesa 24.0.9", nullptr, "desktop 3.3");
+	expect(!desk33.is_gles && desk33.major == 3 && desk33.minor == 3, "desktop 3.3: parsed");
+	expect(desk33.clamp_to_border && desk33.framebuffer_srgb && desk33.rgba16f_renderable,
+		"desktop 3.3: all features on");
+
+	// Desktop GL 3.0/3.1: border clamp is core since GL 1.3, so it stays on.
+	const GlCapabilities desk30 = check("3.0 Mesa 21.3.9", nullptr, "desktop 3.0");
+	expect(desk30.clamp_to_border, "desktop 3.0: clamp_to_border on (core since 1.3)");
+	expect(desk30.rgba16f_renderable && desk30.framebuffer_srgb, "desktop 3.0: 3.0 features on");
+
+	// Desktop GL 2.1 (legacy fallback tier): no float render, no sRGB toggle.
+	const GlCapabilities desk21 = check("2.1.2 NVIDIA-550", nullptr, "desktop 2.1");
+	expect(!desk21.rgba16f_renderable && !desk21.framebuffer_srgb, "desktop 2.1: 3.0 features off");
+	expect(desk21.clamp_to_border, "desktop 2.1: clamp_to_border on (core since 1.3)");
+
+	// ES 3.2: everything core except the sRGB toggle.
+	const GlCapabilities es32 = check("OpenGL ES 3.2 v1.r14p0-01eac0", nullptr, "ES 3.2");
+	expect(es32.is_gles && es32.major == 3 && es32.minor == 2, "ES 3.2: parsed");
+	expect(es32.clamp_to_border && es32.rgba16f_renderable, "ES 3.2: border + float on");
+	expect(!es32.framebuffer_srgb, "ES 3.2: no GL_FRAMEBUFFER_SRGB toggle");
+
+	// ES 3.1 + EXT_color_buffer_half_float: float on, border off without ext.
+	const GlCapabilities es31hf = check("OpenGL ES 3.1 Mesa 24.0.9",
+		"GL_EXT_color_buffer_half_float GL_EXT_texture_norm16", "ES 3.1 + half float");
+	expect(es31hf.rgba16f_renderable, "ES 3.1 + ext: float renderable");
+	expect(!es31hf.clamp_to_border, "ES 3.1 without border ext: clamp_to_border off");
+
+	// ES 3.1 + both border and float extensions.
+	const GlCapabilities es31both = check("OpenGL ES 3.1 Mesa 24.0.9",
+		"GL_EXT_texture_border_clamp GL_EXT_color_buffer_half_float", "ES 3.1 + both");
+	expect(es31both.clamp_to_border && es31both.rgba16f_renderable, "ES 3.1 + both: on");
+
+	// ES 3.0 (RPi4 VideoCore): nothing optional available.
+	const GlCapabilities es30 = check("OpenGL ES 3.1 Mesa v3d-drm-fk-v6.4.14", nullptr, "ES 3.1 bare");
+	expect(!es30.clamp_to_border && !es30.rgba16f_renderable && !es30.framebuffer_srgb,
+		"ES 3.1 bare: optional features off");
+
+	// ES 1.x-style string parses without crashing and stays minimal.
+	const GlCapabilities es11 = check("OpenGL ES-CM 1.1", nullptr, "ES 1.1");
+	expect(es11.is_gles && !es11.clamp_to_border && !es11.rgba16f_renderable, "ES 1.1: minimal");
+
+	// Extensions must be ignored on desktop paths (no false-positive matches).
+	const GlCapabilities desk33ext = check("3.3 (Core Profile) Mesa 24.0.9",
+		"GL_EXT_texture_border_clamp GL_EXT_color_buffer_half_float", "desktop 3.3 + ext noise");
+	expect(desk33ext.clamp_to_border && desk33ext.rgba16f_renderable, "desktop 3.3: unchanged by exts");
+
+	if (failures > 0) {
+		std::cerr << failures << " gl_capability_classify failure(s)\n";
+		return 1;
+	}
+	std::cout << "gl_capability_classify: all checks passed\n";
+	return 0;
+}

--- a/tests/test_crt_gpu_allowlist.sh
+++ b/tests/test_crt_gpu_allowlist.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cxx="${CXX:-c++}"
+out="${TMPDIR:-/tmp}/crt_gpu_allowlist_test.$$"
+trap 'rm -f "$out"' EXIT
+
+"$cxx" -std=c++17 -Wall -Wextra -Werror \
+	-Isrc -Isrc/osdep \
+	-o "$out" \
+	tests/crt_gpu_allowlist_test.cpp \
+	src/osdep/crt_gpu_allowlist.cpp
+"$out"

--- a/tests/test_gl_capability_classify.sh
+++ b/tests/test_gl_capability_classify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cxx="${CXX:-c++}"
+out="${TMPDIR:-/tmp}/gl_capability_classify_test.$$"
+trap 'rm -f "$out"' EXIT
+
+"$cxx" -std=c++17 -Wall -Wextra -Werror \
+	-Isrc -Isrc/osdep \
+	-o "$out" \
+	tests/gl_capability_classify_test.cpp \
+	src/osdep/gl_capability_classify.cpp
+"$out"


### PR DESCRIPTION
Changes proposed in this pull request:

- GL/GLES feature gates (float framebuffers, border-color wrap, sRGB write conversion) now follow the actual driver at runtime instead of compile-time platform guesses, via a new `GlCapabilities` detection layer.
- Shader presets load on strict and GLES drivers: the spec-invalid `GL_RGBA16F`/`GL_UNSIGNED_BYTE` allocation is fixed (`GL_HALF_FLOAT`), and an FBO-completeness fallback downgrades float/sRGB passes to RGBA8 with a logged warning instead of rejecting the whole preset.
- `GL_CLAMP_TO_BORDER` is honored when the context supports it (desktop GL always, ES 3.2+/extension); `GL_FRAMEBUFFER_SRGB` is only toggled on desktop GL >= 3.0 (conversion is automatic on ES, where the old unconditional call raised `GL_INVALID_ENUM`).
- The GL context-request ladder is reworked: iOS and `USE_GLES` builds now always request ES (previously only KMSDRM did — iOS silently requested desktop GL), and Linux/FreeBSD builds gain a last-resort ES 3.0 tier (`AMIBERRY_GLES_FALLBACK`) for hosts whose only hardware driver is GLES. No extra link-time dependency: SDL loads libGLESv2 via EGL.
- When every GL context attempt fails (e.g. VMs stuck on GDI Generic GL 1.1), Amiberry now demotes to the SDL software renderer and keeps running instead of aborting. Demotion force-destroys the GL-flagged window and verifies the SDL renderer exists before reporting success; the GUI follows automatically via its existing renderer-type probe.
- Full-quality CRT shaders are now selected by a GPU renderer-string allowlist (RPi5, Mali-G+, Adreno 6xx+, Apple, Tegra) instead of "any ES context is mobile", so capable hardware no longer gets the simplified path; the on-screen joystick overlay also survives demotion.
- The capability classifier and GPU allowlist are pure functions in their own files with table-driven unit tests (`tests/test_gl_capability_classify.sh`, `tests/test_crt_gpu_allowlist.sh`), following the existing standalone test pattern.

## Verification

- Windows x64 (llvm-mingw + vcpkg): clean configure and full build; `Amiberry.exe` launches, runs the GUI with a GL context, and exits cleanly.
- Both new table tests pass (20-case GPU allowlist, 11-case capability classifier).
- Five-persona code review (correctness, testing, maintainability, reliability, adversarial): 10 findings, all applied and verified in this PR; receipt `status: complete`, artifacts under `out/ce-code-review/20260825-1543-7f3a/`. The top finding (demotion black screen in full-window/no-WM modes) was independently reported by three reviewers and is covered by the forced window destroy + SDL renderer existence gate.
- Not exercised locally: KMSDRM/iOS/Android runtime paths (no hardware here); ES fallback tier needs a GLES-only X11/Wayland host to observe modes 4/5.

## Known Residuals

- ES fallback tier assumes glvnd dispatches direct libGL entry calls into an EGL GLES context; non-glvnd hosts could misbehave.
- `GlCapabilities` is cached once per process; re-creating a context under a different API class within one process would read the first snapshot (not reachable through the current ladder).
- The FBO format downgrade (float/sRGB -> RGBA8) is logged but not surfaced in the GUI.

## Post-Deploy Monitoring & Validation

- Log search terms: `GL capabilities:` (capability snapshot at startup), `Demoting monitor` (GL-to-SDL demotion fired), `downgraded to fallback` (preset format downgrade), `Requesting OpenGL ES 3.0 context` with `mode=4`/`mode=5` (ES fallback tier in use).
- Healthy signals: presets with `float_framebuffer=true` still load on ES 3.2/EXT_color_buffer_half_float devices; capable-GPU devices (RPi5, modern phones) show full-quality CRT output.
- Failure signals / rollback: black screen or abort on GL-less VMs would indicate a demotion regression; preset load failures (`FBO incomplete`) recurring would indicate a fallback-chain regression. Revert this commit to restore prior behavior.
- Validation window: first few days of user reports after release; owner: maintainer.

@midwan

