### PR TITLE
fix(input): don't feed the virtual mouse driver table when disabled

### DIFF
--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -3435,6 +3435,14 @@ static void mousehack_helper (uae_u32 buttonmask)
 		return;
 	}
 
+	// The virtual mouse driver must actually be in use. The guest driver task
+	// is installed unconditionally since "support virtual mouse driver on the
+	// fly change" (it no longer gates on this trap returning 0), so feeding it
+	// events with magic mouse alone would move the guest pointer to the stale
+	// lastmx/lastmy (0,0 after startup) on every button event.
+	if (currprefs.input_tablet == TABLET_OFF) {
+		return;
+	}
 	if (!(currprefs.input_mouse_untrap & MOUSEUNTRAP_MAGIC) && currprefs.input_tablet < TABLET_MOUSEHACK) {
 		return;
 	}


### PR DESCRIPTION
Changes proposed in this pull request:

- With magic mouse enabled and the virtual mouse driver disabled, clicking the left mouse button snapped the guest pointer to the top-left corner of the emulated screen (visible on RTG screens; masked on native screens by the relative port stream).
- Root cause: since the WinUAE 101b95d merge ("Support virtual mouse driver on the fly change"), the guest driver task is installed even when the driver is disabled. With the driver off, motion never updates `lastmx/lastmy`, so the first button event woke the pending task and delivered `IECLASS_POINTERPOS(0,0)` — Intuition clamps the negative coordinates to 0.
- Fix: `mousehack_helper` now returns early when `input_tablet == TABLET_OFF`. The mousehack table is never written and `MH_ACTIVE` is never set, so the pending task stays inert and `mousehack_alive()` stays 0, matching pre-merge behavior. On-the-fly enabling of the driver still works: the first absolute motion event after enabling runs `mousehack_enable()` and events flow again.

Verification: reproduced on the A4000 config (ZZ9000 RTG, Workbench) — before, the log showed the driver task waking at first-click time and the pointer snapping; after, the task is never signaled and clicks behave as before the merge. With `absolute_mouse=mousehack` enabled, pointer tracking and clicks work unchanged.

@midwan
