### PR TITLE
feat(gui): add custom cartridge ROM support; port WinUAE a4720553

### DIFF
--- a/src/ar.cpp
+++ b/src/ar.cpp
@@ -1685,7 +1685,7 @@ int action_replay_load (void)
 #endif
 
 	struct romdata *rd = getromdatabypath(currprefs.cartfile);
-	TCHAR *ident = currprefs.cartident;
+	const TCHAR *ident = currprefs.cartident;
 	if (ident[0] == ':') {
 		ident++;
 	} else {

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -2012,7 +2012,9 @@ static bool load_kickstart_replacement(void)
 		currprefs.z3fastmem[0].size == 0 &&
 		currprefs.mbresmem_high.size == 0 &&
 		currprefs.mbresmem_low.size == 0 &&
-		currprefs.cpuboardmem1.size == 0) {
+		currprefs.cpuboardmem1.size == 0 &&
+		extendedkickmem2a_bank.allocated_size == 0 &&
+		extendedkickmem2b_bank.allocated_size == 0) {
 
 		changed_prefs.custom_memory_addrs[0] = currprefs.custom_memory_addrs[0] = 0xa80000;
 		changed_prefs.custom_memory_sizes[0] = currprefs.custom_memory_sizes[0] = 512 * 1024;
@@ -2190,13 +2192,13 @@ static int load_kickstart (void)
 					maxsize = zfile_size32(zf);
 					singlebigrom = true;
 					extendedkickmem2a_bank.reserved_size = 524288;
-					extendedkickmem2a_bank.mask = extendedkickmem2a_bank.allocated_size - 1;
 					extendedkickmem2a_bank.start = size > 2 * ROM_SIZE_512 ? 0xa00000 : 0xa80000;
 					mapped_malloc(&extendedkickmem2a_bank);
+					extendedkickmem2a_bank.mask = extendedkickmem2a_bank.allocated_size - 1;
 					extendedkickmem2b_bank.reserved_size = 524288;
-					extendedkickmem2b_bank.mask = extendedkickmem2a_bank.allocated_size - 1;
 					extendedkickmem2b_bank.start = extendedkickmem2a_bank.start + 524288;
 					mapped_malloc(&extendedkickmem2b_bank);
+					extendedkickmem2b_bank.mask = extendedkickmem2a_bank.allocated_size - 1;
 					read_kickstart(f, extendedkickmem2a_bank.baseaddr, 524288, 0, 1);
 					read_kickstart(f, extendedkickmem2b_bank.baseaddr, 524288, 0, 1);
 					memset(kickmem_bank.baseaddr, 0, ROM_SIZE_512);

--- a/src/osdep/imgui/rom.cpp
+++ b/src/osdep/imgui/rom.cpp
@@ -207,9 +207,13 @@ void render_panel_rom()
 	EndGroupBox("Advanced Custom ROM Settings");
 
 	BeginGroupBox("Miscellaneous");
+	static bool custom_cart_enabled = false;
+	static char custom_cart_derived_from[MAX_DPATH] = "";
+	static bool custom_cart_local_edit = false;
 	ImGui::Text("Cartridge ROM File:");
 	ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - browse_btn_w - spacing * 2);
-	RomCombo("##CartRomCombo", changed_prefs.cartfile, MAX_DPATH, cart_rom_list, changed_prefs.cartident, sizeof(changed_prefs.cartident));
+	if (RomCombo("##CartRomCombo", changed_prefs.cartfile, MAX_DPATH, cart_rom_list, changed_prefs.cartident, sizeof(changed_prefs.cartident)))
+		custom_cart_local_edit = true;
 	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActive());
 	if (ImGui::IsItemHovered()) ImGui::SetTooltip("%s", changed_prefs.cartfile);
 	ImGui::SameLine();
@@ -218,24 +222,28 @@ void render_panel_rom()
 		OpenFileDialogKey("ROM", "Select Cartridge ROM", ".rom,.bin,.a1000,.a500,.a600,.a1200,.a3000,.a4000,.cdtv,.cd32", get_rom_path());
 	}
 
-	static bool custom_cart_enabled = false;
-	static bool custom_cart_init = false;
-	if (!custom_cart_init) {
-		custom_cart_init = true;
-		bool known_cart = false;
-		for (const auto& entry : cart_rom_list) {
-			if (entry.path == changed_prefs.cartfile) {
-				known_cart = true;
-				break;
+	if (strcmp(custom_cart_derived_from, changed_prefs.cartfile) != 0) {
+		snprintf(custom_cart_derived_from, sizeof(custom_cart_derived_from), "%s", changed_prefs.cartfile);
+		if (!custom_cart_local_edit) {
+			// The cartridge path changed outside this panel (config load, GUI
+			// reopen): re-derive custom mode from the new value.
+			bool known_cart = false;
+			for (const auto& entry : cart_rom_list) {
+				if (entry.path == changed_prefs.cartfile) {
+					known_cart = true;
+					break;
+				}
 			}
+			custom_cart_enabled = changed_prefs.cartfile[0] != 0 && !known_cart;
 		}
-		custom_cart_enabled = changed_prefs.cartfile[0] != 0 && !known_cart;
 	}
+	custom_cart_local_edit = false;
 	AmigaCheckbox("Custom Cartridge ROM", &custom_cart_enabled);
 	ShowHelpMarker("Use an arbitrary cartridge ROM file. For custom dumps, set the identifier (e.g. :DeMoNv1) so the core can recognize it.");
 	if (custom_cart_enabled) {
 		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - browse_btn_w - spacing * 2);
-		AmigaInputText("##CartFileCustom", changed_prefs.cartfile, MAX_DPATH);
+		if (AmigaInputText("##CartFileCustom", changed_prefs.cartfile, MAX_DPATH))
+			custom_cart_local_edit = true;
 		ImGui::SameLine();
 		if (AmigaButton("...##CartFileCustomButton")) {
 			current_pick_type = RomPickType::Cartridge;
@@ -310,10 +318,23 @@ void render_panel_rom()
 			case RomPickType::Extended:
 				strncpy(changed_prefs.romextfile, file_dialog_result.c_str(), MAX_DPATH);
 				break;
-			case RomPickType::Cartridge:
+			case RomPickType::Cartridge: {
 				strncpy(changed_prefs.cartfile, file_dialog_result.c_str(), MAX_DPATH);
 				custom_cart_enabled = true;
+				custom_cart_local_edit = true;
+				// Re-sync the identifier with the newly picked file: a scanned
+				// dump carries its romdata configname, anything else gets a clean
+				// slate so a stale ident can't mis-type an unrecognized ROM.
+				std::string cartident;
+				for (const auto& entry : cart_rom_list) {
+					if (entry.path == file_dialog_result) {
+						cartident = entry.ident;
+						break;
+					}
+				}
+				snprintf(changed_prefs.cartident, sizeof(changed_prefs.cartident), "%s", cartident.c_str());
 				break;
+			}
 			case RomPickType::Flash:
 				strncpy(changed_prefs.flashfile, file_dialog_result.c_str(), MAX_DPATH);
 				break;

--- a/src/osdep/imgui/rom.cpp
+++ b/src/osdep/imgui/rom.cpp
@@ -11,6 +11,7 @@
 struct RomListEntry {
 	std::string name;
 	std::string path;
+	std::string ident;
 };
 
 static std::vector<RomListEntry> main_rom_list;
@@ -42,7 +43,7 @@ static void update_rom_list(std::vector<RomListEntry>& list, int romtype_mask) {
 			const char* name = rl[i].rd->name;
 			const char* path = rl[i].path;
 			if (path && *path) {
-				list.push_back({ name ? name : path, path });
+				list.push_back({ name ? name : path, path, rl[i].rd->configname ? (std::string(":") + rl[i].rd->configname) : "" });
 			}
 		}
 	}
@@ -56,7 +57,7 @@ static void InitializeROMLists() {
 	roms_initialized = true;
 }
 
-static bool RomCombo(const char* label, char* current_path, int max_len, std::vector<RomListEntry>& list) {
+static bool RomCombo(const char* label, char* current_path, int max_len, std::vector<RomListEntry>& list, char* ident = nullptr, int ident_len = 0) {
 	std::string preview_value = "Select ROM...";
 	bool match_found = false;
 	bool value_changed = false;
@@ -83,6 +84,9 @@ static bool RomCombo(const char* label, char* current_path, int max_len, std::ve
 			ImGui::PushID(entry.path.c_str());
 			if (ImGui::Selectable(entry.name.c_str(), is_selected)) {
 				strncpy(current_path, entry.path.c_str(), max_len);
+				if (ident && ident_len > 0) {
+					strncpy(ident, entry.ident.c_str(), ident_len);
+				}
 				value_changed = true;
 			}
 			ImGui::PopID();
@@ -205,13 +209,42 @@ void render_panel_rom()
 	BeginGroupBox("Miscellaneous");
 	ImGui::Text("Cartridge ROM File:");
 	ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - browse_btn_w - spacing * 2);
-	RomCombo("##CartRomCombo", changed_prefs.cartfile, MAX_DPATH, cart_rom_list);
+	RomCombo("##CartRomCombo", changed_prefs.cartfile, MAX_DPATH, cart_rom_list, changed_prefs.cartident, sizeof(changed_prefs.cartident));
 	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActive());
 	if (ImGui::IsItemHovered()) ImGui::SetTooltip("%s", changed_prefs.cartfile);
 	ImGui::SameLine();
 	if (AmigaButton("...##CartRomFileButton")) {
 		current_pick_type = RomPickType::Cartridge;
 		OpenFileDialogKey("ROM", "Select Cartridge ROM", ".rom,.bin,.a1000,.a500,.a600,.a1200,.a3000,.a4000,.cdtv,.cd32", get_rom_path());
+	}
+
+	static bool custom_cart_enabled = false;
+	static bool custom_cart_init = false;
+	if (!custom_cart_init) {
+		custom_cart_init = true;
+		bool known_cart = false;
+		for (const auto& entry : cart_rom_list) {
+			if (entry.path == changed_prefs.cartfile) {
+				known_cart = true;
+				break;
+			}
+		}
+		custom_cart_enabled = changed_prefs.cartfile[0] != 0 && !known_cart;
+	}
+	AmigaCheckbox("Custom Cartridge ROM", &custom_cart_enabled);
+	ShowHelpMarker("Use an arbitrary cartridge ROM file. For custom dumps, set the identifier (e.g. :DeMoNv1) so the core can recognize it.");
+	if (custom_cart_enabled) {
+		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - browse_btn_w - spacing * 2);
+		AmigaInputText("##CartFileCustom", changed_prefs.cartfile, MAX_DPATH);
+		ImGui::SameLine();
+		if (AmigaButton("...##CartFileCustomButton")) {
+			current_pick_type = RomPickType::Cartridge;
+			OpenFileDialogKey("ROM", "Select Cartridge ROM", ".rom,.bin,.a1000,.a500,.a600,.a3000,.a4000,.cdtv,.cd32", get_rom_path());
+		}
+		ImGui::Text("Cartridge identifier:");
+		ImGui::SetNextItemWidth(BUTTON_WIDTH * 2);
+		AmigaInputText("##CartIdent", changed_prefs.cartident, sizeof(changed_prefs.cartident));
+		if (ImGui::IsItemHovered()) ImGui::SetTooltip("Identifier suffix for custom cartridge dumps, e.g. :DeMoNv1, :DeMoNv2, :SuperIV, :XPower or :NPower");
 	}
 
 	ImGui::Text("Flash RAM or A2286/A2386SX BIOS CMOS RAM file:");
@@ -279,6 +312,7 @@ void render_panel_rom()
 				break;
 			case RomPickType::Cartridge:
 				strncpy(changed_prefs.cartfile, file_dialog_result.c_str(), MAX_DPATH);
+				custom_cart_enabled = true;
 				break;
 			case RomPickType::Flash:
 				strncpy(changed_prefs.flashfile, file_dialog_result.c_str(), MAX_DPATH);


### PR DESCRIPTION
Fixes #

Custom cartridge ROMs can now be configured from the GUI, matching WinUAE's option, and the two missing hunks of upstream commit a4720553 are ported into memory.cpp.

Changes proposed in this pull request:
- The ROM panel gains a "Custom Cartridge ROM" checkbox that reveals a path field and a cartridge identifier field for arbitrary or undiscovered cart dumps; browsing for a cart file auto-enables it
- Selecting a known cart from the combo now carries its romdata configname into `changed_prefs.cartident` (e.g. `:NPower`, `:DeMoNv1`), so magic-detected freezer dumps get the identifier Action Replay handling expects instead of falling through to generic AR3
- Ports WinUAE a4720553, completing that upstream commit in amiberry: `load_kickstart_replacement()` also requires both extended kick banks (2a/2b) to be unallocated, and the singlebigrom path sets bank masks after `mapped_malloc` so they reflect the actual allocation
- `action_replay_load()`: make ident pointer const-correct

Design notes:
- The identifier input field goes beyond strict WinUAE GUI parity (upstream has checkbox + path only; the ident is set by hand-editing cfg as `cart=path:DeMoNv1`). It is included because the amiberry GUI has no other way to set `cartident`, which custom or undiscovered DeMoN dumps require.
- The combo-to-ident glue stores the ident with a leading colon, matching upstream `getromfile` (`:%s`); `decode_rom_ident` treats `:`-prefixed idents as opaque.
- The checkbox is session-static state derived on first render; upstream's is dialog-local derived state, and immediate mode needs a persistent bool.

Validation: built and exercised the real GUI — rescan detected a staged cart ROM, combo selection populated path + `:NPower` ident, Save As serialized `cart_file=` + `cart=:NPower`, and emulation booted cleanly with the cart config. The memory.cpp hunks are verbatim from upstream a4720553.

@midwan
