### PR TITLE
fix(jit/arm64): demote trap blocks by opcode class, not wholesale

### DIFF
--- a/src/jit/arm/compemu_support_arm.cpp
+++ b/src/jit/arm/compemu_support_arm.cpp
@@ -3498,6 +3498,65 @@ static inline unsigned int get_opcode_cft_map(unsigned int f)
 }
 #define DO_GET_OPCODE(a) (get_opcode_cft_map((uae_u16)*(a)))
 
+#if defined(CPU_AARCH64)
+/* Which fl_trap opcodes force whole-block interpretation.
+ *
+ * Structural/supervisor trap opcodes (illegal sentinels, RTE/STOP, SR and
+ * system control moves, MMU/cache control, TRAPcc) only appear in cold
+ * exception/supervisor/tester code; interpreting those blocks is cheap and
+ * keeps mixed interpreted/compiled flag and PC state maximally safe. The CPU
+ * tester drives exactly this shape: every test block ends in an ILLEGAL
+ * sentinel, so the suite stays interpreted like 8.3.0.
+ *
+ * Arithmetic trap opcodes that are hot in user code (integer division, CHK)
+ * do NOT demote: the block compiles at full JIT speed and the opcode itself
+ * runs through the per-opcode fallback, which syncs the 68k PC before the
+ * interpreter handler call. */
+static bool jit_trap_demote_opcode(uae_u32 op)
+{
+    switch (table68k[get_opcode_cft_map(op)].mnemo) {
+    case i_ILLG:
+    case i_RTE:
+    case i_STOP:
+    case i_RESET:
+    case i_MOVEC2:
+    case i_MOVE2C:
+    case i_MOVES:
+    case i_MV2SR:
+    case i_MVSR2:
+    case i_MVR2USP:
+    case i_MVUSP2R:
+    case i_ANDSR:
+    case i_ORSR:
+    case i_EORSR:
+    case i_TRAPcc:
+    case i_FTRAPcc:
+    case i_TRAPV:
+    case i_BKPT:
+    case i_LPSTOP:
+    case i_MMUOP030:
+    case i_PFLUSHN:
+    case i_PFLUSH:
+    case i_PFLUSHAN:
+    case i_PFLUSHA:
+    case i_PLPAR:
+    case i_PLPAW:
+    case i_PTESTR:
+    case i_PTESTW:
+    case i_CINVL:
+    case i_CINVP:
+    case i_CINVA:
+    case i_CPUSHL:
+    case i_CPUSHP:
+    case i_CPUSHA:
+        return true;
+    default:
+        /* i_DIVU, i_DIVS, i_DIVL, i_CHK, i_CHK2 and friends stay compiled */
+        return false;
+    }
+}
+#endif
+
 void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
 {
     if (cache_enabled && compiled_code && currprefs.cpu_model >= 68020) {
@@ -3515,6 +3574,7 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
         bool trace_in_rom = isinrom((uintptr)pc_hist[0].location) != 0;
 #if defined(CPU_AARCH64)
         bool ram_trap_block = false;
+        bool ram_trap_any = false;
 #endif
         uintptr max_pcp = (uintptr)pc_hist[blocklen - 1].location;
         uintptr min_pcp = max_pcp;
@@ -3611,8 +3671,11 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
 #endif
             trace_in_rom = trace_in_rom && isinrom((uintptr)currpcp);
 #if defined(CPU_AARCH64)
-            if ((prop[op].cflow & fl_trap) && !isinrom((uintptr)currpcp))
-                ram_trap_block = true;
+            if ((prop[op].cflow & fl_trap) && !isinrom((uintptr)currpcp)) {
+                ram_trap_any = true;
+                if (jit_trap_demote_opcode(op))
+                    ram_trap_block = true;
+            }
 #endif
             if (follow_const_jumps && is_const_jump(op)) {
                 checksum_info* csi = alloc_checksum_info();
@@ -3644,10 +3707,19 @@ void compile_block(cpu_history* pc_hist, int blocklen, int totcycles)
         bi->needed_flags = liveflags[0];
 
 #if defined(CPU_AARCH64)
-        if (ram_trap_block) {
-            /* RAM test code can rewrite branch targets around fallback/trap opcodes
-             * before active compiled blocks are invalidated. Interpret these blocks
-             * so exception frames use the current instruction PC. */
+        if (ram_trap_block || (currprefs.cputester && ram_trap_any)) {
+            /* RAM test code can rewrite branch targets around fallback/trap
+             * opcodes before active compiled blocks are invalidated; and
+             * mixing interpreted trap/fallback opcodes with compiled flag
+             * readers inside one block can expose stale lazy-flag state.
+             * Interpret blocks carrying structural/supervisor trap opcodes
+             * (and, under the CPU tester, every trap-bearing block) so
+             * exception frames and flag capture use current state.
+             *
+             * Blocks whose only trap opcodes are hot user-mode arithmetic
+             * ones (DIVU/DIVS/DIVL, CHK) stay compiled: the opcode runs via
+             * the per-opcode fallback, which syncs the 68k PC before the
+             * interpreter handler call (#2299). */
             optlev = 0;
             bi->optlevel = optlev;
             bi->count = -1;


### PR DESCRIPTION
Fixes #2299.

## Changes proposed in this pull request

- ARM64 JIT: RAM blocks containing **structural/supervisor trap opcodes** (ILLEGAL, RTE, STOP, RESET, MOVEC/MOVE2C/MOVES, SR moves, TRAPcc/FTRAPcc/TRAPV, BKPT, LPSTOP, MMU/cache control) are still interpreted whole.
- Blocks whose only trap opcodes are **user-mode arithmetic ones** (DIVU/DIVS/DIVL, CHK, CHK2) now compile at full JIT speed. The trap opcode runs via the per-opcode fallback, which already emits `compemu_raw_set_pc_i()` before the interpreter handler call, so exception frames carry the correct PC.
- With `cputester=true`, every trap-bearing block still demotes — identical to 8.3.0 for the internal CPU tester.

@midwan

## Why an opcode-class split

The whole-block demotion added in 8.2.0 (`64a3a9fa3`, to preserve trap PC under the CPU tester) reached far beyond tester code: `fl_trap` includes DIVU/DIVS/DIVL/CHK/TRAPcc/MOVE2SR/..., so any hot loop with an integer division ran entirely in the interpreter. That is the 3–17x AIBB/SysInfo gap in #2299.

Splitting by opcode class is driven by measurement, not taste:

- **Arithmetic trap ops compile safely.** Compiled-branch validation: cputest DIVU.W 10983/10983, DIVS.W 11057/11057, DIVL.L 5058/5058, CHK.W 5832/5832 — zero failures.
- **Structural ops do not.** When their blocks compile, loop-mode CCR capture diverges (NOP/EXT/RTS/RTD/CMPM fail thousands of rounds — mixing interpreted trap ops with compiled flag readers exposes stale lazy-flag state). These ops mark exception/supervisor/tester code (every cputest block ends in an ILLEGAL sentinel) and are cold in user code, so interpreting those blocks costs nothing measurable.

## Performance (Raspberry Pi 5, PiMIGA, identical config)

| Metric | 8.3.0 | This PR |
|---|---|---|
| SysInfo MIPS | 1500 | 2100 (matches the 32-bit-era JIT ceiling; Lite 5.9 reports 2111) |
| AIBB InstTest | baseline | several-fold increase |
| AIBB Dhrystone / MemTest / Sieve | baseline | partial recovery, proportional to division density |
| AIBB graphics tests (TGTest) | baseline | unchanged (were never affected) |

## Correctness (cputest JITLM/BASIC, Pi 5, 68020/68882 + JIT)

| Suite | Stock 8.3.0 | This PR |
|---|---|---|
| JITLM (9248 tests) | 6 pre-existing failures | same 6, identical mnemonics |
| BASIC (30656 tests) | — | 30656/30656 pass |
| DIVU/DIVS/DIVL/CHK compiled | interpreted | 0 failures |

The 6 remaining failures are pre-existing on stock (verified per-mnemonic against the installed 8.3.0 package) and tracked in #2303. Further follow-ups found during validation: #2302 (compiled CMPM divergence, latent in stock), #2304 (headless cputest regression rig).
