### PR TITLE
feat(android): expose analog stick mouse map in the native UI

### DIFF
--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/AndroidControlSettings.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/AndroidControlSettings.kt
@@ -31,7 +31,9 @@ object AndroidControlSettings {
 				settings.onScreenKeyboardNumpad
 			} else {
 				fallback.onScreenKeyboardNumpad
-			}
+			},
+			joyport0MouseMap = if ("joyport0mousemap" in keys) settings.joyport0MouseMap else fallback.joyport0MouseMap,
+			joyport1MouseMap = if ("joyport1mousemap" in keys) settings.joyport1MouseMap else fallback.joyport1MouseMap
 		)
 	}
 }

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/AndroidLaunchConfig.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/AndroidLaunchConfig.kt
@@ -58,7 +58,9 @@ object AndroidLaunchConfig {
 			joyport1 = currentSettings.joyport1,
 			onScreenJoystick = currentSettings.onScreenJoystick,
 			onScreenKeyboard = currentSettings.onScreenKeyboard,
-			onScreenKeyboardNumpad = currentSettings.onScreenKeyboardNumpad
+			onScreenKeyboardNumpad = currentSettings.onScreenKeyboardNumpad,
+			joyport0MouseMap = currentSettings.joyport0MouseMap,
+			joyport1MouseMap = currentSettings.joyport1MouseMap
 		)
 	}
 

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/AppPreferences.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/AppPreferences.kt
@@ -36,7 +36,9 @@ class AppPreferences private constructor(context: Context) {
 			joyport1 = prefs.getString(KEY_LAST_JOYPORT1, DEFAULT_JOYPORT1) ?: DEFAULT_JOYPORT1,
 			onScreenJoystick = prefs.getBoolean(KEY_LAST_ON_SCREEN_JOYSTICK, DEFAULT_ON_SCREEN_JOYSTICK),
 			onScreenKeyboard = prefs.getBoolean(KEY_LAST_ON_SCREEN_KEYBOARD, DEFAULT_ON_SCREEN_KEYBOARD),
-			onScreenKeyboardNumpad = prefs.getBoolean(KEY_LAST_ON_SCREEN_KEYBOARD_NUMPAD, false)
+			onScreenKeyboardNumpad = prefs.getBoolean(KEY_LAST_ON_SCREEN_KEYBOARD_NUMPAD, false),
+			joyport0MouseMap = prefs.getBoolean(KEY_LAST_JOYPORT0_MOUSEMAP, false),
+			joyport1MouseMap = prefs.getBoolean(KEY_LAST_JOYPORT1_MOUSEMAP, false)
 		)
 
 	fun applyRememberedAndroidControls(settings: EmulatorSettings, explicitKeys: Set<String>): EmulatorSettings =
@@ -53,6 +55,8 @@ class AppPreferences private constructor(context: Context) {
 			putBoolean(KEY_LAST_ON_SCREEN_JOYSTICK, settings.onScreenJoystick)
 			putBoolean(KEY_LAST_ON_SCREEN_KEYBOARD, settings.onScreenKeyboard)
 			putBoolean(KEY_LAST_ON_SCREEN_KEYBOARD_NUMPAD, settings.onScreenKeyboardNumpad)
+			putBoolean(KEY_LAST_JOYPORT0_MOUSEMAP, settings.joyport0MouseMap)
+			putBoolean(KEY_LAST_JOYPORT1_MOUSEMAP, settings.joyport1MouseMap)
 		}
 	}
 
@@ -122,6 +126,8 @@ class AppPreferences private constructor(context: Context) {
 		private const val KEY_LAST_ON_SCREEN_JOYSTICK = "last_on_screen_joystick"
 		private const val KEY_LAST_ON_SCREEN_KEYBOARD = "last_on_screen_keyboard"
 		private const val KEY_LAST_ON_SCREEN_KEYBOARD_NUMPAD = "last_on_screen_keyboard_numpad"
+		private const val KEY_LAST_JOYPORT0_MOUSEMAP = "last_joyport0_mousemap"
+		private const val KEY_LAST_JOYPORT1_MOUSEMAP = "last_joyport1_mousemap"
 		private const val KEY_RECENT_LAUNCHES = "recent_launches"
 		private const val KEY_LAUNCH_COUNT = "emulator_launch_count"
 		private const val FIRST_REVIEW_LAUNCH = 5

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigGenerator.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigGenerator.kt
@@ -106,13 +106,10 @@ object ConfigGenerator {
 		}
 		// Persist the Android UI's joyport1 choice for reliable round-trip parsing
 		sb.appendLine("amiberry.android_joyport1=${settings.joyport1}")
-		// Analog stick mouse map (mirrors cfgfile.cpp: only written when enabled)
-		if (settings.joyport0MouseMap) {
-			sb.appendLine("joyport0mousemap=1")
-		}
-		if (settings.joyport1MouseMap) {
-			sb.appendLine("joyport1mousemap=1")
-		}
+		// Analog stick mouse map — always explicit so the disabled state
+		// round-trips and is not overridden by remembered-control fallback
+		sb.appendLine("joyport0mousemap=${if (settings.joyport0MouseMap) "1" else "0"}")
+		sb.appendLine("joyport1mousemap=${if (settings.joyport1MouseMap) "1" else "0"}")
 
 		// Amiberry-specific
 		sb.appendLine("amiberry.onscreen_joystick=${settings.onScreenJoystick.toCfg()}")
@@ -137,13 +134,10 @@ object ConfigGenerator {
 			sb.appendLine("joyport1=${settings.joyport1}")
 		}
 		sb.appendLine("amiberry.android_joyport1=${settings.joyport1}")
-		// Analog stick mouse map (mirrors cfgfile.cpp: only written when enabled)
-		if (settings.joyport0MouseMap) {
-			sb.appendLine("joyport0mousemap=1")
-		}
-		if (settings.joyport1MouseMap) {
-			sb.appendLine("joyport1mousemap=1")
-		}
+		// Analog stick mouse map — always explicit so the disabled state
+		// round-trips and is not overridden by remembered-control fallback
+		sb.appendLine("joyport0mousemap=${if (settings.joyport0MouseMap) "1" else "0"}")
+		sb.appendLine("joyport1mousemap=${if (settings.joyport1MouseMap) "1" else "0"}")
 		sb.appendLine("amiberry.onscreen_joystick=${settings.onScreenJoystick.toCfg()}")
 		sb.appendLine("amiberry.vkbd_enabled=${settings.onScreenKeyboard.toCfg()}")
 		sb.appendLine("amiberry.vkbd_numpad=${settings.onScreenKeyboardNumpad.toCfg()}")

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigGenerator.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigGenerator.kt
@@ -106,6 +106,13 @@ object ConfigGenerator {
 		}
 		// Persist the Android UI's joyport1 choice for reliable round-trip parsing
 		sb.appendLine("amiberry.android_joyport1=${settings.joyport1}")
+		// Analog stick mouse map (mirrors cfgfile.cpp: only written when enabled)
+		if (settings.joyport0MouseMap) {
+			sb.appendLine("joyport0mousemap=1")
+		}
+		if (settings.joyport1MouseMap) {
+			sb.appendLine("joyport1mousemap=1")
+		}
 
 		// Amiberry-specific
 		sb.appendLine("amiberry.onscreen_joystick=${settings.onScreenJoystick.toCfg()}")
@@ -130,6 +137,13 @@ object ConfigGenerator {
 			sb.appendLine("joyport1=${settings.joyport1}")
 		}
 		sb.appendLine("amiberry.android_joyport1=${settings.joyport1}")
+		// Analog stick mouse map (mirrors cfgfile.cpp: only written when enabled)
+		if (settings.joyport0MouseMap) {
+			sb.appendLine("joyport0mousemap=1")
+		}
+		if (settings.joyport1MouseMap) {
+			sb.appendLine("joyport1mousemap=1")
+		}
 		sb.appendLine("amiberry.onscreen_joystick=${settings.onScreenJoystick.toCfg()}")
 		sb.appendLine("amiberry.vkbd_enabled=${settings.onScreenKeyboard.toCfg()}")
 		sb.appendLine("amiberry.vkbd_numpad=${settings.onScreenKeyboardNumpad.toCfg()}")

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigParser.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/ConfigParser.kt
@@ -35,6 +35,7 @@ object ConfigParser {
 		"amiberry.gfx_correct_aspect", "amiberry.gfx_auto_crop",
 		"scaling_method", "amiberry.scaling_method", "gfx_autoresolution", "amiberry.shader",
 		"joyport0", "joyport1",
+		"joyport0mousemap", "joyport1mousemap",
 		"amiberry.onscreen_joystick", "amiberry.vkbd_enabled", "amiberry.vkbd_numpad", "input.default_osk",
 		"amiberry.android_joyport1",
 		"use_gui", "config_description", "config_hardware_path"
@@ -165,7 +166,9 @@ object ConfigParser {
 			},
 			onScreenJoystick = kv["amiberry.onscreen_joystick"].toBool(true),
 			onScreenKeyboard = kv["amiberry.vkbd_enabled"]?.toBool(true) ?: kv["input.default_osk"].toBool(true),
-			onScreenKeyboardNumpad = kv["amiberry.vkbd_numpad"].toBool(false)
+			onScreenKeyboardNumpad = kv["amiberry.vkbd_numpad"].toBool(false),
+			joyport0MouseMap = (kv["joyport0mousemap"]?.toIntOrNull() ?: 0) > 0,
+			joyport1MouseMap = (kv["joyport1mousemap"]?.toIntOrNull() ?: 0) > 0
 		)
 	}
 

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchRequest.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchRequest.kt
@@ -103,7 +103,9 @@ sealed interface LaunchRequest {
 		val joyport1: String,
 		val onScreenJoystick: Boolean,
 		val onScreenKeyboard: Boolean,
-		val onScreenKeyboardNumpad: Boolean = false
+		val onScreenKeyboardNumpad: Boolean = false,
+		val joyport0MouseMap: Boolean = false,
+		val joyport1MouseMap: Boolean = false
 	) {
 		fun toArgs(): List<String> {
 			val args = mutableListOf("-s", "joyport0=$joyport0")
@@ -119,6 +121,14 @@ sealed interface LaunchRequest {
 					"-s", "input.default_osk=${onScreenKeyboard.toCfg()}"
 				)
 			)
+			if (joyport0MouseMap) {
+				args.add("-s")
+				args.add("joyport0mousemap=1")
+			}
+			if (joyport1MouseMap) {
+				args.add("-s")
+				args.add("joyport1mousemap=1")
+			}
 
 			return args
 		}
@@ -130,7 +140,9 @@ sealed interface LaunchRequest {
 					joyport1 = settings.joyport1,
 					onScreenJoystick = settings.onScreenJoystick,
 					onScreenKeyboard = settings.onScreenKeyboard,
-					onScreenKeyboardNumpad = settings.onScreenKeyboardNumpad
+					onScreenKeyboardNumpad = settings.onScreenKeyboardNumpad,
+					joyport0MouseMap = settings.joyport0MouseMap,
+					joyport1MouseMap = settings.joyport1MouseMap
 				)
 		}
 	}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchRequest.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/LaunchRequest.kt
@@ -121,14 +121,12 @@ sealed interface LaunchRequest {
 					"-s", "input.default_osk=${onScreenKeyboard.toCfg()}"
 				)
 			)
-			if (joyport0MouseMap) {
-				args.add("-s")
-				args.add("joyport0mousemap=1")
-			}
-			if (joyport1MouseMap) {
-				args.add("-s")
-				args.add("joyport1mousemap=1")
-			}
+			// Mouse map overrides are always explicit (0 or 1) so a backing
+			// config's enabled value cannot survive a disabled switch
+			args.add("-s")
+			args.add("joyport0mousemap=${if (joyport0MouseMap) "1" else "0"}")
+			args.add("-s")
+			args.add("joyport1mousemap=${if (joyport1MouseMap) "1" else "0"}")
 
 			return args
 		}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/WhdLoadAutoConfig.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/WhdLoadAutoConfig.kt
@@ -119,9 +119,10 @@ object WhdLoadAutoConfig {
 			joyport1 = currentSettings.joyport1,
 			onScreenJoystick = currentSettings.onScreenJoystick,
 			onScreenKeyboard = currentSettings.onScreenKeyboard,
-			onScreenKeyboardNumpad = currentSettings.onScreenKeyboardNumpad
+			onScreenKeyboardNumpad = currentSettings.onScreenKeyboardNumpad,
+			joyport0MouseMap = currentSettings.joyport0MouseMap,
+			joyport1MouseMap = currentSettings.joyport1MouseMap
 		)
-
 		settings = applyHardware(settings, hardware, a600Available, useAgaCpuProfile = isAga || isCd32)
 
 		return EmulatorSettingsConstraints.apply(settings, hasTouchScreen = hasTouchScreen)

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettings.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettings.kt
@@ -69,7 +69,9 @@ data class EmulatorSettings(
 	val joyport1: String = "onscreen_joy",
 	val onScreenJoystick: Boolean = true,
 	val onScreenKeyboard: Boolean = true,
-	val onScreenKeyboardNumpad: Boolean = false
+	val onScreenKeyboardNumpad: Boolean = false,
+	val joyport0MouseMap: Boolean = false,  // left analog stick + shoulders act as the Amiga mouse
+	val joyport1MouseMap: Boolean = false
 ) {
 	companion object {
 		/** Create settings from an AmigaModel with sensible defaults. */

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettingsConstraints.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettingsConstraints.kt
@@ -104,6 +104,15 @@ object EmulatorSettingsConstraints {
 			result = result.copy(joyport1 = normalizedJoyport1, onScreenJoystick = false)
 		}
 
+		// The analog mouse map needs a physical controller on the port;
+		// clear stale flags when the port holds some other device
+		if (result.joyport0MouseMap && result.joyport0 !in JOYSTICK_DEVICES) {
+			result = result.copy(joyport0MouseMap = false)
+		}
+		if (result.joyport1MouseMap && result.joyport1 !in JOYSTICK_DEVICES) {
+			result = result.copy(joyport1MouseMap = false)
+		}
+
 		return result
 	}
 
@@ -155,6 +164,7 @@ object EmulatorSettingsConstraints {
 	private const val FLOPPY_TYPE_DISABLED = -1
 	private const val FLOPPY_TYPE_DD = 0
 	private const val FLOPPY_TYPE_HD = 1
+	private val JOYSTICK_DEVICES = setOf("joy0", "joy1")
 	private val ANDROID_PORT_INPUT_DEVICES = setOf(
 		"none",
 		"mouse",

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettingsConstraints.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/EmulatorSettingsConstraints.kt
@@ -104,12 +104,14 @@ object EmulatorSettingsConstraints {
 			result = result.copy(joyport1 = normalizedJoyport1, onScreenJoystick = false)
 		}
 
-		// The analog mouse map needs a physical controller on the port;
-		// clear stale flags when the port holds some other device
-		if (result.joyport0MouseMap && result.joyport0 !in JOYSTICK_DEVICES) {
+		// The analog mouse map feeds the Amiga mouse on port 0 (setmousestate
+		// on an unassigned mouse is a no-op), so it only works with a
+		// controller on port 1 and the system mouse kept on port 0. Port 0
+		// can hold either a controller or the mouse, never both.
+		if (result.joyport0MouseMap) {
 			result = result.copy(joyport0MouseMap = false)
 		}
-		if (result.joyport1MouseMap && result.joyport1 !in JOYSTICK_DEVICES) {
+		if (result.joyport1MouseMap && !(result.joyport1 in JOYSTICK_DEVICES && result.joyport0 == "mouse")) {
 			result = result.copy(joyport1MouseMap = false)
 		}
 

--- a/android/app/src/main/java/com/blitterstudio/amiberry/data/model/SettingsChangeSummary.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/data/model/SettingsChangeSummary.kt
@@ -32,6 +32,8 @@ object SettingsChangeSummary {
 		addIfChanged("On-screen joystick", yesNo(before.onScreenJoystick), yesNo(after.onScreenJoystick))
 		addIfChanged("On-screen keyboard", yesNo(before.onScreenKeyboard), yesNo(after.onScreenKeyboard))
 		addIfChanged("On-screen keyboard numpad", yesNo(before.onScreenKeyboardNumpad), yesNo(after.onScreenKeyboardNumpad))
+		addIfChanged("Port 0 analog mouse map", yesNo(before.joyport0MouseMap), yesNo(after.joyport0MouseMap))
+		addIfChanged("Port 1 analog mouse map", yesNo(before.joyport1MouseMap), yesNo(after.joyport1MouseMap))
 	}
 
 	private fun MutableList<SettingsChange>.addIfChanged(label: String, before: String, after: String) {

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/InputSettingsActions.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/InputSettingsActions.kt
@@ -19,4 +19,11 @@ object InputSettingsActions {
 		} else {
 			settings.copy(onScreenJoystick = false)
 		}
+
+	fun setPortMouseMap(settings: EmulatorSettings, port: Int, isEnabled: Boolean): EmulatorSettings =
+		when (port) {
+			0 -> settings.copy(joyport0MouseMap = isEnabled)
+			1 -> settings.copy(joyport1MouseMap = isEnabled)
+			else -> settings
+		}
 }

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/InputTab.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/InputTab.kt
@@ -44,6 +44,10 @@ internal fun inputDeviceOptionIds(hasTouchScreen: Boolean, portIndex: Int): List
 	add("kbd9")
 }
 
+/** The analog mouse map needs a physical controller on the port. */
+internal fun portSupportsMouseMap(deviceId: String): Boolean =
+	deviceId == "joy0" || deviceId == "joy1"
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InputTab(viewModel: SettingsViewModel) {
@@ -114,6 +118,19 @@ fun InputTab(viewModel: SettingsViewModel) {
 					}
 				}
 
+				if (portSupportsMouseMap(settings.joyport0)) {
+					SwitchRow(
+						label = stringResource(R.string.settings_input_analog_mouse_map),
+						checked = settings.joyport0MouseMap,
+						supportingText = stringResource(R.string.settings_input_analog_mouse_map_summary),
+						onCheckedChange = { isEnabled ->
+							viewModel.updateSettings { s ->
+								InputSettingsActions.setPortMouseMap(s, 0, isEnabled)
+							}
+						}
+					)
+				}
+
 				Spacer(modifier = Modifier.height(8.dp))
 
 				// Port 1
@@ -151,6 +168,19 @@ fun InputTab(viewModel: SettingsViewModel) {
 							)
 						}
 					}
+				}
+
+				if (portSupportsMouseMap(settings.joyport1)) {
+					SwitchRow(
+						label = stringResource(R.string.settings_input_analog_mouse_map),
+						checked = settings.joyport1MouseMap,
+						supportingText = stringResource(R.string.settings_input_analog_mouse_map_summary),
+						onCheckedChange = { isEnabled ->
+							viewModel.updateSettings { s ->
+								InputSettingsActions.setPortMouseMap(s, 1, isEnabled)
+							}
+						}
+					)
 				}
 			}
 		}

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/InputTab.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/screens/settings/InputTab.kt
@@ -44,9 +44,13 @@ internal fun inputDeviceOptionIds(hasTouchScreen: Boolean, portIndex: Int): List
 	add("kbd9")
 }
 
-/** The analog mouse map needs a physical controller on the port. */
-internal fun portSupportsMouseMap(deviceId: String): Boolean =
-	deviceId == "joy0" || deviceId == "joy1"
+/**
+ * The analog mouse map feeds the Amiga mouse on port 0, so it needs a physical
+ * controller on port 1 and the system mouse kept on port 0. Port 0 can hold
+ * either a controller or the mouse, never both — so the map is port-1 only.
+ */
+internal fun portSupportsMouseMap(portIndex: Int, deviceId: String, port0Device: String): Boolean =
+	portIndex == 1 && (deviceId == "joy0" || deviceId == "joy1") && port0Device == "mouse"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -118,19 +122,6 @@ fun InputTab(viewModel: SettingsViewModel) {
 					}
 				}
 
-				if (portSupportsMouseMap(settings.joyport0)) {
-					SwitchRow(
-						label = stringResource(R.string.settings_input_analog_mouse_map),
-						checked = settings.joyport0MouseMap,
-						supportingText = stringResource(R.string.settings_input_analog_mouse_map_summary),
-						onCheckedChange = { isEnabled ->
-							viewModel.updateSettings { s ->
-								InputSettingsActions.setPortMouseMap(s, 0, isEnabled)
-							}
-						}
-					)
-				}
-
 				Spacer(modifier = Modifier.height(8.dp))
 
 				// Port 1
@@ -170,7 +161,7 @@ fun InputTab(viewModel: SettingsViewModel) {
 					}
 				}
 
-				if (portSupportsMouseMap(settings.joyport1)) {
+				if (portSupportsMouseMap(1, settings.joyport1, settings.joyport0)) {
 					SwitchRow(
 						label = stringResource(R.string.settings_input_analog_mouse_map),
 						checked = settings.joyport1MouseMap,

--- a/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/blitterstudio/amiberry/ui/viewmodel/SettingsViewModel.kt
@@ -176,7 +176,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 			joyport1 = previousSettings.joyport1,
 			onScreenJoystick = previousSettings.onScreenJoystick,
 			onScreenKeyboard = previousSettings.onScreenKeyboard,
-			onScreenKeyboardNumpad = previousSettings.onScreenKeyboardNumpad
+			onScreenKeyboardNumpad = previousSettings.onScreenKeyboardNumpad,
+			joyport0MouseMap = previousSettings.joyport0MouseMap,
+			joyport1MouseMap = previousSettings.joyport1MouseMap
 		)
 		applyConstrainedSettings(newSettings, publishNotices = true)
 		appPreferences.saveAndroidControls(settings)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -309,6 +309,8 @@
     <string name="settings_input_on_screen_keyboard_button">On-Screen Keyboard Button</string>
     <string name="settings_input_on_screen_keyboard_numpad">Include Numeric Keypad</string>
     <string name="settings_input_on_screen_keyboard_numpad_summary">Fits the full Amiga keyboard on screen using smaller keys.</string>
+    <string name="settings_input_analog_mouse_map">Left Analog Stick as Mouse</string>
+    <string name="settings_input_analog_mouse_map_summary">Left stick moves the mouse pointer; L/R shoulder buttons act as the left/right mouse buttons. Other controls stay as the port joystick.</string>
     <string name="settings_input_device_mouse">Mouse</string>
     <string name="settings_input_device_joystick_0">Joystick 0</string>
     <string name="settings_input_device_joystick_1">Joystick 1</string>

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/AndroidControlSettingsTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/AndroidControlSettingsTest.kt
@@ -60,4 +60,26 @@ class AndroidControlSettingsTest {
 		assertTrue(settings.onScreenKeyboard)
 		assertTrue(settings.onScreenKeyboardNumpad)
 	}
+
+	@Test
+	fun `mouse map falls back when a config has no explicit mouse map keys`() {
+		val settings = AndroidControlSettings.withFallback(
+			settings = EmulatorSettings(),
+			explicitKeys = setOf("joyport0", "joyport1"),
+			fallback = EmulatorSettings(joyport1MouseMap = true)
+		)
+
+		assertTrue(settings.joyport1MouseMap)
+	}
+
+	@Test
+	fun `explicit mouse map keys from a config override the fallback`() {
+		val settings = AndroidControlSettings.withFallback(
+			settings = EmulatorSettings(joyport1MouseMap = false),
+			explicitKeys = setOf("joyport1mousemap"),
+			fallback = EmulatorSettings(joyport1MouseMap = true)
+		)
+
+		assertFalse(settings.joyport1MouseMap)
+	}
 }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
@@ -166,6 +166,28 @@ class ConfigGeneratorTest {
 	}
 
 	@Test
+	fun `generate writes mouse map lines only when enabled`() {
+		val enabled = ConfigGenerator.generate(
+			EmulatorSettings(joyport0 = "joy0", joyport1 = "joy1", joyport0MouseMap = true, joyport1MouseMap = true)
+		)
+		assertContainsLine(enabled.lines(), "joyport0mousemap=1")
+		assertContainsLine(enabled.lines(), "joyport1mousemap=1")
+
+		val disabled = ConfigGenerator.generate(EmulatorSettings(joyport0 = "mouse", joyport1 = "joy0"))
+		assertFalse(disabled.lines().any { it.startsWith("joyport0mousemap=") || it.startsWith("joyport1mousemap=") })
+	}
+
+	@Test
+	fun `control config includes enabled mouse map lines`() {
+		val output = ConfigGenerator.generateControlConfig(
+			EmulatorSettings(joyport0 = "mouse", joyport1 = "joy0", joyport1MouseMap = true)
+		)
+
+		assertContainsLine(output.lines(), "joyport1mousemap=1")
+		assertFalse(output.lines().any { it.startsWith("joyport0mousemap=") })
+	}
+
+	@Test
 	fun `generate writes enabled on-screen control contract`() {
 		val output = ConfigGenerator.generate(
 			EmulatorSettings(
@@ -380,7 +402,8 @@ class ConfigGeneratorTest {
 			joyport1 = "joy0",
 			onScreenJoystick = false,
 			onScreenKeyboard = true,
-			onScreenKeyboardNumpad = true
+			onScreenKeyboardNumpad = true,
+			joyport1MouseMap = true
 		)
 
 		val configText = ConfigGenerator.generate(original)
@@ -415,8 +438,9 @@ class ConfigGeneratorTest {
 		assertEquals(original.joyport0, result.joyport0)
 		assertEquals(original.joyport1, result.joyport1)
 		assertEquals(original.onScreenJoystick, result.onScreenJoystick)
-		assertEquals(original.onScreenKeyboard, result.onScreenKeyboard)
 		assertEquals(original.onScreenKeyboardNumpad, result.onScreenKeyboardNumpad)
+		assertFalse(result.joyport0MouseMap)
+		assertTrue(result.joyport1MouseMap)
 	}
 
 	@Test

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigGeneratorTest.kt
@@ -166,7 +166,7 @@ class ConfigGeneratorTest {
 	}
 
 	@Test
-	fun `generate writes mouse map lines only when enabled`() {
+	fun `generate writes mouse map state explicitly for both ports`() {
 		val enabled = ConfigGenerator.generate(
 			EmulatorSettings(joyport0 = "joy0", joyport1 = "joy1", joyport0MouseMap = true, joyport1MouseMap = true)
 		)
@@ -174,17 +174,18 @@ class ConfigGeneratorTest {
 		assertContainsLine(enabled.lines(), "joyport1mousemap=1")
 
 		val disabled = ConfigGenerator.generate(EmulatorSettings(joyport0 = "mouse", joyport1 = "joy0"))
-		assertFalse(disabled.lines().any { it.startsWith("joyport0mousemap=") || it.startsWith("joyport1mousemap=") })
+		assertContainsLine(disabled.lines(), "joyport0mousemap=0")
+		assertContainsLine(disabled.lines(), "joyport1mousemap=0")
 	}
 
 	@Test
-	fun `control config includes enabled mouse map lines`() {
+	fun `control config writes mouse map state explicitly`() {
 		val output = ConfigGenerator.generateControlConfig(
 			EmulatorSettings(joyport0 = "mouse", joyport1 = "joy0", joyport1MouseMap = true)
 		)
 
+		assertContainsLine(output.lines(), "joyport0mousemap=0")
 		assertContainsLine(output.lines(), "joyport1mousemap=1")
-		assertFalse(output.lines().any { it.startsWith("joyport0mousemap=") })
 	}
 
 	@Test

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/ConfigParserTest.kt
@@ -264,6 +264,21 @@ class ConfigParserTest {
 	}
 
 	@Test
+	fun `parse input reads analog mouse map keys`() {
+		val file = writeConfig("""
+			joyport0=mouse
+			joyport1=joy0
+			joyport1mousemap=1
+		""".trimIndent())
+		val result = ConfigParser.parse(file)
+
+		assertFalse(result.settings.joyport0MouseMap)
+		assertTrue(result.settings.joyport1MouseMap)
+		assertTrue("joyport1mousemap" in result.explicitKeys)
+		assertTrue(result.unknownLines.none { it.trimStart().startsWith("joyport1mousemap=") })
+	}
+
+	@Test
 	fun `parse input uses native vkbd key before default osk`() {
 		val file = writeConfig("""
 			amiberry.vkbd_enabled=true

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/EmulatorSettingsTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/EmulatorSettingsTest.kt
@@ -131,7 +131,7 @@ class EmulatorSettingsTest {
 	}
 
 	@Test
-	fun `constraints keep mouse map on ports with a joystick device`() {
+	fun `constraints keep port 1 mouse map when the mouse stays on port 0`() {
 		val constrained = EmulatorSettingsConstraints.apply(
 			EmulatorSettings(
 				joyport0 = "mouse",
@@ -146,22 +146,33 @@ class EmulatorSettingsTest {
 	}
 
 	@Test
-	fun `constraints clear mouse map when the port has no joystick device`() {
-		val constrained = EmulatorSettingsConstraints.apply(
+	fun `constraints clear mouse map outside the supported arrangement`() {
+		// Port 0 can never host the map: the stick feeds the port-0 mouse,
+		// which requires port 0 to hold the mouse device
+		val port0Controller = EmulatorSettingsConstraints.apply(
 			EmulatorSettings(
-				joyport0 = "mouse",
+				joyport0 = "joy0",
+				joyport1 = "joy1",
+				onScreenJoystick = false,
+				joyport0MouseMap = true
+			),
+			hasTouchScreen = true
+		)
+		assertFalse(port0Controller.joyport0MouseMap)
+
+		// Port 1 map needs both a controller on port 1 and the mouse on port 0
+		val noMouseOnPort0 = EmulatorSettingsConstraints.apply(
+			EmulatorSettings(
+				joyport0 = "joy1",
 				joyport1 = "joy0",
 				onScreenJoystick = false,
-				joyport0MouseMap = true,
 				joyport1MouseMap = true
 			),
 			hasTouchScreen = true
 		)
+		assertFalse(noMouseOnPort0.joyport1MouseMap)
 
-		assertFalse(constrained.joyport0MouseMap)
-		assertTrue(constrained.joyport1MouseMap)
-
-		val withoutJoystick = EmulatorSettingsConstraints.apply(
+		val onScreenJoystickPort = EmulatorSettingsConstraints.apply(
 			EmulatorSettings(
 				joyport0 = "mouse",
 				joyport1 = "onscreen_joy",
@@ -170,8 +181,7 @@ class EmulatorSettingsTest {
 			),
 			hasTouchScreen = true
 		)
-
-		assertFalse(withoutJoystick.joyport1MouseMap)
+		assertFalse(onScreenJoystickPort.joyport1MouseMap)
 	}
 
 	@Test

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/EmulatorSettingsTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/EmulatorSettingsTest.kt
@@ -131,6 +131,50 @@ class EmulatorSettingsTest {
 	}
 
 	@Test
+	fun `constraints keep mouse map on ports with a joystick device`() {
+		val constrained = EmulatorSettingsConstraints.apply(
+			EmulatorSettings(
+				joyport0 = "mouse",
+				joyport1 = "joy0",
+				onScreenJoystick = false,
+				joyport1MouseMap = true
+			),
+			hasTouchScreen = true
+		)
+
+		assertTrue(constrained.joyport1MouseMap)
+	}
+
+	@Test
+	fun `constraints clear mouse map when the port has no joystick device`() {
+		val constrained = EmulatorSettingsConstraints.apply(
+			EmulatorSettings(
+				joyport0 = "mouse",
+				joyport1 = "joy0",
+				onScreenJoystick = false,
+				joyport0MouseMap = true,
+				joyport1MouseMap = true
+			),
+			hasTouchScreen = true
+		)
+
+		assertFalse(constrained.joyport0MouseMap)
+		assertTrue(constrained.joyport1MouseMap)
+
+		val withoutJoystick = EmulatorSettingsConstraints.apply(
+			EmulatorSettings(
+				joyport0 = "mouse",
+				joyport1 = "onscreen_joy",
+				joyport1MouseMap = true,
+				onScreenJoystick = true
+			),
+			hasTouchScreen = true
+		)
+
+		assertFalse(withoutJoystick.joyport1MouseMap)
+	}
+
+	@Test
 	fun `constraints disable on-screen joystick without touchscreen`() {
 		val constrained = EmulatorSettingsConstraints.apply(
 			EmulatorSettings(

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/LaunchRequestTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/LaunchRequestTest.kt
@@ -243,6 +243,39 @@ class LaunchRequestTest {
 	}
 
 	@Test
+	fun `saved config request applies enabled mouse map overrides`() {
+		val configPath = "/tmp/saved.uae"
+
+		val args = LaunchRequest.SavedConfig(
+			configPath = configPath,
+			controlOverrides = LaunchRequest.AndroidControlOverrides(
+				joyport0 = "mouse",
+				joyport1 = "joy0",
+				onScreenJoystick = false,
+				onScreenKeyboard = true,
+				joyport1MouseMap = true
+			),
+			skipGui = true
+		).toArgs()
+
+		assertArrayEquals(
+			arrayOf(
+				"--rescan-roms",
+				"--config", configPath,
+				"-s", "joyport0=mouse",
+				"-s", "joyport1=joy0",
+				"-s", "amiberry.onscreen_joystick=false",
+				"-s", "amiberry.vkbd_enabled=true",
+				"-s", "amiberry.vkbd_numpad=false",
+				"-s", "input.default_osk=true",
+				"-s", "joyport1mousemap=1",
+				"-G"
+			),
+			args
+		)
+	}
+
+	@Test
 	fun `saved config request with skip gui false omits skip gui flag`() {
 		val configPath = "/tmp/saved.uae"
 

--- a/android/app/src/test/java/com/blitterstudio/amiberry/data/LaunchRequestTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/data/LaunchRequestTest.kt
@@ -126,6 +126,8 @@ class LaunchRequestTest {
 				"-s", "amiberry.vkbd_enabled=true",
 				"-s", "amiberry.vkbd_numpad=true",
 				"-s", "input.default_osk=true",
+				"-s", "joyport0mousemap=0",
+				"-s", "joyport1mousemap=0",
 				"-G"
 			),
 			args
@@ -204,6 +206,8 @@ class LaunchRequestTest {
 				"-s", "amiberry.vkbd_enabled=false",
 				"-s", "amiberry.vkbd_numpad=false",
 				"-s", "input.default_osk=false",
+				"-s", "joyport0mousemap=0",
+				"-s", "joyport1mousemap=0",
 				"-G"
 			),
 			args
@@ -236,6 +240,8 @@ class LaunchRequestTest {
 				"-s", "amiberry.vkbd_enabled=true",
 				"-s", "amiberry.vkbd_numpad=true",
 				"-s", "input.default_osk=true",
+				"-s", "joyport0mousemap=0",
+				"-s", "joyport1mousemap=0",
 				"-G"
 			),
 			args
@@ -268,6 +274,7 @@ class LaunchRequestTest {
 				"-s", "amiberry.vkbd_enabled=true",
 				"-s", "amiberry.vkbd_numpad=false",
 				"-s", "input.default_osk=true",
+				"-s", "joyport0mousemap=0",
 				"-s", "joyport1mousemap=1",
 				"-G"
 			),

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/InputSettingsActionsTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/InputSettingsActionsTest.kt
@@ -40,4 +40,29 @@ class InputSettingsActionsTest {
 		assertEquals("joy1", settings.joyport1)
 		assertFalse(settings.onScreenJoystick)
 	}
+
+	@Test
+	fun `enabling the mouse map targets the selected port only`() {
+		val settings = InputSettingsActions.setPortMouseMap(
+			settings = EmulatorSettings(joyport0 = "mouse", joyport1 = "joy0"),
+			port = 1,
+			isEnabled = true
+		)
+
+		assertFalse(settings.joyport0MouseMap)
+		assertTrue(settings.joyport1MouseMap)
+	}
+
+	@Test
+	fun `disabling the mouse map keeps the port device untouched`() {
+		val settings = InputSettingsActions.setPortMouseMap(
+			settings = EmulatorSettings(joyport0 = "joy0", joyport1 = "joy1", joyport0MouseMap = true),
+			port = 0,
+			isEnabled = false
+		)
+
+		assertFalse(settings.joyport0MouseMap)
+		assertEquals("joy0", settings.joyport0)
+		assertEquals("joy1", settings.joyport1)
+	}
 }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/InputTabOptionsTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/InputTabOptionsTest.kt
@@ -32,4 +32,13 @@ class InputTabOptionsTest {
 
 		assertFalse(options.contains("onscreen_joy"))
 	}
+
+	@Test
+	fun `mouse map is offered only for physical joystick devices`() {
+		assertTrue(portSupportsMouseMap("joy0"))
+		assertTrue(portSupportsMouseMap("joy1"))
+		assertFalse(portSupportsMouseMap("mouse"))
+		assertFalse(portSupportsMouseMap("onscreen_joy"))
+		assertFalse(portSupportsMouseMap("none"))
+	}
 }

--- a/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/InputTabOptionsTest.kt
+++ b/android/app/src/test/java/com/blitterstudio/amiberry/ui/screens/settings/InputTabOptionsTest.kt
@@ -34,11 +34,15 @@ class InputTabOptionsTest {
 	}
 
 	@Test
-	fun `mouse map is offered only for physical joystick devices`() {
-		assertTrue(portSupportsMouseMap("joy0"))
-		assertTrue(portSupportsMouseMap("joy1"))
-		assertFalse(portSupportsMouseMap("mouse"))
-		assertFalse(portSupportsMouseMap("onscreen_joy"))
-		assertFalse(portSupportsMouseMap("none"))
+	fun `mouse map is offered only for port 1 controllers with the mouse on port 0`() {
+		assertTrue(portSupportsMouseMap(portIndex = 1, deviceId = "joy0", port0Device = "mouse"))
+		assertTrue(portSupportsMouseMap(portIndex = 1, deviceId = "joy1", port0Device = "mouse"))
+		// Port 0 can hold a controller or the mouse, never both — the map
+		// feeds the port-0 mouse, so it is never offered on port 0
+		assertFalse(portSupportsMouseMap(portIndex = 0, deviceId = "joy0", port0Device = "mouse"))
+		// Without the system mouse on port 0 there is no pointer to drive
+		assertFalse(portSupportsMouseMap(portIndex = 1, deviceId = "joy0", port0Device = "joy1"))
+		assertFalse(portSupportsMouseMap(portIndex = 1, deviceId = "onscreen_joy", port0Device = "mouse"))
+		assertFalse(portSupportsMouseMap(portIndex = 1, deviceId = "none", port0Device = "mouse"))
 	}
 }

--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -2008,6 +2008,27 @@ void ensure_onscreen_joystick_registered()
 	write_log("On-Screen Joystick registered as JOY%d\n", osj_device_index);
 }
 
+// Joyport (0..3) the given joystick device is currently assigned to, or -1.
+// The analog mouse map is configured per joyport, but axis events arrive
+// carrying the di_joystick[] device index — these must not be conflated
+// (e.g. default Android: port 0 = mouse, port 1 = joy0/device 0).
+static int assigned_joyport(const int device_index)
+{
+	for (int port = 0; port < MAX_JPORTS; port++) {
+		if (jsem_isjoy(port, &currprefs) == device_index)
+			return port;
+	}
+	return -1;
+}
+
+// Mouse device index that receives the emulated Amiga mouse (port 0) input
+// while an analog stick is mapped to mouse movement.
+static int mousemap_mouse_device()
+{
+	const int mouse = jsem_ismouse(0, &currprefs);
+	return mouse >= 0 ? mouse : 0;
+}
+
 static bool invert_axis(int axis, const didata* did)
 {
 	switch (axis)
@@ -2069,11 +2090,14 @@ void read_controller_axis(const int id, const int axis, const int value)
 
 	if (isfocus() || currprefs.inactive_input & 4)
 	{
-		// If analog mouse mapping is used, the Left stick acts as a mouse
-		if (axis <= SDL_GAMEPAD_AXIS_LEFTY && currprefs.jports[id].mousemap > 0)
+		// If analog mouse mapping is used, the Left stick acts as a mouse.
+		// The mousemap flag lives on the joyport this controller is assigned
+		// to, which is not necessarily the same number as the device index.
+		const int port = assigned_joyport(id);
+		if (axis <= SDL_GAMEPAD_AXIS_LEFTY && port >= 0 && currprefs.jports[port].mousemap > 0)
 		{
 			if (value > joystick_dead_zone || value < -joystick_dead_zone)
-				setmousestate(id, axis, value / 10000, 0);
+				setmousestate(mousemap_mouse_device(), axis, value / 10000, 0);
 		}
 		else
 		{
@@ -2134,11 +2158,14 @@ void read_joystick_axis(const int id, const int axis, int value)
 		{
 			if (did->mapping.axis[did_axis] == axis)
 			{
-				// If analog mouse mapping is used, the Left stick acts as a mouse
-				if (did_axis <= SDL_GAMEPAD_AXIS_LEFTY && currprefs.jports[id].mousemap > 0)
+				// If analog mouse mapping is used, the Left stick acts as a mouse.
+				// The mousemap flag lives on the joyport this controller is
+				// assigned to, not the device index.
+				const int port = assigned_joyport(id);
+				if (did_axis <= SDL_GAMEPAD_AXIS_LEFTY && port >= 0 && currprefs.jports[port].mousemap > 0)
 				{
 					if (value > joystick_dead_zone || value < -joystick_dead_zone)
-						setmousestate(id, did_axis, value / 1000, 0);
+						setmousestate(mousemap_mouse_device(), did_axis, value / 1000, 0);
 				}
 				else
 				{

--- a/src/osdep/imgui/input.cpp
+++ b/src/osdep/imgui/input.cpp
@@ -268,11 +268,14 @@ void render_panel_input() {
             ImGui::SetNextItemWidth(item_w);
 
             ImGui::BeginDisabled(changed_prefs.jports[port_idx].mode == 0);
+            // mousemap can also be toggled to 2/3 by hotkeys; treat any
+            // nonzero value as "LStick" so the combo never indexes past the array
+            const int mouse_map_value = changed_prefs.jports[port_idx].mousemap > 0 ? 1 : 0;
             const char *mouse_map_names[] = {"None", "LStick"};
             if (ImGui::BeginCombo(std::string("##MouseMap").append(std::to_string(port_idx)).c_str(),
-                                  mouse_map_names[changed_prefs.jports[port_idx].mousemap])) {
+                                  mouse_map_names[mouse_map_value])) {
                 for (int n = 0; n < IM_ARRAYSIZE(mouse_map_names); n++) {
-                    const bool is_selected = (changed_prefs.jports[port_idx].mousemap == n);
+                    const bool is_selected = (mouse_map_value == n);
                     if (is_selected)
                         ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyle().Colors[ImGuiCol_HeaderActive]);
                     if (ImGui::Selectable(mouse_map_names[n], is_selected)) {

--- a/tests/test_analog_mouse_map.sh
+++ b/tests/test_analog_mouse_map.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Contract for the analog-stick mouse map (joyportXmousemap):
+# - Axis routing must key off the joyport the controller is assigned to,
+#   not the di_joystick[] device index (they differ in the default Android
+#   arrangement: port 0 = mouse, port 1 = joy0/device 0).
+# - Stick movement must feed the mouse device bound to the Amiga mouse
+#   (port 0), so the pointer moves even though the pad sits on port 1.
+# - Shoulder buttons must become the mouse click events while the map is on.
+
+if command -v python3 >/dev/null 2>&1; then
+	PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+	PYTHON=python
+elif command -v py >/dev/null 2>&1; then
+	PYTHON="py -3"
+else
+	echo "python3, python, or py is required" >&2
+	exit 1
+fi
+
+$PYTHON - <<'PY'
+from pathlib import Path
+import sys
+
+amiberry_input = Path("src/osdep/amiberry_input.cpp").read_text()
+cfgfile = Path("src/cfgfile.cpp").read_text()
+
+
+def fail(message: str) -> None:
+	print(message, file=sys.stderr)
+	sys.exit(1)
+
+
+def region_between(text: str, start_marker: str, end_marker: str) -> str:
+	try:
+		start = text.index(start_marker)
+		end = text.index(end_marker, start)
+	except ValueError as exc:
+		fail(f"Could not find source marker: {exc}")
+	return text[start:end]
+
+
+helpers = region_between(
+	amiberry_input,
+	"static int assigned_joyport(",
+	"static bool invert_axis(",
+)
+if "jsem_isjoy(port, &currprefs) == device_index" not in helpers:
+	fail("The assigned joyport must be resolved through jsem_isjoy, not assumed to equal the device index")
+if "jsem_ismouse(0, &currprefs)" not in helpers:
+	fail("Stick mouse movement must target the mouse device assigned to the Amiga mouse (port 0)")
+
+for start_marker, end_marker, axis in (
+	("void read_controller_axis(", "void read_joystick_button_single(", "axis"),
+	("void read_joystick_axis(", "void read_joystick_hat(", "did_axis"),
+):
+	handler = region_between(amiberry_input, start_marker, end_marker)
+	if "const int port = assigned_joyport(id);" not in handler:
+		fail(f"{start_marker[:-2]} must resolve the assigned joyport before checking the mouse map")
+	if f"currprefs.jports[port].mousemap > 0" not in handler:
+		fail(f"{start_marker[:-2]} must check the assigned port's mousemap, not jports[id]")
+	if "currprefs.jports[id].mousemap" in handler:
+		fail(f"{start_marker[:-2]} must not conflate the device index with the joyport index")
+	if "setmousestate(mousemap_mouse_device()" not in handler:
+		fail(f"{start_marker[:-2]} must route stick movement through the resolved port-0 mouse device")
+
+defaults = region_between(
+	amiberry_input,
+	"int input_get_default_joystick(",
+	"int input_get_default_joystick_analog(",
+)
+if "currprefs.jports[port].mousemap > 0" not in defaults:
+	fail("Shoulder buttons must keep switching to mouse click events while the mouse map is on")
+if "currprefs.jports[port].mousemap == 0" not in defaults:
+	fail("Shoulder buttons must not stay as Space/Return defaults while the mouse map is on")
+
+for key in ("joyport0mousemap", "joyport1mousemap"):
+	if key not in cfgfile:
+		fail(f"cfgfile must keep parsing the {key} configuration key")
+PY
+
+echo "analog mouse map contract OK"


### PR DESCRIPTION
Fixes #2296.

Changes proposed in this pull request:
- Add a "Left Analog Stick as Mouse" switch to the Android Input settings, offered for a controller on port 1 while the system mouse stays on port 0 — the only arrangement where the mapping can work, since the stick feeds the port-0 mouse and port 0 can hold either a controller or the mouse, never both
- Round-trip the setting through config save/load (`joyport0mousemap` / `joyport1mousemap`), remembered controls, launch `-s` overrides, and the QuickStart/WHDLoad snapshots
- Fix the runtime mouse map so it works outside the desktop default: axis events were keyed off the controller's device index instead of the joyport it is assigned to, which silently disabled the feature in the default Android arrangement (port 0 = mouse, port 1 = joy0)
- Clamp the ImGui MouseMap combo, whose 2-entry label array was indexed out of bounds when a hotkey toggled the map to 2/3

## What the option does

With the switch on, the controller doubles as the Amiga mouse while staying a joystick on its port — the Steam Deck role, where the trackpad is the mouse:

| Controller input | Acts as |
|---|---|
| Left analog stick | Mouse movement |
| L/R shoulder | Left / right mouse button |
| D-pad, face buttons, right stick | Unchanged (joystick on that port) |

This is the same mapping the ImGui Ports panel ("Mouse map: LStick") and the libretro `amiberry_joy_as_mouse` option already expose, so behavior stays consistent across platforms instead of introducing a divergent Android mapping.

The runtime fix routes stick movement through the mouse device assigned to port 0 (resolved with `jsem_ismouse`), since `setmousestate` on an unassigned mouse is a no-op — with the Android defaults that mouse is the touch pointer's device.

## Validation

- Android unit suite: 535/537 green. New tests cover config generation (explicit 0/1 for both states), parsing, round-trip, constraint cleanup, remembered-control fallback, launch args, and the UI gating. The 2 failures (`RomExtensionContractTest`, `FilePickerFiltersTest`) are pre-existing on master — the cartridge-ROM PR added a 5th ROM chooser filter the contract tests don't expect.
- Native NDK arm64-v8a debug build compiles both modified C++ TUs.
- `tests/test_analog_mouse_map.sh` locks the source contract (port resolution, port-0 mouse target, shoulder mapping).
- On-device confirmation with a physical gamepad is still manual: stick moves the pointer, shoulders click.
