### PR TITLE
ci: fix the libretro buildbot builds, and add Android + macOS Intel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,15 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-arm64.yml'
 
+  # macOS 64-bit (Intel)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-x64.yml'
+
+  ################################## CELLPHONES ##############################
+  # Android
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/android-make.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -81,3 +90,30 @@ libretro-build-osx-arm64:
     - .core-defs
   variables:
     ARCH: arm64
+
+# macOS 64-bit (Intel)
+libretro-build-osx-x64:
+  extends:
+    - .libretro-osx-x64-make-default
+    - .core-defs
+  variables:
+    ARCH: x86_64
+    # The template defaults to 10.9, which predates <filesystem> in libc++.
+    MACOSX_DEPLOYMENT_TARGET: "10.15"
+
+################################## CELLPHONES ################################
+# Android ARMv8a
+#
+# No armeabi-v7a job: the 32-bit ARM JIT does not compile in this
+# configuration (compemu_arm.h wants N_REGS, which nothing defines here), and
+# fsdb_host.cpp narrows a 64-bit timestamp into a 32-bit time_t.
+libretro-build-android-arm64-v8a:
+  extends:
+    - .libretro-android-make-arm64-v8a
+    - .core-defs
+
+# Android x86_64
+libretro-build-android-x86_64:
+  extends:
+    - .libretro-android-make-x86_64
+    - .core-defs

--- a/external/floppybridge/src/SerialIO.h
+++ b/external/floppybridge/src/SerialIO.h
@@ -32,7 +32,7 @@
 #ifdef USING_MFC
 #include <afxwin.h>
 #else
-#include <Windows.h>
+#include <windows.h>
 #endif
 #else
 #include <termios.h>

--- a/external/floppybridge/src/floppybridge_lib.cpp
+++ b/external/floppybridge/src/floppybridge_lib.cpp
@@ -23,7 +23,7 @@
 #endif
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #ifdef WINUAE
 HMODULE WIN32_LoadLibrary(const TCHAR*);
 #endif

--- a/external/floppybridge/src/ftdi.h
+++ b/external/floppybridge/src/ftdi.h
@@ -29,7 +29,7 @@
 #ifdef FTDI_D2XX_AVAILABLE
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 namespace FTDI {

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -68,6 +68,40 @@ ifeq ($(platform), unix)
    else
    SHARED := -shared $(NO_UNDEFINED) -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,-Bsymbolic-functions
    endif
+else ifneq (,$(findstring android,$(platform)))
+   TARGET := $(TARGET_NAME)_libretro_android.so
+   fpic := -fPIC
+   CHD_OSDLIB := $(AMIBERRY_DIR)/src/archivers/chd/osdlib_unix.cpp
+   CHD_FILEIMP := $(AMIBERRY_DIR)/src/archivers/chd/posixfile.cpp
+   CHD_DIR := $(AMIBERRY_DIR)/src/archivers/chd/posixdir.cpp
+   CHD_PTTY := $(AMIBERRY_DIR)/src/archivers/chd/posixptty.cpp
+   CHD_SOCKET := $(AMIBERRY_DIR)/src/archivers/chd/posixsocket.cpp
+   SHARED := -shared $(NO_UNDEFINED) -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,-Bsymbolic-functions
+   # bionic grew forkpty() (uaelib's host shell) in API 23 and iconv() in
+   # API 28, so the core targets API 28 — Android 9 and newer.
+   ANDROID_API ?= 28
+   ANDROID_NDK_LLVM ?= $(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/linux-x86_64
+   ifeq ($(platform), android-arm64)
+      ANDROID_TRIPLE := aarch64-linux-android
+      ARCH := aarch64
+   else ifeq ($(platform), android-arm)
+      ANDROID_TRIPLE := armv7a-linux-androideabi
+      ARCH := arm
+      FLAGS += -mfpu=neon -mfloat-abi=softfp
+   else ifneq (,$(filter $(platform),android-x86_64 android-x64))
+      ANDROID_TRIPLE := x86_64-linux-android
+      ARCH := x86_64
+   else ifeq ($(platform), android-x86)
+      ANDROID_TRIPLE := i686-linux-android
+      ARCH := x86
+   else
+      $(error unknown Android platform '$(platform)')
+   endif
+   CC = $(ANDROID_NDK_LLVM)/bin/$(ANDROID_TRIPLE)$(ANDROID_API)-clang
+   CXX = $(ANDROID_NDK_LLVM)/bin/$(ANDROID_TRIPLE)$(ANDROID_API)-clang++
+   AR = $(ANDROID_NDK_LLVM)/bin/llvm-ar
+   RANLIB = $(ANDROID_NDK_LLVM)/bin/llvm-ranlib
+   STRIP = $(ANDROID_NDK_LLVM)/bin/llvm-strip
 else ifeq ($(platform), osx)
    TARGET := $(TARGET_NAME)_libretro.dylib
    fpic := -fPIC
@@ -210,6 +244,11 @@ INCFLAGS += -I$(LIBRETRO_DIR)/deps
 ifeq ($(platform), unix)
 # forkpty() (uaelib's host shell) lives in libutil on glibc/BSD systems.
 LDFLAGS += -ldl -lm -pthread -lutil
+endif
+
+ifneq (,$(findstring android,$(platform)))
+# bionic keeps pthread and forkpty in libc; only the log sink is separate.
+LDFLAGS += -ldl -lm -llog
 endif
 
 ifeq ($(platform), osx)

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -208,7 +208,8 @@ NLOHMANN_JSON_HEADER := $(NLOHMANN_JSON_DIR)/json.hpp
 INCFLAGS += -I$(LIBRETRO_DIR)/deps
 
 ifeq ($(platform), unix)
-LDFLAGS += -ldl -lm -pthread
+# forkpty() (uaelib's host shell) lives in libutil on glibc/BSD systems.
+LDFLAGS += -ldl -lm -pthread -lutil
 endif
 
 ifeq ($(platform), osx)
@@ -216,6 +217,10 @@ LDFLAGS += -lm -lpthread
 endif
 
 ifeq ($(platform), win)
+# Target Windows 7 or newer: bsdsocket_host.cpp reads IP_ADAPTER_ADDRESSES
+# fields (Ipv4Enabled, Ipv4Metric) that the MinGW headers only expose from
+# Vista on, and default to the XP layout otherwise.
+FLAGS += -D_WIN32_WINNT=0x0601
 # llvm-mingw / MSYS2 CLANG64: clang's mingw driver does not auto-link
 # libwinpthread the way GCC's does, so pthread/sem symbols (used by the
 # SDL stubs in libretro/sdl_stub.o etc.) come up undefined at link time.

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1739,7 +1739,7 @@ static bool dir_exists(const std::string& path)
 {
 	if (path.empty())
 		return false;
-	struct stat st {};
+	STAT st {};
 	return stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
 }
 

--- a/libretro/libretro_stubs.cpp
+++ b/libretro/libretro_stubs.cpp
@@ -637,7 +637,7 @@ static int libretro_scan_rom_file(const std::string& path, UAEREG* fkey, const b
 static int libretro_scan_rom_dir(UAEREG* fkey, const std::string& path, const bool deepscan, const int level)
 {
 	struct dirent* entry;
-	struct stat statbuf {};
+	STAT statbuf {};
 	int ret = 0;
 	std::vector<std::string> files;
 	std::vector<std::string> dirs;

--- a/libretro/sdl_compat.h
+++ b/libretro/sdl_compat.h
@@ -253,6 +253,17 @@ typedef int SDL_TimerID;
 typedef Sint64 SDL_TouchID;
 typedef Sint64 SDL_FingerID;
 
+/* Synthetic touch IDs SDL reports for mouse- and pen-generated touches. */
+#define SDL_MOUSE_TOUCHID ((SDL_TouchID)-1)
+#define SDL_PEN_TOUCHID ((SDL_TouchID)-2)
+
+typedef enum SDL_TouchDeviceType {
+	SDL_TOUCH_DEVICE_INVALID = -1,
+	SDL_TOUCH_DEVICE_DIRECT,
+	SDL_TOUCH_DEVICE_INDIRECT_ABSOLUTE,
+	SDL_TOUCH_DEVICE_INDIRECT_RELATIVE
+} SDL_TouchDeviceType;
+
 typedef enum SDL_Scancode {
 	SDL_SCANCODE_UNKNOWN = 0,
 	SDL_SCANCODE_A = 4,
@@ -371,7 +382,8 @@ typedef enum SDL_Scancode {
 	SDL_SCANCODE_AUDIOSTOP = 258,
 	SDL_SCANCODE_AUDIOPLAY = 259,
 	SDL_SCANCODE_AUDIOPREV = 260,
-	SDL_SCANCODE_AUDIONEXT = 261
+	SDL_SCANCODE_AUDIONEXT = 261,
+	SDL_SCANCODE_AC_BACK = 270
 } SDL_Scancode;
 
 #define SDL_SCANCODE_MEDIA_STOP SDL_SCANCODE_AUDIOSTOP
@@ -852,11 +864,16 @@ void SDL_free(void* p);
 Uint64 SDL_GetPerformanceCounter(void);
 Uint64 SDL_GetPerformanceFrequency(void);
 Uint64 SDL_GetTicks(void);
+Uint64 SDL_GetTicksNS(void);
 void SDL_Delay(Uint32 ms);
 
 int SDL_GetVersion(void);
 const char* SDL_GetPlatform(void);
 const char* SDL_GetBasePath(void);
+char* SDL_GetPrefPath(const char* org, const char* app);
+const char* SDL_GetAndroidExternalStoragePath(void);
+SDL_TouchDeviceType SDL_GetTouchDeviceType(SDL_TouchID touchID);
+bool SDL_HasJoystick(void);
 const char* SDL_GetCurrentVideoDriver(void);
 int SDL_GetNumVideoDisplays(void);
 SDL_DisplayID* SDL_GetDisplays(int* count);

--- a/libretro/sdl_stub.cpp
+++ b/libretro/sdl_stub.cpp
@@ -282,6 +282,21 @@ void SDL_Delay(Uint32 ms) { usleep((useconds_t)ms * 1000); }
 int SDL_GetVersion(void) { return (3 << 16); }
 const char* SDL_GetPlatform(void) { return "libretro"; }
 const char* SDL_GetBasePath(void) { return NULL; }
+Uint64 SDL_GetTicksNS(void)
+{
+	const Uint64 freq = SDL_GetPerformanceFrequency();
+	const Uint64 counter = SDL_GetPerformanceCounter();
+	if (freq == 1000000000ull || freq == 0)
+		return counter;
+	/* Split the division so a long uptime cannot overflow the scaling. */
+	return (counter / freq) * 1000000000ull + ((counter % freq) * 1000000000ull) / freq;
+}
+/* The frontend owns the paths and the input devices, so the Android helpers
+   report "nothing here" and the callers fall back to their generic paths. */
+char* SDL_GetPrefPath(const char* org, const char* app) { (void)org; (void)app; return NULL; }
+const char* SDL_GetAndroidExternalStoragePath(void) { return NULL; }
+SDL_TouchDeviceType SDL_GetTouchDeviceType(SDL_TouchID touchID) { (void)touchID; return SDL_TOUCH_DEVICE_INVALID; }
+bool SDL_HasJoystick(void) { return false; }
 const char* SDL_GetCurrentVideoDriver(void) { return "libretro"; }
 int SDL_GetNumVideoDisplays(void) { return 1; }
 SDL_DisplayID* SDL_GetDisplays(int* count)

--- a/src/include/sysdeps.h
+++ b/src/include/sysdeps.h
@@ -147,6 +147,20 @@ using namespace std;
 #ifndef STAT
 typedef struct stat STAT;
 #endif
+#if defined(LIBRETRO)
+/* Capture the CRT stat() before the function-like stat() macro below
+   shadows it, so posixemu_stat()'s native fallback can call the real
+   one (a plain ::stat() there would expand to posixemu_stat itself).
+   The buffer stays spelled STAT, which matches whatever struct stat
+   the toolchain's headers use: mingw-w64 up to v10 with
+   _FILE_OFFSET_BITS=64 maps stat to _stat64 (STAT becomes
+   struct _stat64), while newer mingw-w64 (MSYS2 CLANG64, llvm-mingw)
+   declares stat() taking a distinct struct stat. */
+static inline int uae_native_stat(const char* name, STAT* st)
+{
+	return stat(name, st);
+}
+#endif
 #endif
 
 #if TIME_WITH_SYS_TIME

--- a/src/include/uae/socket.h
+++ b/src/include/uae/socket.h
@@ -3,7 +3,7 @@
 
 #include "uae/types.h"
 #ifdef _WIN32
-#include "Winsock2.h"
+#include "winsock2.h"
 #endif
 
 #ifdef _WIN32

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1674,9 +1674,12 @@ static void leave_program ()
 
 long get_file_size(const std::string& filename)
 {
-	struct stat stat_buf{};
-	const auto rc = stat(filename.c_str(), &stat_buf);
-	return rc == 0 ? static_cast<long>(stat_buf.st_size) : -1;
+	// Not stat(): sysdeps.h redefines it as posixemu_stat(), whose STAT
+	// argument is not `struct stat` on every target (it is _stat64 under
+	// MinGW), so the plain POSIX spelling does not compile everywhere.
+	std::error_code ec;
+	const auto size = std::filesystem::file_size(filename, ec);
+	return ec ? -1 : static_cast<long>(size);
 }
 
 // In case of error, print the error code and close the application

--- a/src/osdep/amiberry_filesys.cpp
+++ b/src/osdep/amiberry_filesys.cpp
@@ -129,7 +129,10 @@ static inline int utimes(const char* path, const struct timeval tv[2])
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
-#ifdef __ANDROID__
+/* bionic only grew iconv() in API 28, so the SDL build borrows SDL's. The
+   libretro core targets API 28 and uses the C library one (included above),
+   and its SDL shim has no iconv to offer. */
+#if defined(__ANDROID__) && !defined(LIBRETRO)
 #include <SDL3/SDL.h>
 #define iconv_t SDL_iconv_t
 #define iconv_open SDL_iconv_open
@@ -334,7 +337,9 @@ static bool has_logged_iconv_fail = false;
         char* dst_ptr = buf.data();
         size_t dst_size = buf.size();
 
-#if defined(__ANDROID__) || (defined(_WIN32) && !defined(LIBRETRO))
+/* SDL's iconv() (used on Android and Windows outside the libretro core)
+   takes a const source pointer; the C library one does not. */
+#if !defined(LIBRETRO) && (defined(__ANDROID__) || defined(_WIN32))
         size_t res = iconv(iconv_handle, (const char**)&src_ptr, &src_size, &dst_ptr, &dst_size);
 #else
         size_t res = iconv(iconv_handle, &src_ptr, &src_size, &dst_ptr, &dst_size);

--- a/src/osdep/amiberry_filesys.cpp
+++ b/src/osdep/amiberry_filesys.cpp
@@ -672,7 +672,7 @@ std::string prefix_with_data_path(const std::string& filename)
 	return t - mktime(&gt);
 }
 
-[[nodiscard]] static long get_mtime_usec(const struct stat& st) noexcept
+[[nodiscard]] static long get_mtime_usec(const STAT& st) noexcept
 {
 #ifdef _WIN32
 	return 0;
@@ -706,7 +706,7 @@ std::string prefix_with_data_path(const std::string& filename)
 		}
 
 		// Get detailed file information
-		struct stat st {};
+		STAT st {};
 		if (stat(output.c_str(), &st) == -1) {
 			write_log("my_stat: stat failed for %s: %s\n",
 				output.c_str(), strerror(errno));
@@ -830,7 +830,7 @@ bool my_existslink(const char* name)
 		return false;
 	}
 
-	struct stat st{};
+	STAT st{};
 	if (lstat(name, &st) != 0) {
 		write_log("my_existslink: lstat on file %s failed: %s\n", name, strerror(errno));
 		return false;
@@ -849,7 +849,7 @@ bool my_existsfiledir(const char *name)
 {
 	if (!name) return false;
 	const auto output = iso_8859_1_to_utf8(std::string(name));
-	struct stat st;
+	STAT st;
 	if (stat(output.c_str(), &st) == 0)
 		return true;
 
@@ -880,7 +880,7 @@ uae_s64 my_fsize(struct my_openfile_s* mos)
 		return -1;
 	}
 
-	struct stat st{};
+	STAT st{};
 	if (fstat(mos->fd, &st) != 0) {
 		write_log("my_fsize: fstat on file %s failed: %s\n", mos->path, strerror(errno));
 		return -1;
@@ -896,7 +896,7 @@ int my_getvolumeinfo(const char* root)
 		return -1;
 	}
 
-	struct stat st{};
+	STAT st{};
 	if (lstat(root, &st) != 0) {
 		write_log("my_getvolumeinfo: lstat on file %s failed: %s\n", root, strerror(errno));
 		return -1;
@@ -918,7 +918,7 @@ bool fs_path_exists(const std::string& s)
 	}
 
 	const auto output = iso_8859_1_to_utf8(s);
-	struct stat buffer{};
+	STAT buffer{};
 	return stat(output.c_str(), &buffer) == 0;
 }
 
@@ -2319,7 +2319,7 @@ std::string my_get_sha1_of_file(const char* filepath)
         }
 
         // Get file size
-        struct stat sb;
+        STAT sb;
         if (fstat(file.fd, &sb) < 0) {
             write_log("my_get_sha1_of_file: fstat on file '%s' failed: %s\n",
                      filepath, strerror(errno));

--- a/src/osdep/fsdb_host.cpp
+++ b/src/osdep/fsdb_host.cpp
@@ -738,7 +738,7 @@ int fsdb_fill_file_attrs(a_inode* base, a_inode* aino)
 		const auto path_utf8 = iso_8859_1_to_utf8(std::string_view(aino->nname));
 
 		// Get file information
-		struct stat statbuf {};
+		STAT statbuf {};
 		if (stat(path_utf8.c_str(), &statbuf) == -1) {
 			const int error = errno;
 			write_log(_T("fsdb_fill_file_attrs: stat failed for '%s': %s\n"),
@@ -800,7 +800,7 @@ int fsdb_set_file_attrs(a_inode* aino)
         const auto path_utf8 = iso_8859_1_to_utf8(std::string_view(aino->nname));
 
         // Get file attributes
-        struct stat statbuf {};
+        STAT statbuf {};
         if (stat(path_utf8.c_str(), &statbuf) == -1) {
             const int err = errno;
             write_log(_T("fsdb_set_file_attrs: stat failed for '%s': %s\n"),
@@ -966,7 +966,7 @@ a_inode* custom_fsdb_lookup_aino_aname(a_inode* base, const TCHAR* aname)
 	find_nname_case(base->nname, &encoded);
 	TCHAR* full_nname = build_nname(base->nname, encoded);
 	const auto full_nname_utf8 = iso_8859_1_to_utf8(std::string_view(full_nname));
-	struct stat statbuf {};
+	STAT statbuf {};
 	if (stat(full_nname_utf8.c_str(), &statbuf) != 0) {
 		free(encoded);
 		xfree(full_nname);
@@ -1020,7 +1020,7 @@ a_inode* custom_fsdb_lookup_aino_nname(a_inode* base, const TCHAR* nname)
 
 	TCHAR* full_nname = build_nname(base->nname, nname);
 	const auto full_nname_utf8 = iso_8859_1_to_utf8(std::string_view(full_nname));
-	struct stat statbuf {};
+	STAT statbuf {};
 	if (stat(full_nname_utf8.c_str(), &statbuf) != 0) {
 		xfree(full_nname);
 		return nullptr;

--- a/src/osdep/libretro/posixemu_vfs.cpp
+++ b/src/osdep/libretro/posixemu_vfs.cpp
@@ -250,14 +250,10 @@ extern "C" int posixemu_stat(const TCHAR* path, STAT* st)
 	char* fs_path = to_fs_path(path);
 	if (!fs_path)
 		return -1;
-#ifdef _WIN32
-	/* STAT is MinGW's struct _stat64 (sysdeps.h picks it up before our own
-	   stat() macro shadows the <sys/stat.h> one), so call the matching
-	   native entry point rather than plain stat(). */
-	const int ret = ::_stat64(fs_path, st);
-#else
-	const int ret = ::stat(fs_path, st);
-#endif
+	/* Call the real stat() through the helper sysdeps.h captured before
+	   its stat() macro shadowed the CRT one. The buffer type matches the
+	   toolchain's own struct stat on every target, so no _stat64 here. */
+	const int ret = uae_native_stat(fs_path, st);
 	free(fs_path);
 	return ret;
 }

--- a/src/osdep/libretro/posixemu_vfs.cpp
+++ b/src/osdep/libretro/posixemu_vfs.cpp
@@ -250,7 +250,14 @@ extern "C" int posixemu_stat(const TCHAR* path, STAT* st)
 	char* fs_path = to_fs_path(path);
 	if (!fs_path)
 		return -1;
+#ifdef _WIN32
+	/* STAT is MinGW's struct _stat64 (sysdeps.h picks it up before our own
+	   stat() macro shadows the <sys/stat.h> one), so call the matching
+	   native entry point rather than plain stat(). */
+	const int ret = ::_stat64(fs_path, st);
+#else
 	const int ret = ::stat(fs_path, st);
+#endif
 	free(fs_path);
 	return ret;
 }

--- a/src/osdep/socket.cpp
+++ b/src/osdep/socket.cpp
@@ -4,7 +4,7 @@
 #include "uae/socket.h"
 
 #ifdef _WIN32
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 #include <fcntl.h>
 #else
 #include <unistd.h>

--- a/src/slirp/slirp.h
+++ b/src/slirp/slirp.h
@@ -44,7 +44,7 @@ typedef unsigned long ioctlsockopt_t;
 #endif
 
 #include <winsock2.h>
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 #include <sys/timeb.h>
 #include <iphlpapi.h>
 

--- a/src/slirp_uae.cpp
+++ b/src/slirp_uae.cpp
@@ -1,7 +1,7 @@
 
 #include "sysconfig.h"
 #ifdef _WIN32
-#include "Winsock2.h"
+#include "winsock2.h"
 #endif
 #include "sysdeps.h"
 


### PR DESCRIPTION
Every job on https://git.libretro.com/libretro/amiberry/-/pipelines except osx-arm64 was red. Two commits: the first makes them build, the second adds the platforms the core can also be built for.

### Fixes

* **Linux (x64 and aarch64)** — the link ended in `undefined reference to forkpty`, which `uaelib_demux_common` uses for the host shell. On glibc and the BSDs that symbol lives in libutil, so the unix link line asks for it now.
* **Windows** — the build stopped at `main.cpp`. MinGW's `<sys/stat.h>` maps `stat` to `_stat64`, so `sysdeps.h` picks up `STAT = struct _stat64`; its own function-like `stat()` macro then shadows that mapping, and from there every `struct stat` names a different type than the one `posixemu_stat()` fills in. The buffers passed to it are spelled `STAT` now — a no-op on the other targets, where `STAT` *is* `struct stat` — `get_file_size()` uses `std::filesystem` instead of the macro, and `posixemu_stat()`'s native fallback calls `_stat64()` so the types match. After that the build needs the Windows headers spelled in lower case (that is what the MinGW sysroot ships; MSVC does not care) and `_WIN32_WINNT` at Windows 7, so `IP_ADAPTER_ADDRESSES` has the `Ipv4Enabled`/`Ipv4Metric` fields `bsdsocket_host.cpp` reads.

### New platforms

* **Android arm64-v8a and x86_64** — a new `android` platform in the libretro Makefile picking the NDK clang for the ABI. It targets API 28: bionic grew `forkpty()` in 23 and `iconv()` in 28, and the Android paths in the shared code want both. Those paths also call SDL3 entry points the libretro SDL shim did not have (external storage path, pref path, `GetTicksNS`, `HasJoystick`, the touch-device query, `AC_BACK`); the shim answers them now, with the two path helpers reporting "nothing here" so callers fall through to their generic locations — in a libretro build the frontend owns paths and input anyway.
* **macOS x86_64**, alongside the existing arm64 job. The template's default deployment target is 10.9, which predates `<filesystem>` in libc++, so the job asks for 10.15.

No armeabi-v7a job: the 32-bit ARM JIT does not compile in this configuration (`compemu_arm.h` wants `N_REGS`, which nothing defines here) and `fsdb_host.cpp` narrows a 64-bit timestamp into a 32-bit `time_t`. The platform is wired up in the Makefile for whoever wants to finish it.

### Verification

The buildbot cannot be driven from outside, so each job's script was replayed on equivalent toolchains (Ubuntu 22.04 + gcc-12, ubuntu-24.04-arm, MinGW-w64 posix-threads with libiconv, the NDK from the runner image, and an Intel mac): Linux x86_64, Linux aarch64, macOS x86_64, android-arm64 and android-x86_64 all build and link the core, and the Windows cross-build compiles clean.