### PR TITLE
perf(gfx): register-based auto-crop scan; crop UI and IPC improvements

### DIFF
--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -60,12 +60,9 @@ struct AmiberryAutoCropScanState {
 	// The last perimeter-detected border, kept so an interlaced scan can still
 	// recognize the generation the other field was drawn with.
 	AmiberryAutoCropBorderColors previous_border{};
-	// The cleared surface color beyond the Amiga border, detected by the last
-	// scan. Between scans the cheap edge/outside triggers must treat it as
-	// non-content, or a colored border over a cleared black edge re-triggers
-	// a full scan every frame.
-	uint32_t surface_background = 0;
-	bool surface_background_valid = false;
+	// Sampled colors of the outside regions at the last observation; the
+	// between-scan trigger fires only when a sampled pixel changed.
+	std::vector<uint32_t> outside_signature;
 };
 
 static inline bool amiberry_auto_crop_border_state_changed(
@@ -316,25 +313,35 @@ static inline void amiberry_auto_crop_get_outside_regions(
 	regions[3] = { 0, bottom, buffer.width, buffer.height - bottom };
 }
 
-// True when the outside regions hold a pixel that is neither a known border
-// color nor the cleared surface background. Sampled in two passes over the
-// outside regions: every row reads every 4th column, and every column reads
-// every 4th row. A component of at least 16 pixels is either >= 4 wide (the
-// row pass reads one of any 4 consecutive columns) or narrower and therefore
-// >= 6 tall (the column pass reads all of its columns, one row in every 4),
-// so anything the expansion could accept is detected within one frame at
-// roughly half the outside area in reads.
-static inline bool amiberry_auto_crop_outside_regions_have_content(
+// Detects whether the outside regions changed since the last observation by
+// comparing a color-agnostic signature sampled on the two-pass grid (every
+// row reads every 4th column, every column reads every 4th row; any
+// component of at least 16 pixels is hit — it is either >= 4 wide, so the
+// row pass reads one of any 4 consecutive columns, or narrower and therefore
+// >= 6 tall, so the column pass reads all of its columns). The comparison
+// carries no color semantics: any sampled pixel that differs from the last
+// observation is exactly the condition under which the expansion's outcome
+// could differ, while stable sub-threshold specks the last scan already
+// rejected keep matching the signature and stay silent. The signature is
+// refreshed on every call, so the triggering frame re-baselines itself.
+static inline bool amiberry_auto_crop_outside_regions_changed(
 	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& rect,
-	const AmiberryAutoCropBorderColors& border,
-	const uint32_t background_rgb, const bool background_valid)
+	std::vector<uint32_t>& signature)
 {
-	if (!amiberry_auto_crop_buffer_valid(buffer) || border.count <= 0) {
+	if (!amiberry_auto_crop_buffer_valid(buffer)) {
 		return true;
 	}
-	const auto is_non_content = [&](const uint32_t rgb) {
-		return amiberry_auto_crop_border_matches(border, rgb)
-			|| (background_valid && rgb == background_rgb);
+	std::vector<uint32_t> observed;
+	bool changed = false;
+	const bool first_observation = signature.empty();
+	auto visit = [&](const uint32_t rgb) {
+		observed.push_back(rgb);
+		if (!first_observation) {
+			const size_t index = observed.size() - 1;
+			if (index >= signature.size() || signature[index] != rgb) {
+				changed = true;
+			}
+		}
 	};
 	AmiberryAutoCropRect regions[4];
 	amiberry_auto_crop_get_outside_regions(buffer, rect, regions);
@@ -343,22 +350,20 @@ static inline bool amiberry_auto_crop_outside_regions_have_content(
 		const int bottom = amiberry_auto_crop_rect_bottom(region);
 		for (int y = region.y; y < bottom; y++) {
 			for (int x = region.x; x < right; x += 4) {
-				if (!is_non_content(
-					amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
-					return true;
-				}
+				visit(amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask);
 			}
 		}
 		for (int x = region.x; x < right; x++) {
 			for (int y = region.y; y < bottom; y += 4) {
-				if (!is_non_content(
-					amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
-					return true;
-				}
+				visit(amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask);
 			}
 		}
 	}
-	return false;
+	if (!first_observation && observed.size() != signature.size()) {
+		changed = true;
+	}
+	signature = std::move(observed);
+	return changed && !first_observation;
 }
 
 // Woven is a template parameter so the far more common single-color border
@@ -810,14 +815,8 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 	}
 
 	uint32_t background_rgb = 0;
-	state.surface_background = 0;
-	state.surface_background_valid = false;
 	const bool background_valid = amiberry_auto_crop_detect_surface_background_color(
 		buffer, crop, background_rgb);
-	// Remember the cleared surface color so the between-scan triggers treat
-	// it as non-content instead of re-triggering a full scan every frame.
-	state.surface_background = background_rgb;
-	state.surface_background_valid = background_valid;
 	if (!amiberry_auto_crop_detect_border_color(
 		buffer, crop, background_rgb, background_valid, interlaced, state)) {
 		return false;

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -310,6 +310,53 @@ static inline void amiberry_auto_crop_get_outside_regions(
 	regions[3] = { 0, bottom, buffer.width, buffer.height - bottom };
 }
 
+// True when the one-pixel band just outside the rect holds a pixel that is
+// not a known border color. Crop expansion flood-fills outward from the
+// rect's edges, so content can only enlarge the rect by crossing this band;
+// a non-border pixel there means an immediate rescan is due. Sampled every
+// 2nd pixel so the per-frame cost stays a few hundred reads.
+static inline bool amiberry_auto_crop_edge_band_has_content(
+	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& rect,
+	const AmiberryAutoCropBorderColors& border)
+{
+	if (!amiberry_auto_crop_buffer_valid(buffer) || border.count <= 0) {
+		return true;
+	}
+	const int right = amiberry_auto_crop_rect_right(rect);
+	const int bottom = amiberry_auto_crop_rect_bottom(rect);
+	auto sample_row = [&](const int y, const int x0, const int x1) {
+		for (int x = x0; x < x1; x += 2) {
+			if (!amiberry_auto_crop_border_matches(border,
+				amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
+				return true;
+			}
+		}
+		return false;
+	};
+	auto sample_col = [&](const int x, const int y0, const int y1) {
+		for (int y = y0; y < y1; y += 2) {
+			if (!amiberry_auto_crop_border_matches(border,
+				amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
+				return true;
+			}
+		}
+		return false;
+	};
+	if (rect.y > 0 && sample_row(rect.y - 1, rect.x, right)) {
+		return true;
+	}
+	if (bottom < buffer.height && sample_row(bottom, rect.x, right)) {
+		return true;
+	}
+	if (rect.x > 0 && sample_col(rect.x - 1, rect.y, bottom)) {
+		return true;
+	}
+	if (right < buffer.width && sample_col(right, rect.y, bottom)) {
+		return true;
+	}
+	return false;
+}
+
 // Woven is a template parameter so the far more common single-color border
 // keeps one comparison per pixel in this scan's hottest loop.
 template<bool Woven>

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -316,59 +316,14 @@ static inline void amiberry_auto_crop_get_outside_regions(
 	regions[3] = { 0, bottom, buffer.width, buffer.height - bottom };
 }
 
-// True when the one-pixel band just outside the rect holds a pixel that is
-// not a known border color or the cleared surface background. Crop expansion
-// flood-fills outward from the rect's edges, so adjacent content can only
-// enlarge the rect by crossing this band; a content pixel there means an
-// immediate rescan is due. Sampled every 2nd pixel so the per-frame cost
-// stays a few hundred reads.
-static inline bool amiberry_auto_crop_edge_band_has_content(
-	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& rect,
-	const AmiberryAutoCropBorderColors& border,
-	const uint32_t background_rgb, const bool background_valid)
-{
-	if (!amiberry_auto_crop_buffer_valid(buffer) || border.count <= 0) {
-		return true;
-	}
-	const auto is_non_content = [&](const uint32_t rgb) {
-		return amiberry_auto_crop_border_matches(border, rgb)
-			|| (background_valid && rgb == background_rgb);
-	};
-	const int right = amiberry_auto_crop_rect_right(rect);
-	const int bottom = amiberry_auto_crop_rect_bottom(rect);
-	auto sample_row = [&](const int y, const int x0, const int x1) {
-		for (int x = x0; x < x1; x += 2) {
-			if (!is_non_content(
-				amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
-				return true;
-			}
-		}
-		return false;
-	};
-	auto sample_col = [&](const int x, const int y0, const int y1) {
-		for (int y = y0; y < y1; y += 2) {
-			if (!is_non_content(
-				amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
-				return true;
-			}
-		}
-		return false;
-	};
-	if (rect.y > 0 && sample_row(rect.y - 1, rect.x, right)) {
-		return true;
-	}
-	if (bottom < buffer.height && sample_row(bottom, rect.x, right)) {
-		return true;
-	}
-	if (rect.x > 0 && sample_col(rect.x - 1, rect.y, bottom)) {
-		return true;
-	}
-	if (right < buffer.width && sample_col(right, rect.y, bottom)) {
-		return true;
-	}
-	return false;
-}
-
+// True when the outside regions hold a pixel that is neither a known border
+// color nor the cleared surface background. Sampled in two passes over the
+// outside regions: every row reads every 4th column, and every column reads
+// every 4th row. A component of at least 16 pixels is either >= 4 wide (the
+// row pass reads one of any 4 consecutive columns) or narrower and therefore
+// >= 6 tall (the column pass reads all of its columns, one row in every 4),
+// so anything the expansion could accept is detected within one frame at
+// roughly half the outside area in reads.
 static inline bool amiberry_auto_crop_outside_regions_have_content(
 	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& rect,
 	const AmiberryAutoCropBorderColors& border,
@@ -384,8 +339,18 @@ static inline bool amiberry_auto_crop_outside_regions_have_content(
 	AmiberryAutoCropRect regions[4];
 	amiberry_auto_crop_get_outside_regions(buffer, rect, regions);
 	for (const auto& region : regions) {
-		for (int y = region.y; y < amiberry_auto_crop_rect_bottom(region); y += 4) {
-			for (int x = region.x; x < amiberry_auto_crop_rect_right(region); x += 4) {
+		const int right = amiberry_auto_crop_rect_right(region);
+		const int bottom = amiberry_auto_crop_rect_bottom(region);
+		for (int y = region.y; y < bottom; y++) {
+			for (int x = region.x; x < right; x += 4) {
+				if (!is_non_content(
+					amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
+					return true;
+				}
+			}
+		}
+		for (int x = region.x; x < right; x++) {
+			for (int y = region.y; y < bottom; y += 4) {
 				if (!is_non_content(
 					amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
 					return true;

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -357,6 +357,34 @@ static inline bool amiberry_auto_crop_edge_band_has_content(
 	return false;
 }
 
+// Sparse counterpart for content DISCONNECTED from the crop: expansion
+// unions every non-border component in the outside regions, not only ones
+// adjacent to the rect's edge. Sample those regions on a coarse grid (every
+// 4th pixel) so a disconnected component large enough to expand the crop is
+// normally hit within a frame; anything thinner than the stride falls back
+// to the periodic interval scan.
+static inline bool amiberry_auto_crop_outside_regions_have_content(
+	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& rect,
+	const AmiberryAutoCropBorderColors& border)
+{
+	if (!amiberry_auto_crop_buffer_valid(buffer) || border.count <= 0) {
+		return true;
+	}
+	AmiberryAutoCropRect regions[4];
+	amiberry_auto_crop_get_outside_regions(buffer, rect, regions);
+	for (const auto& region : regions) {
+		for (int y = region.y; y < amiberry_auto_crop_rect_bottom(region); y += 4) {
+			for (int x = region.x; x < amiberry_auto_crop_rect_right(region); x += 4) {
+				if (!amiberry_auto_crop_border_matches(border,
+					amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
 // Woven is a template parameter so the far more common single-color border
 // keeps one comparison per pixel in this scan's hottest loop.
 template<bool Woven>

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -331,17 +331,21 @@ static inline bool amiberry_auto_crop_outside_regions_changed(
 	if (!amiberry_auto_crop_buffer_valid(buffer)) {
 		return true;
 	}
-	std::vector<uint32_t> observed;
+	// Compare and update in place: the stable path performs no allocation
+	// and no writes, and a differing sample only rewrites its own slot.
+	size_t index = 0;
 	bool changed = false;
 	const bool first_observation = signature.empty();
 	auto visit = [&](const uint32_t rgb) {
-		observed.push_back(rgb);
-		if (!first_observation) {
-			const size_t index = observed.size() - 1;
-			if (index >= signature.size() || signature[index] != rgb) {
+		if (index < signature.size()) {
+			if (signature[index] != rgb) {
 				changed = true;
+				signature[index] = rgb;
 			}
+		} else {
+			signature.push_back(rgb);
 		}
+		index++;
 	};
 	AmiberryAutoCropRect regions[4];
 	amiberry_auto_crop_get_outside_regions(buffer, rect, regions);
@@ -359,10 +363,11 @@ static inline bool amiberry_auto_crop_outside_regions_changed(
 			}
 		}
 	}
-	if (!first_observation && observed.size() != signature.size()) {
+	if (signature.size() != index) {
+		// The sampled area itself changed (surface or rect geometry).
+		signature.resize(index);
 		changed = true;
 	}
-	signature = std::move(observed);
 	return changed && !first_observation;
 }
 

--- a/src/osdep/amiberry_autocrop_helpers.h
+++ b/src/osdep/amiberry_autocrop_helpers.h
@@ -60,6 +60,12 @@ struct AmiberryAutoCropScanState {
 	// The last perimeter-detected border, kept so an interlaced scan can still
 	// recognize the generation the other field was drawn with.
 	AmiberryAutoCropBorderColors previous_border{};
+	// The cleared surface color beyond the Amiga border, detected by the last
+	// scan. Between scans the cheap edge/outside triggers must treat it as
+	// non-content, or a colored border over a cleared black edge re-triggers
+	// a full scan every frame.
+	uint32_t surface_background = 0;
+	bool surface_background_valid = false;
 };
 
 static inline bool amiberry_auto_crop_border_state_changed(
@@ -311,22 +317,28 @@ static inline void amiberry_auto_crop_get_outside_regions(
 }
 
 // True when the one-pixel band just outside the rect holds a pixel that is
-// not a known border color. Crop expansion flood-fills outward from the
-// rect's edges, so content can only enlarge the rect by crossing this band;
-// a non-border pixel there means an immediate rescan is due. Sampled every
-// 2nd pixel so the per-frame cost stays a few hundred reads.
+// not a known border color or the cleared surface background. Crop expansion
+// flood-fills outward from the rect's edges, so adjacent content can only
+// enlarge the rect by crossing this band; a content pixel there means an
+// immediate rescan is due. Sampled every 2nd pixel so the per-frame cost
+// stays a few hundred reads.
 static inline bool amiberry_auto_crop_edge_band_has_content(
 	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& rect,
-	const AmiberryAutoCropBorderColors& border)
+	const AmiberryAutoCropBorderColors& border,
+	const uint32_t background_rgb, const bool background_valid)
 {
 	if (!amiberry_auto_crop_buffer_valid(buffer) || border.count <= 0) {
 		return true;
 	}
+	const auto is_non_content = [&](const uint32_t rgb) {
+		return amiberry_auto_crop_border_matches(border, rgb)
+			|| (background_valid && rgb == background_rgb);
+	};
 	const int right = amiberry_auto_crop_rect_right(rect);
 	const int bottom = amiberry_auto_crop_rect_bottom(rect);
 	auto sample_row = [&](const int y, const int x0, const int x1) {
 		for (int x = x0; x < x1; x += 2) {
-			if (!amiberry_auto_crop_border_matches(border,
+			if (!is_non_content(
 				amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
 				return true;
 			}
@@ -335,7 +347,7 @@ static inline bool amiberry_auto_crop_edge_band_has_content(
 	};
 	auto sample_col = [&](const int x, const int y0, const int y1) {
 		for (int y = y0; y < y1; y += 2) {
-			if (!amiberry_auto_crop_border_matches(border,
+			if (!is_non_content(
 				amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
 				return true;
 			}
@@ -357,25 +369,24 @@ static inline bool amiberry_auto_crop_edge_band_has_content(
 	return false;
 }
 
-// Sparse counterpart for content DISCONNECTED from the crop: expansion
-// unions every non-border component in the outside regions, not only ones
-// adjacent to the rect's edge. Sample those regions on a coarse grid (every
-// 4th pixel) so a disconnected component large enough to expand the crop is
-// normally hit within a frame; anything thinner than the stride falls back
-// to the periodic interval scan.
 static inline bool amiberry_auto_crop_outside_regions_have_content(
 	const AmiberryAutoCropPixelBuffer& buffer, const AmiberryAutoCropRect& rect,
-	const AmiberryAutoCropBorderColors& border)
+	const AmiberryAutoCropBorderColors& border,
+	const uint32_t background_rgb, const bool background_valid)
 {
 	if (!amiberry_auto_crop_buffer_valid(buffer) || border.count <= 0) {
 		return true;
 	}
+	const auto is_non_content = [&](const uint32_t rgb) {
+		return amiberry_auto_crop_border_matches(border, rgb)
+			|| (background_valid && rgb == background_rgb);
+	};
 	AmiberryAutoCropRect regions[4];
 	amiberry_auto_crop_get_outside_regions(buffer, rect, regions);
 	for (const auto& region : regions) {
 		for (int y = region.y; y < amiberry_auto_crop_rect_bottom(region); y += 4) {
 			for (int x = region.x; x < amiberry_auto_crop_rect_right(region); x += 4) {
-				if (!amiberry_auto_crop_border_matches(border,
+				if (!is_non_content(
 					amiberry_auto_crop_read_pixel(buffer, x, y) & buffer.rgb_mask)) {
 					return true;
 				}
@@ -834,8 +845,14 @@ static inline bool amiberry_auto_crop_expand_to_visible_content(
 	}
 
 	uint32_t background_rgb = 0;
+	state.surface_background = 0;
+	state.surface_background_valid = false;
 	const bool background_valid = amiberry_auto_crop_detect_surface_background_color(
 		buffer, crop, background_rgb);
+	// Remember the cleared surface color so the between-scan triggers treat
+	// it as non-content instead of re-triggering a full scan every frame.
+	state.surface_background = background_rgb;
+	state.surface_background_valid = background_valid;
 	if (!amiberry_auto_crop_detect_border_color(
 		buffer, crop, background_rgb, background_valid, interlaced, state)) {
 		return false;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -2300,11 +2300,15 @@ void auto_crop_image()
 					&& !amiberry_auto_crop_edge_band_has_content(band_buffer,
 						{ last_scan_rect.x, last_scan_rect.y,
 							last_scan_rect.w, last_scan_rect.h },
-						scan_state.border)
+						scan_state.border,
+						scan_state.surface_background,
+						scan_state.surface_background_valid)
 					&& !amiberry_auto_crop_outside_regions_have_content(band_buffer,
 						{ last_scan_rect.x, last_scan_rect.y,
 							last_scan_rect.w, last_scan_rect.h },
-						scan_state.border)) {
+						scan_state.border,
+						scan_state.surface_background,
+						scan_state.surface_background_valid)) {
 					crop_rect = last_scan_rect;
 					clamp_auto_crop_rect(surface, crop_rect);
 				} else {

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -2272,7 +2272,10 @@ void auto_crop_image()
 			// a duty cycle: immediately when the base or source buffer changes,
 			// and every auto_crop_scan_interval-th frame otherwise. Between
 			// scans the last scan's rect is reused, eliminating the per-frame
-			// pixel walk.
+			// pixel walk. A cheap 1-frame trigger covers content that appears
+			// between interval scans: the rect can only grow by content
+			// crossing the band just outside its edge, so a non-border pixel
+			// there forces an immediate scan.
 			static SDL_Rect last_scan_rect = { 0, 0, 0, 0 };
 			static SDL_Rect last_scan_base = { 0, 0, 0, 0 };
 			static int last_scan_hres = -1, last_scan_vres = -1;
@@ -2285,14 +2288,24 @@ void auto_crop_image()
 				&& last_scan_hres == hres && last_scan_vres == vres
 				&& last_scan_base.x == cx && last_scan_base.y == cy
 				&& last_scan_base.w == cw && last_scan_base.h == ch;
-			const bool scan_due = !scan_context_matches
+			bool scan_due = !scan_context_matches
 				|| force_auto_crop
 				|| last_autocrop != currprefs.gfx_auto_crop
 				|| (scan_frame % auto_crop_scan_interval) == 0;
 			if (!scan_due && last_scan_rect.w > 0 && last_scan_rect.h > 0) {
-				crop_rect = last_scan_rect;
-				clamp_auto_crop_rect(surface, crop_rect);
-			} else {
+				AmiberryAutoCropPixelBuffer band_buffer;
+				if (get_auto_crop_pixel_buffer(surface, band_buffer)
+					&& !amiberry_auto_crop_edge_band_has_content(band_buffer,
+						{ last_scan_rect.x, last_scan_rect.y,
+							last_scan_rect.w, last_scan_rect.h },
+						scan_state.border)) {
+					crop_rect = last_scan_rect;
+					clamp_auto_crop_rect(surface, crop_rect);
+				} else {
+					scan_due = true;
+				}
+			}
+			if (scan_due) {
 				const int sprite_horizontal_edges = get_autoscale_sprite_horizontal_edges();
 				int sprite_zero_left = 0;
 				int sprite_zero_right = 0;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -2272,23 +2272,21 @@ void auto_crop_image()
 			// a duty cycle: immediately when the base or source buffer changes,
 			// and every auto_crop_scan_interval-th frame otherwise. Between
 			// scans the last scan's rect is reused, eliminating the per-frame
-			// pixel walk. A per-frame two-pass sample of the outside regions
+			// pixel walk. The outside regions are sampled on a two-pass grid
 			// (every row at every 4th column, every column at every 4th row)
-			// triggers an immediate scan for any outside component the
-			// expansion could accept; a trigger scan that leaves the rect
-			// unchanged parks triggers for one interval so stable
-			// sub-threshold specks cannot force a scan every frame.
+			// and compared against a color-agnostic signature from the last
+			// observation; any sampled change triggers an immediate scan.
+			// Because the comparison carries no color semantics, stable
+			// sub-threshold specks the last scan rejected keep matching the
+			// signature and stay silent, and newly appearing content of any
+			// color — including enclosed background-colored components —
+			// triggers within one frame.
 			static SDL_Rect last_scan_rect = { 0, 0, 0, 0 };
 			static SDL_Rect last_scan_base = { 0, 0, 0, 0 };
 			static int last_scan_hres = -1, last_scan_vres = -1;
 			static SDL_Surface* last_scan_surface = nullptr;
 			static int last_scan_surface_w = 0, last_scan_surface_h = 0;
 			static unsigned scan_frame = 0;
-			// A trigger scan that leaves the rect unchanged (stable specks the
-			// expansion deliberately ignores) parks trigger-based rescans for
-			// one interval, so sub-threshold content degrades the cadence to
-			// the interval at worst instead of a scan every frame.
-			static int trigger_cooldown = 0;
 			scan_frame++;
 			const bool scan_context_matches = last_scan_surface == surface
 				&& last_scan_surface_w == surface_w && last_scan_surface_h == surface_h
@@ -2299,20 +2297,13 @@ void auto_crop_image()
 				|| force_auto_crop
 				|| last_autocrop != currprefs.gfx_auto_crop
 				|| (scan_frame % auto_crop_scan_interval) == 0;
-			const bool duty_cycle_scan = scan_due;
-			if (trigger_cooldown > 0) {
-				trigger_cooldown--;
-			}
-			if (!scan_due && trigger_cooldown == 0
-				&& last_scan_rect.w > 0 && last_scan_rect.h > 0) {
+			if (!scan_due && last_scan_rect.w > 0 && last_scan_rect.h > 0) {
 				AmiberryAutoCropPixelBuffer outside_buffer;
 				if (get_auto_crop_pixel_buffer(surface, outside_buffer)
-					&& !amiberry_auto_crop_outside_regions_have_content(outside_buffer,
+					&& !amiberry_auto_crop_outside_regions_changed(outside_buffer,
 						{ last_scan_rect.x, last_scan_rect.y,
 							last_scan_rect.w, last_scan_rect.h },
-						scan_state.border,
-						scan_state.surface_background,
-						scan_state.surface_background_valid)) {
+						scan_state.outside_signature)) {
 					crop_rect = last_scan_rect;
 					clamp_auto_crop_rect(surface, crop_rect);
 				} else {
@@ -2346,14 +2337,6 @@ void auto_crop_image()
 					(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_RIGHT) != 0, sprite_zero,
 					visible_state,
 					force_auto_crop || last_autocrop != currprefs.gfx_auto_crop);
-				const bool rect_unchanged = crop_rect.x == last_scan_rect.x
-					&& crop_rect.y == last_scan_rect.y
-					&& crop_rect.w == last_scan_rect.w
-					&& crop_rect.h == last_scan_rect.h;
-				if (!duty_cycle_scan) {
-					trigger_cooldown = rect_unchanged
-						? auto_crop_scan_interval : 0;
-				}
 				last_scan_rect = crop_rect;
 				last_scan_base = { cx, cy, cw, ch };
 				last_scan_hres = hres;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -2272,18 +2272,23 @@ void auto_crop_image()
 			// a duty cycle: immediately when the base or source buffer changes,
 			// and every auto_crop_scan_interval-th frame otherwise. Between
 			// scans the last scan's rect is reused, eliminating the per-frame
-			// pixel walk. Two cheap per-frame triggers cover content that
-			// appears between interval scans: a one-pixel band just outside
-			// the rect's edge for adjacent content, and a coarse grid over the
-			// outside regions for components disconnected from the crop
-			// (expansion unions every non-border component out there, not
-			// only edge-connected ones).
+			// pixel walk. A per-frame two-pass sample of the outside regions
+			// (every row at every 4th column, every column at every 4th row)
+			// triggers an immediate scan for any outside component the
+			// expansion could accept; a trigger scan that leaves the rect
+			// unchanged parks triggers for one interval so stable
+			// sub-threshold specks cannot force a scan every frame.
 			static SDL_Rect last_scan_rect = { 0, 0, 0, 0 };
 			static SDL_Rect last_scan_base = { 0, 0, 0, 0 };
 			static int last_scan_hres = -1, last_scan_vres = -1;
 			static SDL_Surface* last_scan_surface = nullptr;
 			static int last_scan_surface_w = 0, last_scan_surface_h = 0;
 			static unsigned scan_frame = 0;
+			// A trigger scan that leaves the rect unchanged (stable specks the
+			// expansion deliberately ignores) parks trigger-based rescans for
+			// one interval, so sub-threshold content degrades the cadence to
+			// the interval at worst instead of a scan every frame.
+			static int trigger_cooldown = 0;
 			scan_frame++;
 			const bool scan_context_matches = last_scan_surface == surface
 				&& last_scan_surface_w == surface_w && last_scan_surface_h == surface_h
@@ -2294,16 +2299,15 @@ void auto_crop_image()
 				|| force_auto_crop
 				|| last_autocrop != currprefs.gfx_auto_crop
 				|| (scan_frame % auto_crop_scan_interval) == 0;
-			if (!scan_due && last_scan_rect.w > 0 && last_scan_rect.h > 0) {
-				AmiberryAutoCropPixelBuffer band_buffer;
-				if (get_auto_crop_pixel_buffer(surface, band_buffer)
-					&& !amiberry_auto_crop_edge_band_has_content(band_buffer,
-						{ last_scan_rect.x, last_scan_rect.y,
-							last_scan_rect.w, last_scan_rect.h },
-						scan_state.border,
-						scan_state.surface_background,
-						scan_state.surface_background_valid)
-					&& !amiberry_auto_crop_outside_regions_have_content(band_buffer,
+			const bool duty_cycle_scan = scan_due;
+			if (trigger_cooldown > 0) {
+				trigger_cooldown--;
+			}
+			if (!scan_due && trigger_cooldown == 0
+				&& last_scan_rect.w > 0 && last_scan_rect.h > 0) {
+				AmiberryAutoCropPixelBuffer outside_buffer;
+				if (get_auto_crop_pixel_buffer(surface, outside_buffer)
+					&& !amiberry_auto_crop_outside_regions_have_content(outside_buffer,
 						{ last_scan_rect.x, last_scan_rect.y,
 							last_scan_rect.w, last_scan_rect.h },
 						scan_state.border,
@@ -2342,6 +2346,14 @@ void auto_crop_image()
 					(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_RIGHT) != 0, sprite_zero,
 					visible_state,
 					force_auto_crop || last_autocrop != currprefs.gfx_auto_crop);
+				const bool rect_unchanged = crop_rect.x == last_scan_rect.x
+					&& crop_rect.y == last_scan_rect.y
+					&& crop_rect.w == last_scan_rect.w
+					&& crop_rect.h == last_scan_rect.h;
+				if (!duty_cycle_scan) {
+					trigger_cooldown = rect_unchanged
+						? auto_crop_scan_interval : 0;
+				}
 				last_scan_rect = crop_rect;
 				last_scan_base = { cx, cy, cw, ch };
 				last_scan_hres = hres;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -2272,10 +2272,12 @@ void auto_crop_image()
 			// a duty cycle: immediately when the base or source buffer changes,
 			// and every auto_crop_scan_interval-th frame otherwise. Between
 			// scans the last scan's rect is reused, eliminating the per-frame
-			// pixel walk. A cheap 1-frame trigger covers content that appears
-			// between interval scans: the rect can only grow by content
-			// crossing the band just outside its edge, so a non-border pixel
-			// there forces an immediate scan.
+			// pixel walk. Two cheap per-frame triggers cover content that
+			// appears between interval scans: a one-pixel band just outside
+			// the rect's edge for adjacent content, and a coarse grid over the
+			// outside regions for components disconnected from the crop
+			// (expansion unions every non-border component out there, not
+			// only edge-connected ones).
 			static SDL_Rect last_scan_rect = { 0, 0, 0, 0 };
 			static SDL_Rect last_scan_base = { 0, 0, 0, 0 };
 			static int last_scan_hres = -1, last_scan_vres = -1;
@@ -2296,6 +2298,10 @@ void auto_crop_image()
 				AmiberryAutoCropPixelBuffer band_buffer;
 				if (get_auto_crop_pixel_buffer(surface, band_buffer)
 					&& !amiberry_auto_crop_edge_band_has_content(band_buffer,
+						{ last_scan_rect.x, last_scan_rect.y,
+							last_scan_rect.w, last_scan_rect.h },
+						scan_state.border)
+					&& !amiberry_auto_crop_outside_regions_have_content(band_buffer,
 						{ last_scan_rect.x, last_scan_rect.y,
 							last_scan_rect.w, last_scan_rect.h },
 						scan_state.border)) {

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -129,6 +129,11 @@ constexpr int auto_crop_wide_aspect_h = 9;
 constexpr int auto_crop_shrink_stable_frames = 6;
 constexpr int auto_crop_min_outside_pixels = 16;
 constexpr int auto_crop_horizontal_jitter_tolerance = 2;
+// Content-scan duty cycle for auto-crop. The DIW/DDF register window is the
+// crop base; the scan only expands beyond it for border effects, so it runs
+// when the base changes or every Nth frame. Odd so that successive periodic
+// scans on interlaced content alternate field parity.
+constexpr int auto_crop_scan_interval = 25;
 
 struct AutoCropVisibleState {
 	const SDL_Surface* surface = nullptr;
@@ -2195,6 +2200,7 @@ void auto_crop_image()
 {
 	const AmigaMonitor* mon = &AMonitors[0];
 	static bool last_autocrop;
+	static unsigned scan_count;
 
 	if (currprefs.gfx_auto_crop)
 	{
@@ -2258,32 +2264,70 @@ void auto_crop_image()
 			crop_rect = { mapped.x, mapped.y, mapped.w, mapped.h };
 			clamp_auto_crop_rect(surface, crop_rect);
 		} else {
-			const int sprite_horizontal_edges = get_autoscale_sprite_horizontal_edges();
-			int sprite_zero_left = 0;
-			int sprite_zero_right = 0;
-			const int sprite_zero_edges = get_autoscale_sprite_zero_horizontal_edges(
-				&sprite_zero_left, &sprite_zero_right);
-			const AmiberryAutoCropHorizontalEvidence sprite_zero = {
-				sprite_zero_left,
-				sprite_zero_right,
-				(sprite_zero_edges & AUTOSCALE_SPRITE_EDGE_LEFT) != 0,
-				(sprite_zero_edges & AUTOSCALE_SPRITE_EDGE_RIGHT) != 0
-			};
-			clamp_auto_crop_rect(surface, crop_rect);
-			const SDL_Rect source_crop_rect = crop_rect;
-			// DIW/bitplane limits can exclude visible sprites or raster content.
-			// Preserve real pixels outside those limits without restoring the
-			// conservative minimum frame that keeps intentional black borders.
-			// Only a line-doubled interlaced buffer weaves two fields together.
-			const bool interlaced = interlace_seen > 0 && vres > VRES_NONDOUBLE;
-			expand_auto_crop_rect_to_visible_content(surface, crop_rect, interlaced,
-				scan_state);
-			preserve_auto_crop_visible_content(surface, source_crop_rect, crop_rect,
-				hres, vres, scan_state.border,
-				(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_LEFT) != 0,
-				(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_RIGHT) != 0, sprite_zero,
-				visible_state,
-				force_auto_crop || last_autocrop != currprefs.gfx_auto_crop);
+			// The DIW/DDF register window from get_custom_limits() is the
+			// deterministic crop base; the register union already tracks sprite
+			// extents. The content scan's only remaining job is to expand beyond
+			// that base for visible pixels OUTSIDE the display window (raster or
+			// copper border effects the register union cannot see), so it runs on
+			// a duty cycle: immediately when the base or source buffer changes,
+			// and every auto_crop_scan_interval-th frame otherwise. Between
+			// scans the last scan's rect is reused, eliminating the per-frame
+			// pixel walk.
+			static SDL_Rect last_scan_rect = { 0, 0, 0, 0 };
+			static SDL_Rect last_scan_base = { 0, 0, 0, 0 };
+			static int last_scan_hres = -1, last_scan_vres = -1;
+			static SDL_Surface* last_scan_surface = nullptr;
+			static int last_scan_surface_w = 0, last_scan_surface_h = 0;
+			static unsigned scan_frame = 0;
+			scan_frame++;
+			const bool scan_context_matches = last_scan_surface == surface
+				&& last_scan_surface_w == surface_w && last_scan_surface_h == surface_h
+				&& last_scan_hres == hres && last_scan_vres == vres
+				&& last_scan_base.x == cx && last_scan_base.y == cy
+				&& last_scan_base.w == cw && last_scan_base.h == ch;
+			const bool scan_due = !scan_context_matches
+				|| force_auto_crop
+				|| last_autocrop != currprefs.gfx_auto_crop
+				|| (scan_frame % auto_crop_scan_interval) == 0;
+			if (!scan_due && last_scan_rect.w > 0 && last_scan_rect.h > 0) {
+				crop_rect = last_scan_rect;
+				clamp_auto_crop_rect(surface, crop_rect);
+			} else {
+				const int sprite_horizontal_edges = get_autoscale_sprite_horizontal_edges();
+				int sprite_zero_left = 0;
+				int sprite_zero_right = 0;
+				const int sprite_zero_edges = get_autoscale_sprite_zero_horizontal_edges(
+					&sprite_zero_left, &sprite_zero_right);
+				const AmiberryAutoCropHorizontalEvidence sprite_zero = {
+					sprite_zero_left,
+					sprite_zero_right,
+					(sprite_zero_edges & AUTOSCALE_SPRITE_EDGE_LEFT) != 0,
+					(sprite_zero_edges & AUTOSCALE_SPRITE_EDGE_RIGHT) != 0
+				};
+				clamp_auto_crop_rect(surface, crop_rect);
+				const SDL_Rect source_crop_rect = crop_rect;
+				// DIW/bitplane limits can exclude visible sprites or raster content.
+				// Preserve real pixels outside those limits without restoring the
+				// conservative minimum frame that keeps intentional black borders.
+				// Only a line-doubled interlaced buffer weaves two fields together.
+				const bool interlaced = interlace_seen > 0 && vres > VRES_NONDOUBLE;
+				expand_auto_crop_rect_to_visible_content(surface, crop_rect, interlaced,
+					scan_state);
+				preserve_auto_crop_visible_content(surface, source_crop_rect, crop_rect,
+					hres, vres, scan_state.border,
+					(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_LEFT) != 0,
+					(sprite_horizontal_edges & AUTOSCALE_SPRITE_EDGE_RIGHT) != 0, sprite_zero,
+					visible_state,
+					force_auto_crop || last_autocrop != currprefs.gfx_auto_crop);
+				last_scan_rect = crop_rect;
+				last_scan_base = { cx, cy, cw, ch };
+				last_scan_hres = hres;
+				last_scan_vres = vres;
+				last_scan_surface = surface;
+				last_scan_surface_w = surface_w;
+				last_scan_surface_h = surface_h;
+				scan_count++;
+			}
 		}
 		cx = crop_rect.x;
 		cy = crop_rect.y;
@@ -2423,7 +2467,8 @@ void auto_crop_image()
 		renderer->crop_aspect = (height > 0) ? static_cast<float>(width) / static_cast<float>(height) : 0.0f;
 		renderer->crop_display_w = integer_width;
 		renderer->crop_display_h = integer_height;
-		write_log(_T("auto_crop: raw=%dx%d+%d+%d valid=%d provisional=%d final=%dx%d+%d+%d render_res=%d/%d content_res=%d/%d content=%dx%d ntsc=%d (vblank=%.1fHz) => display %dx%d aspect=%.4f\n"),
+		write_log(_T("auto_crop: scans=%u raw=%dx%d+%d+%d valid=%d provisional=%d final=%dx%d+%d+%d render_res=%d/%d content_res=%d/%d content=%dx%d ntsc=%d (vblank=%.1fHz) => display %dx%d aspect=%.4f\n"),
+			scan_count,
 			raw_cw, raw_ch, raw_cx, raw_cy, raw_crop_valid, raw_crop_provisional,
 			cw, ch, cx, cy, hres, vres,
 			content_hres, content_vres, content_width, content_height,

--- a/src/osdep/amiberry_ipc_socket.cpp
+++ b/src/osdep/amiberry_ipc_socket.cpp
@@ -624,13 +624,15 @@ static std::string HandleSetConfig(const std::vector<std::string>& args)
 			set_config_changed();
 		}
 		else if (optname == "gfx_horizontal_offset") {
+			const long max_w = AMIGA_WIDTH_MAX << changed_prefs.gfx_resolution;
 			changed_prefs.gfx_horizontal_offset = static_cast<int>(
-				std::clamp(std::stol(optval), -4096L, 4096L));
+				std::clamp(std::stol(optval), -max_w, max_w));
 			set_config_changed();
 		}
 		else if (optname == "gfx_vertical_offset") {
+			const long max_h = AMIGA_HEIGHT_MAX << changed_prefs.gfx_vresolution;
 			changed_prefs.gfx_vertical_offset = static_cast<int>(
-				std::clamp(std::stol(optval), -4096L, 4096L));
+				std::clamp(std::stol(optval), -max_h, max_h));
 			set_config_changed();
 		}
 		else if (optname == "gfx_overscanmode") {

--- a/src/osdep/amiberry_ipc_socket.cpp
+++ b/src/osdep/amiberry_ipc_socket.cpp
@@ -608,29 +608,38 @@ static std::string HandleSetConfig(const std::vector<std::string>& args)
 			set_config_changed();
 		}
 		else if (optname == "gfx_manual_crop_width") {
-			changed_prefs.gfx_manual_crop_width = static_cast<int>(std::max(0L, std::stol(optval)));
+			// Clamp on the parsed long before narrowing; a huge value would
+			// otherwise wrap through int to something arbitrary.
+			changed_prefs.gfx_manual_crop_width = static_cast<int>(
+				std::clamp(std::stol(optval), 0L, 4096L));
 			set_config_changed();
 		}
 		else if (optname == "gfx_manual_crop_height") {
-			changed_prefs.gfx_manual_crop_height = static_cast<int>(std::max(0L, std::stol(optval)));
+			changed_prefs.gfx_manual_crop_height = static_cast<int>(
+				std::clamp(std::stol(optval), 0L, 4096L));
 			set_config_changed();
 		}
 		else if (optname == "gfx_horizontal_offset") {
-			changed_prefs.gfx_horizontal_offset = std::stol(optval);
+			changed_prefs.gfx_horizontal_offset = static_cast<int>(
+				std::clamp(std::stol(optval), -4096L, 4096L));
 			set_config_changed();
 		}
 		else if (optname == "gfx_vertical_offset") {
-			changed_prefs.gfx_vertical_offset = std::stol(optval);
+			changed_prefs.gfx_vertical_offset = static_cast<int>(
+				std::clamp(std::stol(optval), -4096L, 4096L));
 			set_config_changed();
 		}
 		else if (optname == "gfx_overscanmode") {
-			const int mode = std::stol(optval);
+			// Validate on the parsed long before narrowing; on LP64 an
+			// out-of-range value would otherwise wrap into a valid mode.
+			const long mode = std::stol(optval);
 			// Keep in sync with the overscan_items table in the Display panel.
 			if (mode < 0 || mode > 8) {
 				return make_response(false, {"Invalid gfx_overscanmode (use 0-8)"});
 			}
-			changed_prefs.gfx_overscanmode = mode;
+			changed_prefs.gfx_overscanmode = static_cast<int>(mode);
 			set_config_changed();
+		}
 		} else if (optname == "sound_output") {
 			changed_prefs.produce_sound = std::stol(optval);
 			set_config_changed();

--- a/src/osdep/amiberry_ipc_socket.cpp
+++ b/src/osdep/amiberry_ipc_socket.cpp
@@ -488,6 +488,20 @@ static std::string HandleGetConfig(const std::vector<std::string>& args)
 		value = std::to_string(changed_prefs.gfx_monitor[0].gfx_size_win.height);
 	} else if (optname == "gfx_fullscreen") {
 		value = changed_prefs.gfx_apmode[0].gfx_fullscreen ? "true" : "false";
+	} else if (optname == "gfx_auto_crop") {
+		value = changed_prefs.gfx_auto_crop ? "true" : "false";
+	} else if (optname == "gfx_manual_crop") {
+		value = changed_prefs.gfx_manual_crop ? "true" : "false";
+	} else if (optname == "gfx_manual_crop_width") {
+		value = std::to_string(changed_prefs.gfx_manual_crop_width);
+	} else if (optname == "gfx_manual_crop_height") {
+		value = std::to_string(changed_prefs.gfx_manual_crop_height);
+	} else if (optname == "gfx_horizontal_offset") {
+		value = std::to_string(changed_prefs.gfx_horizontal_offset);
+	} else if (optname == "gfx_vertical_offset") {
+		value = std::to_string(changed_prefs.gfx_vertical_offset);
+	} else if (optname == "gfx_overscanmode") {
+		value = std::to_string(changed_prefs.gfx_overscanmode);
 	}
 	// Sound options
 	else if (optname == "sound_output") {
@@ -574,6 +588,43 @@ static std::string HandleSetConfig(const std::vector<std::string>& args)
 		else if (optname == "gfx_fullscreen") {
 			bool fullscreen = (optval == "true" || optval == "1");
 			changed_prefs.gfx_apmode[0].gfx_fullscreen = fullscreen ? GFX_FULLWINDOW : GFX_WINDOW;
+			set_config_changed();
+		}
+		// Crop options — enabling one mode disables the other
+		else if (optname == "gfx_auto_crop") {
+			const bool enable = (optval == "true" || optval == "1");
+			changed_prefs.gfx_auto_crop = enable;
+			if (enable) {
+				changed_prefs.gfx_manual_crop = false;
+			}
+			set_config_changed();
+		}
+		else if (optname == "gfx_manual_crop") {
+			const bool enable = (optval == "true" || optval == "1");
+			changed_prefs.gfx_manual_crop = enable;
+			if (enable) {
+				changed_prefs.gfx_auto_crop = false;
+			}
+			set_config_changed();
+		}
+		else if (optname == "gfx_manual_crop_width") {
+			changed_prefs.gfx_manual_crop_width = std::max(0, std::stol(optval));
+			set_config_changed();
+		}
+		else if (optname == "gfx_manual_crop_height") {
+			changed_prefs.gfx_manual_crop_height = std::max(0, std::stol(optval));
+			set_config_changed();
+		}
+		else if (optname == "gfx_horizontal_offset") {
+			changed_prefs.gfx_horizontal_offset = std::stol(optval);
+			set_config_changed();
+		}
+		else if (optname == "gfx_vertical_offset") {
+			changed_prefs.gfx_vertical_offset = std::stol(optval);
+			set_config_changed();
+		}
+		else if (optname == "gfx_overscanmode") {
+			changed_prefs.gfx_overscanmode = std::stol(optval);
 			set_config_changed();
 		}
 		// Sound options

--- a/src/osdep/amiberry_ipc_socket.cpp
+++ b/src/osdep/amiberry_ipc_socket.cpp
@@ -624,12 +624,12 @@ static std::string HandleSetConfig(const std::vector<std::string>& args)
 			set_config_changed();
 		}
 		else if (optname == "gfx_overscanmode") {
-			changed_prefs.gfx_overscanmode = std::stol(optval);
-			set_config_changed();
-		}
-		// Sound options
-		else if (optname == "sound_output") {
-			changed_prefs.produce_sound = std::stol(optval);
+			const int mode = std::stol(optval);
+			// Keep in sync with the overscan_items table in the Display panel.
+			if (mode < 0 || mode > 8) {
+				return make_response(false, {"Invalid gfx_overscanmode (use 0-8)"});
+			}
+			changed_prefs.gfx_overscanmode = mode;
 			set_config_changed();
 		} else if (optname == "sound_stereo") {
 			changed_prefs.sound_stereo = std::stol(optval);

--- a/src/osdep/amiberry_ipc_socket.cpp
+++ b/src/osdep/amiberry_ipc_socket.cpp
@@ -631,6 +631,9 @@ static std::string HandleSetConfig(const std::vector<std::string>& args)
 			}
 			changed_prefs.gfx_overscanmode = mode;
 			set_config_changed();
+		} else if (optname == "sound_output") {
+			changed_prefs.produce_sound = std::stol(optval);
+			set_config_changed();
 		} else if (optname == "sound_stereo") {
 			changed_prefs.sound_stereo = std::stol(optval);
 			set_config_changed();

--- a/src/osdep/amiberry_ipc_socket.cpp
+++ b/src/osdep/amiberry_ipc_socket.cpp
@@ -20,6 +20,7 @@
 #include "filesys.h"
 #include "gui.h"
 #include "custom.h"
+#include "amiga_constants.h"
 #include "gui/gui_handling.h"
 #include "newcpu.h"
 #include "blitter.h"
@@ -608,15 +609,18 @@ static std::string HandleSetConfig(const std::vector<std::string>& args)
 			set_config_changed();
 		}
 		else if (optname == "gfx_manual_crop_width") {
-			// Clamp on the parsed long before narrowing; a huge value would
-			// otherwise wrap through int to something arbitrary.
+			// Clamp on the parsed long before narrowing and to the same
+			// native bounds the Filter panel uses, so a headless client
+			// cannot set a crop larger than the surface.
+			const long max_w = AMIGA_WIDTH_MAX << changed_prefs.gfx_resolution;
 			changed_prefs.gfx_manual_crop_width = static_cast<int>(
-				std::clamp(std::stol(optval), 0L, 4096L));
+				std::clamp(std::stol(optval), 0L, max_w));
 			set_config_changed();
 		}
 		else if (optname == "gfx_manual_crop_height") {
+			const long max_h = AMIGA_HEIGHT_MAX << changed_prefs.gfx_vresolution;
 			changed_prefs.gfx_manual_crop_height = static_cast<int>(
-				std::clamp(std::stol(optval), 0L, 4096L));
+				std::clamp(std::stol(optval), 0L, max_h));
 			set_config_changed();
 		}
 		else if (optname == "gfx_horizontal_offset") {

--- a/src/osdep/amiberry_ipc_socket.cpp
+++ b/src/osdep/amiberry_ipc_socket.cpp
@@ -639,7 +639,6 @@ static std::string HandleSetConfig(const std::vector<std::string>& args)
 			}
 			changed_prefs.gfx_overscanmode = static_cast<int>(mode);
 			set_config_changed();
-		}
 		} else if (optname == "sound_output") {
 			changed_prefs.produce_sound = std::stol(optval);
 			set_config_changed();

--- a/src/osdep/amiberry_ipc_socket.cpp
+++ b/src/osdep/amiberry_ipc_socket.cpp
@@ -608,11 +608,11 @@ static std::string HandleSetConfig(const std::vector<std::string>& args)
 			set_config_changed();
 		}
 		else if (optname == "gfx_manual_crop_width") {
-			changed_prefs.gfx_manual_crop_width = std::max(0, std::stol(optval));
+			changed_prefs.gfx_manual_crop_width = static_cast<int>(std::max(0L, std::stol(optval)));
 			set_config_changed();
 		}
 		else if (optname == "gfx_manual_crop_height") {
-			changed_prefs.gfx_manual_crop_height = std::max(0, std::stol(optval));
+			changed_prefs.gfx_manual_crop_height = static_cast<int>(std::max(0L, std::stol(optval)));
 			set_config_changed();
 		}
 		else if (optname == "gfx_horizontal_offset") {

--- a/src/osdep/imgui/filter.cpp
+++ b/src/osdep/imgui/filter.cpp
@@ -239,38 +239,72 @@ void render_panel_filter()
 	const auto& shader_names = get_available_shader_names();
 
 	BeginGroupBox("Crop and Offset");
-	if (changed_prefs.gfx_manual_crop) ImGui::BeginDisabled();
+	const bool auto_crop_on = changed_prefs.gfx_auto_crop;
+	const bool manual_crop_on = changed_prefs.gfx_manual_crop;
+	if (manual_crop_on) ImGui::BeginDisabled();
 	AmigaCheckbox("Auto Crop", &changed_prefs.gfx_auto_crop);
-	ShowHelpMarker("Automatically crop black borders from the display.");
-	if (changed_prefs.gfx_manual_crop) ImGui::EndDisabled();
+	ShowHelpMarker("Automatically crop borders by scanning frame content.");
+	if (manual_crop_on) ImGui::EndDisabled();
 	ImGui::SameLine();
-	if (changed_prefs.gfx_auto_crop) ImGui::BeginDisabled();
+	if (auto_crop_on) ImGui::BeginDisabled();
 	AmigaCheckbox("Manual Crop", &changed_prefs.gfx_manual_crop);
-	ShowHelpMarker("Manually set the visible display area size.");
-	if (changed_prefs.gfx_auto_crop) ImGui::EndDisabled();
-	if (changed_prefs.gfx_manual_crop) {
+	ShowHelpMarker("Manually set the visible display area size and position.");
+	if (auto_crop_on) ImGui::EndDisabled();
+	if (manual_crop_on) {
+		ImGui::AlignTextToFramePadding();
+		ImGui::Text("Width:");
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(BUTTON_WIDTH);
-		ImGui::SliderInt("##W", &changed_prefs.gfx_manual_crop_width, 0, 800);
+		ImGui::SliderInt("##WCropSlider", &changed_prefs.gfx_manual_crop_width, 0, 800);
 		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
 		ImGui::SameLine();
-		ImGui::SetNextItemWidth(BUTTON_WIDTH);
-		ImGui::SliderInt("##H", &changed_prefs.gfx_manual_crop_height, 0, 600);
+		ImGui::SetNextItemWidth(BUTTON_WIDTH * 0.45f);
+		ImGui::InputInt("##WCropInput", &changed_prefs.gfx_manual_crop_width, 0);
 		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
-	}
-	ImGui::AlignTextToFramePadding();
-	ImGui::Text("H. Offset:");
-	ImGui::SameLine();
-	ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - spacing * 2);
-	ImGui::SliderInt("##HOffsetSlider", &changed_prefs.gfx_horizontal_offset, -80, 80);
-	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
+		ImGui::SameLine();
+		ImGui::AlignTextToFramePadding();
+		ImGui::Text("Height:");
+		ImGui::SameLine();
+		ImGui::SetNextItemWidth(BUTTON_WIDTH);
+		ImGui::SliderInt("##HCropSlider", &changed_prefs.gfx_manual_crop_height, 0, 600);
+		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
+		ImGui::SameLine();
+		ImGui::SetNextItemWidth(BUTTON_WIDTH * 0.45f);
+		ImGui::InputInt("##HCropInput", &changed_prefs.gfx_manual_crop_height, 0);
+		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
+		changed_prefs.gfx_manual_crop_width = std::clamp(
+			changed_prefs.gfx_manual_crop_width, 0, 800);
+		changed_prefs.gfx_manual_crop_height = std::clamp(
+			changed_prefs.gfx_manual_crop_height, 0, 600);
 
-	ImGui::AlignTextToFramePadding();
-	ImGui::Text("V. Offset:");
-	ImGui::SameLine();
-	ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - spacing * 2);
-	ImGui::SliderInt("##VOffsetSlider", &changed_prefs.gfx_vertical_offset, -80, 80);
-	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
+		// Offsets position the manual crop window and are only consumed on
+		// the manual-crop render path, so keep them hidden otherwise.
+		ImGui::AlignTextToFramePadding();
+		ImGui::Text("H. Offset:");
+		ImGui::SameLine();
+		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - spacing * 2 - BUTTON_WIDTH * 0.45f);
+		ImGui::SliderInt("##HOffsetSlider", &changed_prefs.gfx_horizontal_offset, -80, 80);
+		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
+		ImGui::SameLine();
+		ImGui::SetNextItemWidth(BUTTON_WIDTH * 0.45f);
+		ImGui::InputInt("##HOffsetInput", &changed_prefs.gfx_horizontal_offset, 0);
+		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
+
+		ImGui::AlignTextToFramePadding();
+		ImGui::Text("V. Offset:");
+		ImGui::SameLine();
+		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - spacing * 2 - BUTTON_WIDTH * 0.45f);
+		ImGui::SliderInt("##VOffsetSlider", &changed_prefs.gfx_vertical_offset, -80, 80);
+		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
+		ImGui::SameLine();
+		ImGui::SetNextItemWidth(BUTTON_WIDTH * 0.45f);
+		ImGui::InputInt("##VOffsetInput", &changed_prefs.gfx_vertical_offset, 0);
+		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
+		changed_prefs.gfx_horizontal_offset = std::clamp(
+			changed_prefs.gfx_horizontal_offset, -80, 80);
+		changed_prefs.gfx_vertical_offset = std::clamp(
+			changed_prefs.gfx_vertical_offset, -80, 80);
+	}
 	ImGui::Spacing();
 	EndGroupBox("Crop and Offset");
 

--- a/src/osdep/imgui/filter.cpp
+++ b/src/osdep/imgui/filter.cpp
@@ -1,5 +1,6 @@
 #include "imgui.h"
 #include "sysdeps.h"
+#include "amiga_constants.h"
 #include "imgui_panels.h"
 #include "options.h"
 #include "gui/gui_handling.h"
@@ -251,11 +252,15 @@ void render_panel_filter()
 	ShowHelpMarker("Manually set the visible display area size and position.");
 	if (auto_crop_on) ImGui::EndDisabled();
 	if (manual_crop_on) {
+		// Full-frame bounds at the active render resolution; a fixed 800/600
+		// would silently truncate a valid superhires crop just by rendering.
+		const int max_crop_w = AMIGA_WIDTH_MAX << changed_prefs.gfx_resolution;
+		const int max_crop_h = AMIGA_HEIGHT_MAX << changed_prefs.gfx_vresolution;
 		ImGui::AlignTextToFramePadding();
 		ImGui::Text("Width:");
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(BUTTON_WIDTH);
-		ImGui::SliderInt("##WCropSlider", &changed_prefs.gfx_manual_crop_width, 0, 800);
+		ImGui::SliderInt("##WCropSlider", &changed_prefs.gfx_manual_crop_width, 0, max_crop_w);
 		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(BUTTON_WIDTH * 0.45f);
@@ -266,16 +271,17 @@ void render_panel_filter()
 		ImGui::Text("Height:");
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(BUTTON_WIDTH);
-		ImGui::SliderInt("##HCropSlider", &changed_prefs.gfx_manual_crop_height, 0, 600);
+		ImGui::SliderInt("##HCropSlider", &changed_prefs.gfx_manual_crop_height, 0, max_crop_h);
 		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(BUTTON_WIDTH * 0.45f);
 		ImGui::InputInt("##HCropInput", &changed_prefs.gfx_manual_crop_height, 0);
 		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
 		changed_prefs.gfx_manual_crop_width = std::clamp(
-			changed_prefs.gfx_manual_crop_width, 0, 800);
+			changed_prefs.gfx_manual_crop_width, 0, max_crop_w);
 		changed_prefs.gfx_manual_crop_height = std::clamp(
-			changed_prefs.gfx_manual_crop_height, 0, 600);
+			changed_prefs.gfx_manual_crop_height, 0, max_crop_h);
+
 
 		// Offsets position the manual crop window and are only consumed on
 		// the manual-crop render path, so keep them hidden otherwise.

--- a/src/osdep/imgui/filter.cpp
+++ b/src/osdep/imgui/filter.cpp
@@ -284,12 +284,16 @@ void render_panel_filter()
 
 
 		// Offsets position the manual crop window and are only consumed on
-		// the manual-crop render path, so keep them hidden otherwise.
+		// the manual-crop render path, so keep them hidden otherwise. Bounds
+		// follow the surface: a WHDLoad-centered origin can legitimately sit
+		// well past the old fixed 80 at higher resolutions.
+		const int max_off_w = AMIGA_WIDTH_MAX << changed_prefs.gfx_resolution;
+		const int max_off_h = AMIGA_HEIGHT_MAX << changed_prefs.gfx_vresolution;
 		ImGui::AlignTextToFramePadding();
 		ImGui::Text("H. Offset:");
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - spacing * 2 - BUTTON_WIDTH * 0.45f);
-		ImGui::SliderInt("##HOffsetSlider", &changed_prefs.gfx_horizontal_offset, -80, 80);
+		ImGui::SliderInt("##HOffsetSlider", &changed_prefs.gfx_horizontal_offset, -max_off_w, max_off_w);
 		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(BUTTON_WIDTH * 0.45f);
@@ -300,16 +304,16 @@ void render_panel_filter()
 		ImGui::Text("V. Offset:");
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - spacing * 2 - BUTTON_WIDTH * 0.45f);
-		ImGui::SliderInt("##VOffsetSlider", &changed_prefs.gfx_vertical_offset, -80, 80);
+		ImGui::SliderInt("##VOffsetSlider", &changed_prefs.gfx_vertical_offset, -max_off_h, max_off_h);
 		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
 		ImGui::SameLine();
 		ImGui::SetNextItemWidth(BUTTON_WIDTH * 0.45f);
 		ImGui::InputInt("##VOffsetInput", &changed_prefs.gfx_vertical_offset, 0);
 		AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), false);
 		changed_prefs.gfx_horizontal_offset = std::clamp(
-			changed_prefs.gfx_horizontal_offset, -80, 80);
+			changed_prefs.gfx_horizontal_offset, -max_off_w, max_off_w);
 		changed_prefs.gfx_vertical_offset = std::clamp(
-			changed_prefs.gfx_vertical_offset, -80, 80);
+			changed_prefs.gfx_vertical_offset, -max_off_h, max_off_h);
 	}
 	ImGui::Spacing();
 	EndGroupBox("Crop and Offset");


### PR DESCRIPTION
Fixes #2308.

Changes proposed in this pull request:
- Auto-crop now consumes the chipset display-window registers (the DIW/DDF union from `get_custom_limits()`) as its deterministic crop base every frame, and runs the content-expansion scan only when that window changes or every 25th frame — identical framing at a fraction of the scan cost.
- The manual-crop H/V offset sliders are hidden unless Manual Crop is selected (the render path only consumes them there), and every manual-crop slider gains a numeric input for exact geometry.
- `SET_CONFIG`/`GET_CONFIG` now cover `gfx_auto_crop`, `gfx_manual_crop`, crop size/offsets and `gfx_overscanmode`, so crop behavior can be scripted and A/B tested without the GUI.

## Why integrated instead of a separate mode

A standalone "register crop" mode was prototyped first. Auto-crop already starts from the register window; its content scan only ever expands beyond that window, and border sprites are already part of the register union — the scan's remaining value is raster/copper border effects. On well-behaved titles the two modes produced byte-identical output (SysInfo 4.4 and TBL Eon: 180 crop recomputes, zero frames where the scan expanded the rect), so a third UI mode had no visible difference to earn its keep. The register mechanism lives inside auto-crop instead, where it removes the per-frame scan cost for everyone.

## Measurements

TBL Eon, 60 s run, auto-crop enabled:

| | per-frame scan | duty-cycled scan |
|---|---|---|
| Crop rect changes | 180 | 180 (identical rects) |
| Content scans over 453 stable frames | 453 | 19 (~4%) |
| Scan share of frame time (Pi 500-class ARM) | ~17% (42→49 fps measured in #2308) | under 1% (derived) |

The scan runs immediately when the display-window registers change, so scene transitions are still tracked frame-accurately; the duty cycle only applies to stable content. The `auto_crop:` log line now carries a `scans=` counter for cadence diagnostics.

## Verification

- Windows build (llvm-mingw); framing regression-checked against the per-frame-scan build on SysInfo 4.4 (`640x512+76+38`, stable) and TBL Eon (identical rect sequence across scene switches).
- GUI verified live: offsets hidden unless Manual Crop; Manual Crop on shows Width/Height sliders with numeric boxes (754/576) and both offset rows; typing 750 into the Width numeric box syncs the slider.
- IPC handlers are compile-verified only — the socket is AF_UNIX and cannot be exercised on the Windows test machine.

@midwan
