### PR TITLE
fix: add the STL includes the macOS libretro build needs

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -31,6 +31,8 @@
 #include <fstream>
 #include <filesystem>
 #include <vector>
+#include <unordered_map>
+#include <functional>
 
 #include "sysdeps.h"
 #include "options.h"

--- a/src/osdep/amiberry_filesys.cpp
+++ b/src/osdep/amiberry_filesys.cpp
@@ -20,6 +20,7 @@
 #endif
 #include <algorithm>
 #include <list>
+#include <memory>
 #include <dirent.h>
 #if !defined(_WIN32) || defined(LIBRETRO)
 #include <iconv.h>

--- a/src/osdep/vulkan_renderer.cpp
+++ b/src/osdep/vulkan_renderer.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <set>
 #include <limits>
+#include <chrono>
 
 #include "imgui.h"
 #include "imgui_impl_vulkan.h"


### PR DESCRIPTION
The libretro buildbot's `libretro-build-osx-x64` job currently fails on master ([pipeline 105527](https://git.libretro.com/libretro/amiberry/-/pipelines/105527)):

```
../src/osdep/amiberry.cpp:679:20: error: no template named 'unordered_map' in namespace 'std'
../src/osdep/amiberry.cpp:690:20: error: no template named 'unordered_map' in namespace 'std'
```

That runner's libc++ no longer provides `<unordered_map>` transitively through the other headers, so the hotkey `modifier_map` / `sdl_key_name_map` tables don't compile. libstdc++ and the arm64 macOS runner still pull it in, which is why only this one job breaks.

I scanned every source in the libretro build for templates used directly without the header (following project includes transitively); besides `amiberry.cpp` the only other hits are `amiberry_filesys.cpp` (`std::unique_ptr`, compiled right after amiberry.cpp, so the next failure in the same build) and `vulkan_renderer.cpp` (`std::chrono`, standalone-only but the same latent issue). Includes added for all three; no behaviour change.