### PR TITLE
macOS: fall back to kIOMasterPortDefault on SDKs without the new name

### DIFF
--- a/src/osdep/amiberry_hardfile.cpp
+++ b/src/osdep/amiberry_hardfile.cpp
@@ -28,6 +28,15 @@
 #include <IOKit/IOKitLib.h>
 #include <IOKit/storage/IOMedia.h>
 #include "macos_authopen.h"
+
+// kIOMainPortDefault arrived in the macOS 12 SDK; before that the same port is
+// called kIOMasterPortDefault, and it is still what an older SDK declares - the
+// libretro buildbot's Intel Mac builds against the 10.15 one. The deployment
+// target matters as well as the SDK: kIOMainPortDefault is marked available
+// from 12.0, so a newer SDK aimed at an older system would link it weakly.
+#if !defined(MAC_OS_VERSION_12_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_VERSION_12_0)
+#define kIOMainPortDefault kIOMasterPortDefault
+#endif
 #endif
 
 struct hardfilehandle


### PR DESCRIPTION
The libretro buildbot's `libretro-build-osx-x64` job is red again after #2312, this time on:

```
../src/osdep/amiberry_hardfile.cpp:334:51: error: use of undeclared identifier 'kIOMainPortDefault'; did you mean 'kIOMasterPortDefault'?
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/IOKit.framework/Headers/IOKitLib.h:103:19: note: 'kIOMasterPortDefault' declared here
```

That runner builds against the **10.15 SDK**, where the port is still called `kIOMasterPortDefault`; `kIOMainPortDefault` is the macOS 12 rename of the same thing. Nothing else sees it — the arm64 runner and this project's own macOS CI are on current SDKs — which is why it only shows up there.

The guard tests the deployment target as well as the SDK version, because `kIOMainPortDefault` is marked available from 12.0: a current SDK aimed at an older system would link it weakly rather than fail, and that is worth avoiding too.