### PR TITLE
fix(libretro): read VFS stream position via tell() after seek

### DIFF
--- a/src/osdep/libretro/posixemu_vfs.cpp
+++ b/src/osdep/libretro/posixemu_vfs.cpp
@@ -212,9 +212,19 @@ extern "C" off_t posixemu_seek(int fd, off_t offset, int whence)
 	retro_vfs_file_handle* handle = vfs_get_fd(fd);
 	if (handle) {
 		const struct retro_vfs_interface* vfs = libretro_get_vfs_interface();
-		if (vfs && vfs->seek) {
-			const int64_t ret = vfs->seek(handle, offset, vfs_whence(whence));
-			return ret < 0 ? static_cast<off_t>(-1) : static_cast<off_t>(ret);
+		if (vfs && vfs->seek && vfs->tell) {
+			/* The libretro VFS seek callback returns a status (0 on success),
+			 * not the resulting position, so query it via tell(). */
+			if (vfs->seek(handle, offset, vfs_whence(whence)) < 0) {
+				errno = ESPIPE;
+				return static_cast<off_t>(-1);
+			}
+			const int64_t position = vfs->tell(handle);
+			if (position < 0) {
+				errno = ESPIPE;
+				return static_cast<off_t>(-1);
+			}
+			return static_cast<off_t>(position);
 		}
 		errno = ESPIPE;
 		return static_cast<off_t>(-1);

--- a/src/osdep/libretro/stdioemu_vfs.cpp
+++ b/src/osdep/libretro/stdioemu_vfs.cpp
@@ -115,7 +115,7 @@ static int vfs_cookie_seek(void* c, off64_t* offset, int whence)
 {
 	auto* cookie = static_cast<VfsCookie*>(c);
 	const struct retro_vfs_interface* vfs = libretro_get_vfs_interface();
-	if (!vfs || !vfs->seek || !cookie || !cookie->handle)
+	if (!vfs || !vfs->seek || !vfs->tell || !cookie || !cookie->handle)
 		return -1;
 
 	int vfs_whence = RETRO_VFS_SEEK_POSITION_START;
@@ -132,12 +132,18 @@ static int vfs_cookie_seek(void* c, off64_t* offset, int whence)
 	default:
 		break;
 	}
-	const int64_t ret = vfs->seek(cookie->handle, *offset, vfs_whence);
-	if (ret < 0) {
+	/* The libretro VFS seek callback returns a status (0 on success),
+	 * not the resulting position, so query it via tell(). */
+	if (vfs->seek(cookie->handle, *offset, vfs_whence) < 0) {
 		errno = ESPIPE;
 		return -1;
 	}
-	*offset = ret;
+	const int64_t position = vfs->tell(cookie->handle);
+	if (position < 0) {
+		errno = ESPIPE;
+		return -1;
+	}
+	*offset = position;
 	return 0;
 }
 


### PR DESCRIPTION
Fixes #2319.

Changes proposed in this pull request:
- BIOS ROMs with a valid CRC32 are identified again in the libretro build. The ROM scan previously logged every kickstart as size 0 (`Name='...':0`, "0 matching path(s)") because both VFS emulation layers treated the frontend `seek()` callback's return value as the new stream position.
- Current libretro frontends return a status from `seek()` — 0 on success, -1 on error — on every backend (stdio, mmap, fd); the "returns the new position" wording still present in `libretro.h` is stale VFS v1 documentation.
- `vfs_cookie_seek` (the `fopencookie` glue behind `stdioemu_fopen`) and `posixemu_seek` now query the position with `vfs->tell()` after a successful seek. `tell()` is authoritative, so this stays correct on frontends implementing either semantics.
- Verified with a harness that mocks the current frontend semantics through a real `fopencookie` stream: the old code reports file size 0 (matching the issue log); the new code returns correct size, reads, and CRC. The full libretro core builds and links clean in the CI Docker image.

@midwan
