### PR TITLE
fix(libretro): use Win32 Fiber libco backend on Windows so CHD C++ exceptions don't kill the core

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -753,6 +753,18 @@ $(LIBRETRO_INFO): $(LIBRETRO_DIR)/libretro.cpp $(AMIBERRY_DIR)/CMakeLists.txt
 %.o: %.c
 	$(CC) $(INCFLAGS) $(FLAGS) -std=gnu99 -c -o $@ $<
 
+ifeq ($(platform), win)
+# On Windows, GCC/Clang select libco's amd64.c raw stack-switching backend for
+# x86_64. Those stacks are not registered in the TEB, so SEH-based C++
+# exception unwinding (used by mingw GCC for throws, including the routine
+# caught throws inside the vendored MAME CHD code) cannot dispatch on the
+# emulation cothread stack and kills the process. Undefine __amd64__ for this
+# TU so libco falls through to fiber.c, which uses the Win32 Fiber API
+# (CreateFiber switches TEB stack bounds; exceptions unwind correctly).
+$(LIBCO_DIR)/libco.o: $(LIBCO_DIR)/libco.c
+	$(CC) $(INCFLAGS) $(FLAGS) -U__amd64__ -std=gnu99 -c -o $@ $<
+endif
+
 clean:
 	rm -f $(OBJECTS) $(TARGET) $(LIBRETRO_INFO)
 


### PR DESCRIPTION
Fixes #2313.

Changes proposed in this pull request:

- CD32/CDTV games in `.chd` format no longer crash the libretro core on Windows; they now boot, matching the `.bin/.cue` and standalone behavior.
- The crash was not in the CHD detection code: the vendored MAME CHD code uses throw-and-catch as normal control flow (`chd_file::read_metadata` probes until a tag miss during `cdrom_open`), so mounting a CHD throws several *caught* C++ exceptions on the emulation cothread. On Windows, libco's `amd64.c` raw stack-switching backend leaves the TEB stack bounds pointing at the original thread stack, and mingw GCC dispatches C++ exceptions through SEH — which cannot unwind an unregistered stack. The exception kills the process even though a handler exists. Linux/macOS unwind via DWARF and are unaffected.
- Fix: compile `libco.c` with `-U__amd64__` on the `win` platform only, so libco falls through to its `fiber.c` backend (`CreateFiber`/`SwitchToFiber`). Kernel-managed fiber stacks switch the TEB bounds with the fiber, so exception dispatch works. Linux, macOS, and Android builds are unchanged.

Verification (Windows x64 core, mingw, run under Wine with RetroArch 1.22.2 and a CD32-labeled CHD): before the fix the process died right after `retro_load_game` with `NtRaiseException Exception frame is not in stack limits` (exception code `0x20474343`, GCC C++ EH); after the fix the disc boots, sector reads proceed, and `.bin/.cue` content and no-content boot are unaffected. An `__cxa_throw` interposer on Linux confirmed the throws originate in `chd_file::read_metadata` via `cdrom_open`.

@midwan
