### PR TITLE
fix(libretro): probe the shared system directory for kickstart files only

### DIFF
--- a/libretro/libretro_stubs.cpp
+++ b/libretro/libretro_stubs.cpp
@@ -581,14 +581,26 @@ static bool libretro_is_rom_key_file(const std::string& path)
 }
 
 // Kickstart images ship under many naming schemes (kick34005.A500, kick.rom,
-// kick40060.CD32.ext, plain "kick"), so shared-directory candidates are
-// filtered by the kick* basename instead of by extension. rom.key is handled
-// separately by libretro_is_rom_key_file().
+// kick40060.CD32.ext, plain "kick"), and Amiberry itself probes the frontend
+// system directory for Cloanto-style names (find_kickstart_in_system_dir /
+// find_ext_rom_in_system_dir in libretro.cpp: cd32.rom, cdtv.rom,
+// amiga-os-*.rom, amiga-ext-*.rom, "CD32 Extended.ROM"). Shared-directory
+// candidates are filtered by these recognized name prefixes instead of by
+// extension, so RP9/WHDLoad checksum lookups still find that firmware. rom.key
+// is handled separately by libretro_is_rom_key_file().
 static bool libretro_is_kickstart_scan_name(const std::string& path)
 {
 	const auto name_pos = path.find_last_of("/\\");
 	const std::string name = name_pos == std::string::npos ? path : path.substr(name_pos + 1);
-	return name.size() >= 4 && _tcsnicmp(name.c_str(), _T("kick"), 4) == 0;
+	static const TCHAR* const prefixes[] = {
+		_T("kick"), _T("cd32"), _T("cdtv"), _T("amiga-os-"), _T("amiga-ext-")
+	};
+	for (const auto* prefix : prefixes) {
+		const size_t len = _tcslen(prefix);
+		if (name.size() >= len && _tcsnicmp(name.c_str(), prefix, len) == 0)
+			return true;
+	}
+	return false;
 }
 
 static bool libretro_is_rom_ext(const std::string& path, const bool deepscan)

--- a/libretro/libretro_stubs.cpp
+++ b/libretro/libretro_stubs.cpp
@@ -440,12 +440,17 @@ struct libretro_rom_scan_candidate
 {
 	std::string path;
 	bool deepscan;
+	// Shared libretro frontends expose one system directory holding BIOS packs
+	// for many cores. Candidates flagged kickstart_only must not open unrelated
+	// firmware: only rom.key and files named kick* are probed (issue #2325).
+	bool kickstart_only;
 };
 
 struct libretro_rom_scan_data
 {
 	UAEREG* fkey;
 	int got;
+	bool kickstart_only;
 };
 
 static std::string libretro_path_join(const std::string& dir, const std::string& file)
@@ -461,7 +466,7 @@ static std::string libretro_path_join(const std::string& dir, const std::string&
 }
 
 static void libretro_append_scan_candidate(std::vector<libretro_rom_scan_candidate>& candidates,
-	const std::string& path, const bool deepscan)
+	const std::string& path, const bool deepscan, const bool kickstart_only)
 {
 	if (path.empty())
 		return;
@@ -478,26 +483,31 @@ static void libretro_append_scan_candidate(std::vector<libretro_rom_scan_candida
 	for (auto& candidate : candidates) {
 		if (_tcsicmp(candidate.path.c_str(), resolved) == 0) {
 			candidate.deepscan = candidate.deepscan || deepscan;
+			candidate.kickstart_only = candidate.kickstart_only || kickstart_only;
 			return;
 		}
 	}
 
-	candidates.push_back({ resolved, deepscan });
+	candidates.push_back({ resolved, deepscan, kickstart_only });
 }
 
+// root_kickstart_only flags the frontend-provided root itself as shared with
+// other cores: its top level is probed non-recursively for kick* / rom.key only.
+// Amiberry-convention subdirectories below it stay unrestricted because they
+// only exist when someone deliberately placed Amiga ROMs there.
 static void libretro_append_scan_root(std::vector<libretro_rom_scan_candidate>& candidates,
-	const char* root)
+	const char* root, const bool root_kickstart_only)
 {
 	if (!root || !*root)
 		return;
 
 	const std::string root_path = root;
-	libretro_append_scan_candidate(candidates, root_path, false);
-	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "roms"), true);
-	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "Kickstarts"), true);
-	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "save-data/Kickstarts"), true);
-	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "whdboot/save-data/Kickstarts"), true);
-	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "amiberry/whdboot/save-data/Kickstarts"), true);
+	libretro_append_scan_candidate(candidates, root_path, false, root_kickstart_only);
+	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "roms"), true, false);
+	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "Kickstarts"), true, false);
+	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "save-data/Kickstarts"), true, false);
+	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "whdboot/save-data/Kickstarts"), true, false);
+	libretro_append_scan_candidate(candidates, libretro_path_join(root_path, "amiberry/whdboot/save-data/Kickstarts"), true, false);
 }
 
 static int libretro_rom_ext_priority(const TCHAR* path, const int size)
@@ -570,6 +580,17 @@ static bool libretro_is_rom_key_file(const std::string& path)
 	return _tcsicmp(name.c_str(), _T("rom.key")) == 0;
 }
 
+// Kickstart images ship under many naming schemes (kick34005.A500, kick.rom,
+// kick40060.CD32.ext, plain "kick"), so shared-directory candidates are
+// filtered by the kick* basename instead of by extension. rom.key is handled
+// separately by libretro_is_rom_key_file().
+static bool libretro_is_kickstart_scan_name(const std::string& path)
+{
+	const auto name_pos = path.find_last_of("/\\");
+	const std::string name = name_pos == std::string::npos ? path : path.substr(name_pos + 1);
+	return name.size() >= 4 && _tcsnicmp(name.c_str(), _T("kick"), 4) == 0;
+}
+
 static bool libretro_is_rom_ext(const std::string& path, const bool deepscan)
 {
 	if (path.empty())
@@ -611,8 +632,12 @@ static int libretro_scan_rom_entry(struct zfile* f, void* user)
 		return 0;
 	}
 
-	if (!libretro_is_rom_ext(path, true))
+	if (rsd->kickstart_only) {
+		if (!libretro_is_kickstart_scan_name(path))
+			return 0;
+	} else if (!libretro_is_rom_ext(path, true)) {
 		return 0;
+	}
 
 	struct romdata* rd = scan_single_rom_file(f);
 	if (rd) {
@@ -624,17 +649,24 @@ static int libretro_scan_rom_entry(struct zfile* f, void* user)
 	return 0;
 }
 
-static int libretro_scan_rom_file(const std::string& path, UAEREG* fkey, const bool deepscan)
+static int libretro_scan_rom_file(const std::string& path, UAEREG* fkey, const bool deepscan, const bool kickstart_only)
 {
-	if (!libretro_is_rom_key_file(path) && !libretro_is_rom_ext(path, deepscan))
-		return 0;
+	if (!libretro_is_rom_key_file(path)) {
+		if (kickstart_only) {
+			if (!libretro_is_kickstart_scan_name(path))
+				return 0;
+		} else if (!libretro_is_rom_ext(path, deepscan)) {
+			return 0;
+		}
+	}
 
-	libretro_rom_scan_data rsd = { fkey, 0 };
+	libretro_rom_scan_data rsd = { fkey, 0, kickstart_only };
 	zfile_zopen(path, libretro_scan_rom_entry, &rsd);
 	return rsd.got;
 }
 
-static int libretro_scan_rom_dir(UAEREG* fkey, const std::string& path, const bool deepscan, const int level)
+static int libretro_scan_rom_dir(UAEREG* fkey, const std::string& path, const bool deepscan,
+	const bool kickstart_only, const int level)
 {
 	struct dirent* entry;
 	STAT statbuf {};
@@ -642,7 +674,8 @@ static int libretro_scan_rom_dir(UAEREG* fkey, const std::string& path, const bo
 	std::vector<std::string> files;
 	std::vector<std::string> dirs;
 
-	write_log(_T("libretro ROM scan directory '%s'\n"), path.c_str());
+	write_log(_T("libretro ROM scan directory '%s'%s\n"), path.c_str(),
+		kickstart_only ? _T(" (kickstart names only)") : _T(""));
 
 	DIR* dp = opendir(path.c_str());
 	if (dp == nullptr)
@@ -669,14 +702,14 @@ static int libretro_scan_rom_dir(UAEREG* fkey, const std::string& path, const bo
 
 	for (const auto& file : files) {
 		if (libretro_is_rom_key_file(file))
-			libretro_scan_rom_file(file, fkey, deepscan);
+			libretro_scan_rom_file(file, fkey, deepscan, kickstart_only);
 	}
 	for (const auto& file : files) {
-		if (!libretro_is_rom_key_file(file) && libretro_scan_rom_file(file, fkey, deepscan))
+		if (!libretro_is_rom_key_file(file) && libretro_scan_rom_file(file, fkey, deepscan, kickstart_only))
 			ret = 1;
 	}
 	for (const auto& dir : dirs) {
-		if (libretro_scan_rom_dir(fkey, dir, deepscan, level + 1))
+		if (libretro_scan_rom_dir(fkey, dir, deepscan, kickstart_only, level + 1))
 			ret = 1;
 	}
 	return ret;
@@ -700,17 +733,19 @@ int scan_roms(int show)
 
 	std::vector<libretro_rom_scan_candidate> candidates;
 	const std::string rom_path = get_rom_path();
-	libretro_append_scan_candidate(candidates, rom_path, false);
-	libretro_append_scan_root(candidates, getenv("AMIBERRY_LIBRETRO_SYSTEM_DIR"));
-	libretro_append_scan_root(candidates, getenv("AMIBERRY_LIBRETRO_SAVE_DIR"));
-	libretro_append_scan_root(candidates, getenv("AMIBERRY_WHDBOOT_ASSETS_DIR"));
-	libretro_append_scan_root(candidates, getenv("AMIBERRY_WHDBOOT_PATH"));
-	libretro_append_scan_root(candidates, getenv("WHDBOOT_SAVE_DATA"));
-	libretro_append_scan_candidate(candidates, changed_prefs.path_rom.path[0], false);
+	libretro_append_scan_candidate(candidates, rom_path, false, false);
+	// The frontend system directory is shared with every other core's BIOS
+	// packs: probe its top level for kick* / rom.key only, never recursively.
+	libretro_append_scan_root(candidates, getenv("AMIBERRY_LIBRETRO_SYSTEM_DIR"), true);
+	libretro_append_scan_root(candidates, getenv("AMIBERRY_LIBRETRO_SAVE_DIR"), false);
+	libretro_append_scan_root(candidates, getenv("AMIBERRY_WHDBOOT_ASSETS_DIR"), false);
+	libretro_append_scan_root(candidates, getenv("AMIBERRY_WHDBOOT_PATH"), false);
+	libretro_append_scan_root(candidates, getenv("WHDBOOT_SAVE_DATA"), false);
+	libretro_append_scan_candidate(candidates, changed_prefs.path_rom.path[0], false, false);
 
 	int cnt = 0;
 	for (const auto& candidate : candidates) {
-		if (libretro_scan_rom_dir(fkey, candidate.path, candidate.deepscan, 0))
+		if (libretro_scan_rom_dir(fkey, candidate.path, candidate.deepscan, candidate.kickstart_only, 0))
 			cnt++;
 	}
 

--- a/tools/check_libretro_contract.py
+++ b/tools/check_libretro_contract.py
@@ -126,7 +126,7 @@ def main():
 	dump_xlate = extract_body(debug_text, "static uae_u8 *dump_xlate (uae_u32 addr)")
 	dump_xlate_range = extract_body(debug_text, "static uae_u8 *dump_xlate_range (uae_u32 addr, uae_u32 size)")
 	memory_map_dump_3 = extract_body(debug_text, "static void memory_map_dump_3(UaeMemoryMap *map, int log)")
-	whdload_auto_prefs = extract_body(whdbooter_text, "void whdload_auto_prefs(uae_prefs* prefs, const char* filepath)")
+	whdload_auto_prefs = extract_body(whdbooter_text, "void whdload_auto_prefs(uae_prefs* prefs, const char* filepath, const bool preserve_quickstart_hardware)")
 
 	require(
 		"RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY" not in set_environment,
@@ -319,9 +319,15 @@ def main():
 	require(
 		"static bool libretro_is_rom_key_file" in stub_text
 		and "if (libretro_is_rom_key_file(path)) {\n\t\taddkeyfile(path);\n\t\treturn 0;\n\t}" in stub_text
-		and "if (!libretro_is_rom_key_file(path) && !libretro_is_rom_ext(path, deepscan))" in stub_text
-		and "for (const auto& file : files) {\n\t\tif (libretro_is_rom_key_file(file))\n\t\t\tlibretro_scan_rom_file(file, fkey, deepscan);\n\t}" in stub_text,
+		and "if (!libretro_is_rom_key_file(path)) {" in stub_text
+		and "for (const auto& file : files) {\n\t\tif (libretro_is_rom_key_file(file))\n\t\t\tlibretro_scan_rom_file(file, fkey, deepscan, kickstart_only);\n\t}" in stub_text,
 		"libretro ROM scanning must let rom.key through and register keys before encrypted ROM candidates",
+		failures,
+	)
+	require(
+		"static bool libretro_is_kickstart_scan_name" in stub_text
+		and 'libretro_append_scan_root(candidates, getenv("AMIBERRY_LIBRETRO_SYSTEM_DIR"), true)' in libretro_scan_roms,
+		"the shared libretro system directory must only be probed for kick* / rom.key, never for unrelated BIOS-pack firmware",
 		failures,
 	)
 	require(

--- a/tools/check_libretro_contract.py
+++ b/tools/check_libretro_contract.py
@@ -326,8 +326,9 @@ def main():
 	)
 	require(
 		"static bool libretro_is_kickstart_scan_name" in stub_text
+		and '_T("kick"), _T("cd32"), _T("cdtv"), _T("amiga-os-"), _T("amiga-ext-")' in stub_text
 		and 'libretro_append_scan_root(candidates, getenv("AMIBERRY_LIBRETRO_SYSTEM_DIR"), true)' in libretro_scan_roms,
-		"the shared libretro system directory must only be probed for kick* / rom.key, never for unrelated BIOS-pack firmware",
+		"the shared libretro system directory must only be probed for recognized kickstart/CD32/Cloanto firmware names, never for unrelated BIOS-pack firmware",
 		failures,
 	)
 	require(


### PR DESCRIPTION
Fixes #2325.

Changes proposed in this pull request:
- The libretro core no longer opens and checksums every `.rom`/`.bin`/`.u##` file at the top of the frontend's shared system directory. That scan fully read, CRC32'd and SHA1'd each file on every content load — the startup delay and the thousands of `!: Name=` log lines reported in the issue.
- The system directory is now probed for files named `kick*` (case-insensitive, extension-agnostic) plus `rom.key`, non-recursively. Extension-agnostic matching also closes a discovery gap: `kick40060.CD32.ext` was rejected by the old extension whitelist.
- Amiberry-convention locations keep the previous unrestricted scanning: `Kickstarts/`, `save-data/Kickstarts/`, `whdboot/save-data/Kickstarts/` subdirectories and the save directory, so Cloanto-style `amiga-os-*.rom` names and other ROMs placed there still register. AROS replacement ROMs are unaffected — `memory.cpp` resolves those by direct path lookup, not via the scan.
- Candidate deduplication ORs the new flag, so a directory reachable through several env roots (system dir reused as WHDBOOT assets dir or save-dir fallback) keeps the stricter rule.
- `tools/check_libretro_contract.py`: updated the two scan-shape assertions, added one asserting the system directory is kickstart-only, and repaired a stale `whdload_auto_prefs` signature that crashed the test before any assertion ran.

Measured by running the real scan code (extracted verbatim into a harness) against a fixture mimicking the reporter's layout — a shared BIOS directory with 40+ unrelated firmware files:

| | before | after |
|---|---|---|
| files opened + checksummed | 48 | 6 (kickstarts + `rom.key`) |
| directories read | 6 | 6 |

Note: neither version recurses into the system directory's subdirectories — the deep `Name=` probes quoted in the issue can only come from an older binary; either way the per-load scan cost is now a handful of opens. `make -C libretro platform=unix` links clean and `tests/test_libretro_rom_path.sh` passes. `check_libretro_contract.py` now runs to completion; its two remaining failures (WHDLoad archive canonicalization, A1200 unknown-chipset fallback) reproduce identically on pristine `master` and predate this change.

@midwan
